### PR TITLE
Phase 2A: contracts, coverage gates, outage tests, and benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,45 @@ jobs:
           ruff check . --select E9,F63,F7,F82
 
       - name: Run tests
+        if: matrix.python-version != '3.11'
         run: |
           python -m pytest -q
+
+      - name: Run tests with coverage gates
+        if: matrix.python-version == '3.11'
+        run: |
+          python -m pytest -q \
+            --cov=protocol \
+            --cov=agent \
+            --cov=environment \
+            --cov=eap \
+            --cov-branch \
+            --cov-report=term-missing \
+            --cov-report=json:coverage.json
+          python - <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          totals = json.loads(Path("coverage.json").read_text(encoding="utf-8"))["totals"]
+          line_coverage = float(totals["percent_covered"])
+          num_branches = int(totals.get("num_branches", 0))
+          covered_branches = int(totals.get("covered_branches", 0))
+          branch_coverage = 100.0 if num_branches == 0 else (covered_branches / num_branches) * 100.0
+
+          line_threshold = 80.0
+          branch_threshold = 65.0
+          print(
+              f"Coverage gates: line={line_coverage:.2f}% (min {line_threshold:.2f}%), "
+              f"branch={branch_coverage:.2f}% (min {branch_threshold:.2f}%)"
+          )
+          if line_coverage < line_threshold:
+              print("Line coverage gate failed.", file=sys.stderr)
+              sys.exit(1)
+          if branch_coverage < branch_threshold:
+              print("Branch coverage gate failed.", file=sys.stderr)
+              sys.exit(1)
+          PY
 
   build:
     name: Build package (py3.11)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ python3 -m build
 - `ROADMAP.md`
 - `docs/v1_contract.md`
 - `docs/release_notes_template.md`
+- `docs/benchmarks.md`
 - GitHub roadmap board: https://github.com/users/GenieWeenie/projects/1
 - `docs/configuration.md`
 - `docs/architecture.md`

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,39 @@
+# Benchmarks
+
+This document defines the reproducible benchmark method for EAP and records baseline numbers.
+
+## Environment
+
+Capture and publish this context alongside benchmark results:
+
+- OS and version
+- CPU model
+- Python version
+- EAP commit SHA
+- whether debug/profiling instrumentation is enabled
+
+## Benchmark Command
+
+Run the performance test subset:
+
+```bash
+python3 -m pytest -q tests/perf --durations=10
+```
+
+## Baseline (2026-02-23)
+
+Measured on local macOS development machine, Python 3.9:
+
+- `tests/perf/test_concurrency_limits.py::ConcurrencyLimitsPerfTest::test_rate_limit_generates_saturation_metrics`: `1.70s`
+- `tests/perf/test_concurrency_limits.py::ConcurrencyLimitsPerfTest::test_global_concurrency_limit_caps_parallel_work`: `0.28s`
+- `tests/perf/test_distributed_resilience.py::DistributedResiliencePerfTest::test_expired_lease_is_reassigned`: `0.01s`
+- `tests/perf/test_distributed_resilience.py::DistributedResiliencePerfTest::test_stale_completion_report_is_rejected_after_reassignment`: `0.01s`
+
+## CI Regression Gates
+
+Critical perf tests include upper-bound assertions to catch major slowdowns:
+
+- global-concurrency perf test: must stay below `2.0s`
+- rate-limit perf test: must stay below `4.0s`
+
+These assertions run in standard CI test jobs.

