### PR TITLE
Phase 1: define v1 contract, user profile, and release-note template

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@
 Efficient Agent Protocol is a local-first framework for multi-step tool workflows.
 It stores large outputs as pointer-backed state (`ptr_*`) and runs dependency-aware DAG steps in parallel.
 
+## Who This Is For
+
+- Python developers building local-first agent/tool orchestration
+- Teams that need pointer-backed state and execution trace visibility
+
+Not ideal yet for:
+- strict long-term API compatibility requirements before `v1.0`
+- non-technical users expecting zero-configuration onboarding
+
 ## What You Get
 
 - Pointer-based state to keep prompts small
@@ -93,6 +102,8 @@ python3 -m build
 
 - `STABILITY.md`
 - `ROADMAP.md`
+- `docs/v1_contract.md`
+- `docs/release_notes_template.md`
 - GitHub roadmap board: https://github.com/users/GenieWeenie/projects/1
 - `docs/configuration.md`
 - `docs/architecture.md`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,3 +35,5 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Branch protection on `main` with required CI checks and PR review.
 - MIT license added.
 - Release workflow stabilized and validated on tagged release runs.
+- Phase 1 contract draft published (`docs/v1_contract.md`).
+- Release notes template published (`docs/release_notes_template.md`).

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -7,6 +7,7 @@ This project is currently **pre-1.0 (experimental)**.
 - Python runtime requirement (`>=3.9`) is intentional and documented.
 - CI must pass for merges to `main`.
 - Tagged releases are used for published milestones.
+- `v1.0` scope and freeze candidates are documented in `docs/v1_contract.md`.
 
 ## Not Yet Stable (May Change Without Notice)
 

--- a/docs/release_notes_template.md
+++ b/docs/release_notes_template.md
@@ -1,0 +1,31 @@
+# Release Notes Template
+
+Use this template for every tagged release.
+
+## Added
+
+- 
+
+## Changed
+
+- 
+
+## Fixed
+
+- 
+
+## Deprecated
+
+- 
+
+## Removed
+
+- 
+
+## Breaking Changes
+
+- 
+
+## Upgrade Notes
+
+- 

--- a/docs/v1_contract.md
+++ b/docs/v1_contract.md
@@ -1,0 +1,78 @@
+# V1 Contract Draft
+
+This document defines the intended contract for `v1.0`.
+Until `v1.0` is released, this is a target contract and may still evolve in `0.x`.
+
+## V1.0 Scope
+
+The `v1.0` goal is a stable local-first execution core with a stable public import surface for:
+
+- Macro planning/validation models
+- Dependency-aware local execution
+- Pointer-backed state persistence
+- Basic provider integration through `AgentClient`
+
+## V1.0 Non-Goals
+
+The following are explicitly out of scope for `v1.0` stability guarantees:
+
+- Streamlit UI layout and UX details in `app.py`
+- Internal module organization under non-`eap.*` namespaces
+- Experimental plugin manifest fields not exported through `eap.environment`
+- Advanced distributed coordination semantics beyond documented behavior
+
+## Public API Freeze Candidates (for V1.0)
+
+The symbols exported by these module entry points are the stability candidates:
+
+- `eap.protocol`
+- `eap.environment`
+- `eap.agent`
+
+The current candidate symbol list is the explicit `__all__` set in those files.
+Additions are allowed in minor releases; removals/behavioral breaks are only allowed in major releases after `v1.0`.
+
+## Workflow Schema Freeze Candidates (for V1.0)
+
+For `PersistedWorkflowGraph` and related types, these fields are intended to be stable:
+
+- `workflow_id`
+- `version`
+- `nodes`
+- `edges`
+- `created_at_utc`
+- `updated_at_utc`
+- `metadata`
+
+For node and edge models, these fields are intended to be stable:
+
+- Node: `node_id`, `step`, `label`, `position_x`, `position_y`
+- Edge: `source_node_id`, `target_node_id`, `kind`
+
+The validation guarantees in `docs/workflow_schema.md` are also intended to be part of the `v1.0` contract.
+
+## Supported User Profile
+
+This project is currently best for:
+
+- Python developers building local tool-execution agents
+- Teams that want pointer-backed state and execution traces
+- Users comfortable with pre-1.0 iteration and explicit upgrade checks
+
+This project is not yet ideal for:
+
+- Teams needing strict long-term API stability today
+- Non-technical users expecting no-code setup
+- Regulated production environments requiring formal support SLAs
+
+## Release Notes Contract (starting now)
+
+Each release notes entry should include, when applicable:
+
+- `Added`
+- `Changed`
+- `Fixed`
+- `Deprecated`
+- `Removed`
+- `Breaking Changes`
+- `Upgrade Notes`


### PR DESCRIPTION
## Summary
- add `docs/v1_contract.md` with v1.0 scope, non-goals, API/schema freeze candidates, and target user profile
- add `docs/release_notes_template.md` with explicit breaking/deprecated sections
- update `README.md`, `STABILITY.md`, and `ROADMAP.md` to reference Phase 1 contract artifacts

## Why
Implements the first roadmap phase for project-contract clarity before `v1.0`.

Closes #1