--- a/tests/contract/test_public_api_contract.py
+++ b/tests/contract/test_public_api_contract.py
@@ -1,0 +1,84 @@
+import unittest
+
+import eap.agent as eap_agent
+import eap.environment as eap_environment
+import eap.protocol as eap_protocol
+
+
+class PublicApiContractTest(unittest.TestCase):
+    def test_eap_protocol_exports_are_stable(self) -> None:
+        expected = {
+            "PointerResponse",
+            "PersistedWorkflowGraph",
+            "ToolErrorPayload",
+            "ToolCall",
+            "BranchingRule",
+            "RetryPolicy",
+            "MemoryStrategy",
+            "ConversationSession",
+            "ConversationTurn",
+            "ExecutionTraceEventType",
+            "ExecutionTraceEvent",
+            "ToolExecutionLimit",
+            "ExecutionLimits",
+            "BatchedMacroRequest",
+            "WorkflowEdgeKind",
+            "WorkflowGraphEdge",
+            "WorkflowGraphNode",
+            "StateManager",
+            "configure_logging",
+            "LLMClientSettings",
+            "ToolLimitSettings",
+            "ExecutorLimitSettings",
+            "EAPSettings",
+            "load_settings",
+            "PointerStoreBackend",
+            "PostgresPointerStore",
+            "RedisPointerStore",
+            "SQLitePointerStore",
+        }
+        actual = set(eap_protocol.__all__)
+        self.assertSetEqual(actual, expected)
+        for symbol in actual:
+            self.assertTrue(hasattr(eap_protocol, symbol), f"eap.protocol missing export: {symbol}")
+
+    def test_eap_environment_exports_are_stable(self) -> None:
+        expected = {
+            "AsyncLocalExecutor",
+            "DistributedCoordinator",
+            "ToolRegistry",
+            "ToolDefinition",
+            "InputValidationError",
+            "PluginManifestError",
+            "PluginLoadError",
+            "DEFAULT_PLUGIN_ENTRYPOINT_GROUP",
+            "discover_plugin_entry_points",
+            "load_plugins_into_registry",
+        }
+        actual = set(eap_environment.__all__)
+        self.assertSetEqual(actual, expected)
+        for symbol in actual:
+            self.assertTrue(hasattr(eap_environment, symbol), f"eap.environment missing export: {symbol}")
+
+    def test_eap_agent_exports_are_stable(self) -> None:
+        expected = {
+            "MacroCompiler",
+            "WorkflowGraphCompiler",
+            "AgentClient",
+            "ProviderMessage",
+            "CompletionRequest",
+            "CompletionResponse",
+            "LLMProvider",
+            "OpenAIProvider",
+            "AnthropicProvider",
+            "GoogleProvider",
+            "create_provider",
+        }
+        actual = set(eap_agent.__all__)
+        self.assertSetEqual(actual, expected)
+        for symbol in actual:
+            self.assertTrue(hasattr(eap_agent, symbol), f"eap.agent missing export: {symbol}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/contract/test_workflow_schema_contract.py
+++ b/tests/contract/test_workflow_schema_contract.py
@@ -1,0 +1,47 @@
+import unittest
+
+from eap.protocol import PersistedWorkflowGraph, WorkflowEdgeKind, WorkflowGraphEdge, WorkflowGraphNode
+
+
+class WorkflowSchemaContractTest(unittest.TestCase):
+    def test_persisted_workflow_graph_contract_fields(self) -> None:
+        schema = PersistedWorkflowGraph.model_json_schema()
+        self.assertEqual(set(schema["required"]), {"workflow_id", "nodes"})
+        self.assertSetEqual(
+            set(schema["properties"].keys()),
+            {
+                "workflow_id",
+                "version",
+                "nodes",
+                "edges",
+                "created_at_utc",
+                "updated_at_utc",
+                "metadata",
+            },
+        )
+
+    def test_workflow_node_contract_fields(self) -> None:
+        schema = WorkflowGraphNode.model_json_schema()
+        self.assertEqual(set(schema["required"]), {"node_id", "step"})
+        self.assertSetEqual(
+            set(schema["properties"].keys()),
+            {"node_id", "step", "label", "position_x", "position_y"},
+        )
+
+    def test_workflow_edge_contract_fields(self) -> None:
+        schema = WorkflowGraphEdge.model_json_schema()
+        self.assertEqual(set(schema["required"]), {"source_node_id", "target_node_id"})
+        self.assertSetEqual(
+            set(schema["properties"].keys()),
+            {"source_node_id", "target_node_id", "kind"},
+        )
+
+    def test_workflow_edge_kind_values_are_stable(self) -> None:
+        self.assertEqual(
+            [kind.value for kind in WorkflowEdgeKind],
+            ["dependency", "branch_true", "branch_false", "branch_fallback"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/perf/test_concurrency_limits.py
+++ b/tests/perf/test_concurrency_limits.py
@@ -68,12 +68,15 @@ class ConcurrencyLimitsPerfTest(unittest.TestCase):
             retry_policy=RetryPolicy(max_attempts=1, initial_delay_seconds=0.0, backoff_multiplier=1.0),
             execution_limits=ExecutionLimits(max_global_concurrency=3),
         )
+        started = time.perf_counter()
         result = asyncio.run(executor.execute_macro(macro))
+        elapsed = time.perf_counter() - started
         metrics = result["metadata"]["saturation_metrics"]
 
         self.assertLessEqual(tracker.max_inflight, 3)
         self.assertLessEqual(metrics["max_inflight_global"], 3)
         self.assertGreater(metrics["global_concurrency_wait_count"], 0)
+        self.assertLess(elapsed, 2.0)
 
     def test_rate_limit_generates_saturation_metrics(self) -> None:
         tracker = _ConcurrencyTrackerTool(sleep_seconds=0.01)
@@ -103,6 +106,7 @@ class ConcurrencyLimitsPerfTest(unittest.TestCase):
         metrics = result["metadata"]["saturation_metrics"]
 
         self.assertGreaterEqual(elapsed, 1.3)
+        self.assertLess(elapsed, 4.0)
         self.assertGreater(metrics["global_rate_wait_count"], 0)
         self.assertGreater(metrics["global_rate_wait_seconds"], 0.0)
         self.assertGreater(metrics["total_rate_limited_attempts"], 0)

--- a/tests/unit/test_storage_backend.py
+++ b/tests/unit/test_storage_backend.py
@@ -196,6 +196,66 @@ class FakePostgresPointerClient:
         return self.rows.pop(pointer_id, None) is not None
 
 
+class UnavailableRedisClient:
+    def _fail(self) -> None:
+        raise ConnectionError("redis unavailable")
+
+    def hset(self, key: str, mapping: Dict[str, str]) -> int:
+        self._fail()
+
+    def hget(self, key: str, field: str) -> Optional[str]:
+        self._fail()
+
+    def hgetall(self, key: str) -> Dict[str, str]:
+        self._fail()
+
+    def sadd(self, key: str, *members: str) -> int:
+        self._fail()
+
+    def smembers(self, key: str) -> set[str]:
+        self._fail()
+
+    def srem(self, key: str, *members: str) -> int:
+        self._fail()
+
+    def delete(self, key: str) -> int:
+        self._fail()
+
+
+class UnavailablePostgresPointerClient(FakePostgresPointerClient):
+    def _fail(self) -> None:
+        raise ConnectionError("postgres unavailable")
+
+    def initialize(self) -> None:
+        self._fail()
+
+    def insert_pointer(
+        self,
+        pointer_id: str,
+        raw_data: str,
+        summary: str,
+        metadata: Dict[str, Any],
+        created_at_utc: str,
+        ttl_seconds: Optional[int],
+        expires_at_utc: Optional[str],
+    ) -> None:
+        self._fail()
+
+    def retrieve_pointer(self, pointer_id: str) -> Any:
+        self._fail()
+
+    def list_pointers(
+        self,
+        include_expired: bool = True,
+        now_utc: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        self._fail()
+
+    def delete_pointer(self, pointer_id: str) -> bool:
+        self._fail()
+
+
 class PointerStoreContractMixin:
     def build_store(self) -> PointerStoreBackend:
         raise NotImplementedError
@@ -291,6 +351,29 @@ class StateManagerStorageInjectionTest(unittest.TestCase):
         manager.delete_pointer(pointer["pointer_id"])
         with self.assertRaises(KeyError):
             manager.retrieve(pointer["pointer_id"])
+
+
+class PointerStoreOutageTest(unittest.TestCase):
+    def test_redis_backend_outage_propagates_connection_error(self) -> None:
+        store = RedisPointerStore(client=UnavailableRedisClient(), key_prefix="eap:test:outage")
+        with self.assertRaises(ConnectionError):
+            store.store_pointer(
+                pointer_id="ptr_outage",
+                raw_data="{}",
+                summary="outage",
+                metadata={},
+                created_at_utc="2026-02-23T00:00:00+00:00",
+                ttl_seconds=None,
+                expires_at_utc=None,
+            )
+
+    def test_postgres_backend_outage_propagates_connection_error(self) -> None:
+        store = PostgresPointerStore(client=UnavailablePostgresPointerClient())
+        with self.assertRaises(ConnectionError):
+            store.initialize()
+
+        with self.assertRaises(ConnectionError):
+            store.list_pointers()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add contract tests for stable exports in `eap.protocol`, `eap.environment`, and `eap.agent`
- add workflow schema contract tests for `PersistedWorkflowGraph`, `WorkflowGraphNode`, and `WorkflowGraphEdge`
- enforce CI coverage gates on py3.11 (line + branch thresholds)
- add Redis/Postgres outage-path tests via unavailable client doubles
- add benchmark methodology + baseline doc and link it from README
- add upper-bound perf regression assertions for critical concurrency perf tests

## Validation
- `python3 -m pytest -q`
- `python3 -m pytest -q --cov=protocol --cov=agent --cov=environment --cov=eap --cov-branch --cov-report=json:coverage.json`
- local coverage totals: line `82.17%`, branch `70.41%`

## Roadmap
Partially addresses #2.
