### PR TITLE
Phase 4: migration safety, observability, and governance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,6 @@ EAP_AUDITOR_TEMPERATURE=0.0
 
 # Logging
 EAP_LOG_LEVEL=INFO
-EAP_LOG_JSON=0
-
+EAP_LOG_FORMAT=json
+# Legacy override (optional): 1/true/yes enables JSON, 0/false/no disables JSON
+EAP_LOG_JSON=

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report a reproducible defect
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please include concrete reproduction steps and expected vs actual behavior.
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: Short description of the problem
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      placeholder: v0.1.3 or commit SHA
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / output
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/GenieWeenie/efficient-agent-protocol/security/advisories/new
+    about: Please report security issues via private advisory.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: Propose an enhancement
+labels: ["enhancement"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: Short proposal title
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      placeholder: What user problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      placeholder: Describe expected behavior and API/UX shape
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / migration impact
+      placeholder: Mention compatibility, migration, or ops impact

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+- 
+
+## Validation
+
+- [ ] `python3 -m pytest -q`
+- [ ] `python3 -m pre_commit run --all-files`
+- [ ] `python3 -m pip_audit -r requirements.txt`
+
+## Risk Notes
+
+- 
+
+## Roadmap / Issue Link
+
+- Closes #...

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ dist/
 # Local runtime/state
 *.db
 *.sqlite
+*.bak
+metrics/
 .env
 .DS_Store
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thanks for contributing to Efficient Agent Protocol (EAP).
+
+## Workflow
+
+1. Create a branch from `main` using `codex/` or `feature/` prefix.
+2. Keep changes focused and scoped to one objective.
+3. Run local checks before opening a PR.
+4. Open a PR with a clear summary and validation steps.
+
+## Local Validation
+
+```bash
+python3 -m pytest -q
+python3 -m pre_commit run --all-files
+python3 -m pip_audit -r requirements.txt
+```
+
+## Pull Request Expectations
+
+- Link the roadmap issue (`Closes #<id>` or `Partially addresses #<id>`).
+- Include risk notes for behavioral changes.
+- Include migration notes if schema/state format changes.
+- Keep PRs small enough for fast review.
+
+## Issue and PR Response Expectations
+
+- New issues: first maintainer response target is within 3 business days.
+- New PRs: first maintainer review target is within 3 business days.
+- If blocked or delayed, maintainers should post a status update within 7 days.
+
+## Release and Migration Notes
+
+- Follow `docs/release.md` for release procedure and rollback.
+- Follow `docs/migrations.md` for schema/state migration policy.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ macro = architect.generate_macro("Read README.md and summarize setup steps", man
 ```bash
 python3 -m pytest -q
 pre-commit run --all-files
+python3 scripts/migrate_state_db.py --db-path agent_state.db --dry-run
+python3 scripts/export_metrics.py --db-path agent_state.db --output metrics/latest.json
 python3 -m build
 ```
 
@@ -107,7 +109,11 @@ python3 -m build
 - `docs/release_notes_template.md`
 - `docs/benchmarks.md`
 - `docs/release.md`
+- `docs/migrations.md`
+- `docs/observability.md`
+- `docs/maintainer_runbook.md`
 - `SECURITY.md`
+- `CONTRIBUTING.md`
 - GitHub roadmap board: https://github.com/users/GenieWeenie/projects/1
 - `docs/configuration.md`
 - `docs/architecture.md`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,3 +39,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Release notes template published (`docs/release_notes_template.md`).
 - Phase 2 reliability/contract/perf tranche completed (issue #2).
 - Phase 3 release and security hardening shipped (issue #3).
+- Phase 4 migration/observability/governance tranche completed (issue #4).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,8 @@ Role-specific overrides:
 
 Logging:
 - `EAP_LOG_LEVEL` (`DEBUG`, `INFO`, `WARNING`, `ERROR`)
-- `EAP_LOG_JSON` (`1`/`true`/`yes` to enable JSON logs)
+- `EAP_LOG_FORMAT` (`json` or `text`, default: `json`)
+- `EAP_LOG_JSON` (legacy boolean override for JSON logs)
 
 Executor concurrency/rate limits:
 - `EAP_EXECUTOR_MAX_CONCURRENCY` (integer > 0, default `8`)

--- a/docs/maintainer_runbook.md
+++ b/docs/maintainer_runbook.md
@@ -1,0 +1,42 @@
+# Maintainer Runbook
+
+This runbook captures core maintainer operations to reduce bus factor.
+
+## Daily / Routine
+
+- Review open issues and PRs.
+- Confirm CI, Security, and CodeQL workflows are healthy.
+- Triage flaky test reports and release blockers.
+
+## Triage Process
+
+1. Confirm reproduction details.
+2. Classify severity and scope.
+3. Label issue (`bug`, `enhancement`, roadmap phase labels).
+4. Link issue to a milestone/roadmap task.
+
+## Incident Response
+
+1. Acknowledge issue and post impact statement.
+2. Reproduce and isolate root cause.
+3. Land fix behind CI validation.
+4. Publish release and post remediation note.
+
+## Release Owner Checklist
+
+- Follow `docs/release.md`.
+- Validate release notes and migration implications.
+- Verify post-release workflows are green.
+
+## Response Expectations
+
+- First maintainer response target:
+  - issues: within 3 business days
+  - PRs: within 3 business days
+- If blocked, post status update within 7 days.
+
+## Credentials and Access
+
+- Keep repository admin and package publish access documented and rotated.
+- Keep branch protection enabled on `main`.
+- Ensure at least two maintainers have workflow/release access when team size allows.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,38 @@
+# Migrations
+
+This document defines how EAP handles SQLite schema/state migrations safely.
+
+## Policy
+
+- Schema changes must be additive and backward compatible when possible.
+- Every schema change requires:
+  - a migration step in `protocol/migrations.py`
+  - a migration test in `tests/unit/test_migrations.py`
+  - release notes mention if user action is needed
+- Do not mutate or delete historical migration versions once released.
+
+## Runtime Behavior
+
+- `StateManager` applies pending SQLite migrations on startup.
+- Applied versions are tracked in `schema_migrations`.
+
+## Manual Migration Script
+
+Use the migration script for explicit control (including dry-run and backups):
+
+```bash
+python3 scripts/migrate_state_db.py --db-path agent_state.db --dry-run
+python3 scripts/migrate_state_db.py --db-path agent_state.db --backup
+```
+
+## Rollback Guidance
+
+- Prefer restoring from backup (`--backup` creates `.bak` file) for SQLite rollback.
+- If rollback is required after a release:
+  - stop writes
+  - restore DB backup
+  - deploy previous compatible application version
+
+## Versioning
+
+- Current schema version is managed by `LATEST_SCHEMA_VERSION` in `protocol/migrations.py`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,34 @@
+# Observability
+
+EAP provides structured logging defaults and operational metrics export.
+
+## Structured Logging
+
+- Default format is JSON.
+- Override with:
+  - `EAP_LOG_FORMAT=text` for plain text
+  - `EAP_LOG_LEVEL=DEBUG|INFO|WARNING|ERROR`
+  - `EAP_LOG_JSON` (legacy boolean override)
+
+Logs are configured through `eap.protocol.configure_logging()`.
+
+## Metrics Snapshot Export
+
+`StateManager` exposes:
+
+- `collect_operational_metrics()`
+- `export_operational_metrics(output_path=...)`
+
+You can export metrics with:
+
+```bash
+python3 scripts/export_metrics.py --db-path agent_state.db --output metrics/latest.json
+```
+
+Snapshot fields include:
+
+- pointer-store counts (total/active/expired)
+- execution run and trace-event summaries
+- conversation session/turn counts
+
+This path is intended for operational diagnostics and periodic health snapshots.

--- a/protocol/logging_config.py
+++ b/protocol/logging_config.py
@@ -11,6 +11,7 @@ class JsonFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         payload = {
+            "timestamp_utc": self.formatTime(record, datefmt="%Y-%m-%dT%H:%M:%S"),
             "level": record.levelname,
             "logger": record.name,
             "message": record.getMessage(),
@@ -39,6 +40,7 @@ class RedactionFilter(logging.Filter):
 def configure_logging(
     level: Optional[str] = None,
     use_json: Optional[bool] = None,
+    log_format: Optional[str] = None,
     stream: Optional[TextIO] = None,
 ) -> logging.Logger:
     """
@@ -46,7 +48,8 @@ def configure_logging(
 
     Environment variables:
     - EAP_LOG_LEVEL: DEBUG/INFO/WARNING/ERROR (default INFO)
-    - EAP_LOG_JSON: 1/true/yes for JSON output (default false)
+    - EAP_LOG_FORMAT: json|text (default json)
+    - EAP_LOG_JSON: legacy bool override for JSON output
     """
     logger = logging.getLogger("eap")
     logger.handlers.clear()
@@ -57,7 +60,14 @@ def configure_logging(
 
     json_enabled = use_json
     if json_enabled is None:
-        json_enabled = os.getenv("EAP_LOG_JSON", "").lower() in {"1", "true", "yes"}
+        requested_format = (log_format or os.getenv("EAP_LOG_FORMAT", "json")).strip().lower()
+        if requested_format not in {"json", "text"}:
+            requested_format = "json"
+        json_enabled = requested_format == "json"
+
+        legacy_json_flag = os.getenv("EAP_LOG_JSON", "").strip()
+        if legacy_json_flag:
+            json_enabled = legacy_json_flag.lower() in {"1", "true", "yes"}
 
     handler = logging.StreamHandler(stream or sys.stdout)
     handler.addFilter(RedactionFilter())

--- a/protocol/migrations.py
+++ b/protocol/migrations.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class MigrationStep:
+    version: int
+    description: str
+    statements: List[str]
+
+
+MIGRATIONS: List[MigrationStep] = [
+    MigrationStep(
+        version=1,
+        description="Create schema_migrations tracking table",
+        statements=[
+            """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version INTEGER PRIMARY KEY,
+                description TEXT NOT NULL,
+                applied_at_utc TEXT NOT NULL
+            )
+            """
+        ],
+    ),
+    MigrationStep(
+        version=2,
+        description="Add trace-event step_id index for faster diagnostics",
+        statements=[
+            "CREATE INDEX IF NOT EXISTS idx_execution_trace_events_step_id ON execution_trace_events(step_id)"
+        ],
+    ),
+    MigrationStep(
+        version=3,
+        description="Add run-summary completion-time index for faster history queries",
+        statements=[
+            "CREATE INDEX IF NOT EXISTS idx_execution_run_summaries_completed_at ON execution_run_summaries(completed_at_utc)"
+        ],
+    ),
+]
+
+
+LATEST_SCHEMA_VERSION = MIGRATIONS[-1].version if MIGRATIONS else 0
+
+
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    ).fetchone()
+    return bool(row)
+
+
+def _ensure_migration_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            version INTEGER PRIMARY KEY,
+            description TEXT NOT NULL,
+            applied_at_utc TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _current_schema_version(conn: sqlite3.Connection) -> int:
+    if not _table_exists(conn, "schema_migrations"):
+        return 0
+    row = conn.execute("SELECT COALESCE(MAX(version), 0) FROM schema_migrations").fetchone()
+    return int(row[0]) if row else 0
+
+
+def pending_migrations(
+    db_path: str,
+    target_version: Optional[int] = None,
+) -> List[MigrationStep]:
+    target = target_version if target_version is not None else LATEST_SCHEMA_VERSION
+    if target < 0 or target > LATEST_SCHEMA_VERSION:
+        raise ValueError(f"target_version must be between 0 and {LATEST_SCHEMA_VERSION}")
+
+    with sqlite3.connect(db_path) as conn:
+        current = _current_schema_version(conn)
+    return [step for step in MIGRATIONS if current < step.version <= target]
+
+
+def apply_sqlite_migrations(
+    db_path: str,
+    target_version: Optional[int] = None,
+    dry_run: bool = False,
+) -> Dict[str, object]:
+    target = target_version if target_version is not None else LATEST_SCHEMA_VERSION
+    if target < 0 or target > LATEST_SCHEMA_VERSION:
+        raise ValueError(f"target_version must be between 0 and {LATEST_SCHEMA_VERSION}")
+
+    with sqlite3.connect(db_path) as conn:
+        current = _current_schema_version(conn)
+        planned = [step for step in MIGRATIONS if current < step.version <= target]
+
+        if dry_run:
+            return {
+                "db_path": db_path,
+                "dry_run": True,
+                "current_version": current,
+                "target_version": target,
+                "planned_versions": [step.version for step in planned],
+                "applied_versions": [],
+            }
+
+        _ensure_migration_table(conn)
+        applied_versions: List[int] = []
+        applied_at = datetime.now(timezone.utc).isoformat()
+
+        for step in planned:
+            for statement in step.statements:
+                conn.execute(statement)
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO schema_migrations (version, description, applied_at_utc)
+                VALUES (?, ?, ?)
+                """,
+                (step.version, step.description, applied_at),
+            )
+            applied_versions.append(step.version)
+
+        final_version = _current_schema_version(conn)
+        return {
+            "db_path": db_path,
+            "dry_run": False,
+            "current_version": current,
+            "target_version": target,
+            "planned_versions": [step.version for step in planned],
+            "applied_versions": applied_versions,
+            "final_version": final_version,
+        }

--- a/protocol/state_manager.py
+++ b/protocol/state_manager.py
@@ -4,6 +4,7 @@ import sys
 import sqlite3
 import json
 import os
+from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
@@ -14,6 +15,7 @@ from .models import (
     MemoryStrategy,
     PointerResponse,
 )
+from .migrations import apply_sqlite_migrations
 from .storage import PointerStoreBackend, SQLitePointerStore
 
 class StateManager:
@@ -102,6 +104,7 @@ class StateManager:
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_conversation_sessions_updated_at ON conversation_sessions(updated_at_utc)"
             )
+        apply_sqlite_migrations(self.db_path)
 
     @staticmethod
     def _now_utc_iso() -> str:
@@ -590,3 +593,77 @@ class StateManager:
         if os.path.exists(self.db_path):
             os.remove(self.db_path)
             self._init_db()
+
+    def collect_operational_metrics(self, now_utc: Optional[str] = None) -> Dict[str, Any]:
+        snapshot_now = self._parse_now_utc(now_utc).isoformat()
+
+        total_pointers = len(self.list_pointers(include_expired=True, now_utc=snapshot_now))
+        active_pointers = len(self.list_pointers(include_expired=False, now_utc=snapshot_now))
+        expired_pointers = max(0, total_pointers - active_pointers)
+
+        with sqlite3.connect(self.db_path) as conn:
+            run_row = conn.execute(
+                """
+                SELECT
+                    COUNT(*) AS run_count,
+                    COALESCE(SUM(total_steps), 0) AS total_steps,
+                    COALESCE(SUM(succeeded_steps), 0) AS succeeded_steps,
+                    COALESCE(SUM(failed_steps), 0) AS failed_steps,
+                    COALESCE(AVG(total_duration_ms), 0.0) AS avg_duration_ms
+                FROM execution_run_summaries
+                """
+            ).fetchone()
+            failed_run_count = conn.execute(
+                "SELECT COUNT(*) FROM execution_run_summaries WHERE failed_steps > 0"
+            ).fetchone()[0]
+
+            event_rows = conn.execute(
+                """
+                SELECT event_type, COUNT(*)
+                FROM execution_trace_events
+                GROUP BY event_type
+                """
+            ).fetchall()
+            trace_event_total = conn.execute("SELECT COUNT(*) FROM execution_trace_events").fetchone()[0]
+
+            session_count = conn.execute("SELECT COUNT(*) FROM conversation_sessions").fetchone()[0]
+            turn_count = conn.execute("SELECT COUNT(*) FROM conversation_turns").fetchone()[0]
+
+        return {
+            "snapshot_utc": snapshot_now,
+            "db_path": self.db_path,
+            "pointer_store": {
+                "total_pointers": total_pointers,
+                "active_pointers": active_pointers,
+                "expired_pointers": expired_pointers,
+            },
+            "execution": {
+                "run_count": int(run_row[0]),
+                "failed_run_count": int(failed_run_count),
+                "total_steps": int(run_row[1]),
+                "succeeded_steps": int(run_row[2]),
+                "failed_steps": int(run_row[3]),
+                "avg_duration_ms": float(run_row[4]),
+                "trace_event_total": int(trace_event_total),
+                "trace_events_by_type": {row[0]: int(row[1]) for row in event_rows},
+            },
+            "conversation": {
+                "session_count": int(session_count),
+                "turn_count": int(turn_count),
+            },
+        }
+
+    def export_operational_metrics(
+        self,
+        output_path: str,
+        now_utc: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        metrics = self.collect_operational_metrics(now_utc=now_utc)
+        output = Path(output_path)
+        if output.parent and str(output.parent) != ".":
+            output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(metrics, indent=2, sort_keys=True), encoding="utf-8")
+        return {
+            "output_path": str(output.resolve()),
+            "snapshot_utc": metrics["snapshot_utc"],
+        }

--- a/scripts/export_metrics.py
+++ b/scripts/export_metrics.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from protocol.state_manager import StateManager
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export EAP operational metrics snapshot.")
+    parser.add_argument("--db-path", default="agent_state.db", help="Path to SQLite DB file.")
+    parser.add_argument(
+        "--output",
+        default="metrics/latest.json",
+        help="Output path for metrics JSON (default: metrics/latest.json).",
+    )
+    args = parser.parse_args()
+
+    state_manager = StateManager(db_path=args.db_path)
+    result = state_manager.export_operational_metrics(output_path=args.output)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migrate_state_db.py
+++ b/scripts/migrate_state_db.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from protocol.migrations import LATEST_SCHEMA_VERSION, apply_sqlite_migrations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Apply SQLite state DB migrations for EAP.")
+    parser.add_argument("--db-path", default="agent_state.db", help="Path to SQLite DB file.")
+    parser.add_argument(
+        "--target-version",
+        type=int,
+        default=LATEST_SCHEMA_VERSION,
+        help=f"Target schema version (default: {LATEST_SCHEMA_VERSION}).",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show planned migrations without applying.")
+    parser.add_argument("--backup", action="store_true", help="Create a .bak file before applying migrations.")
+    args = parser.parse_args()
+
+    db_path = Path(args.db_path)
+    if not db_path.exists():
+        parser.error(f"DB file not found: {db_path}")
+
+    if args.backup and not args.dry_run:
+        backup_path = db_path.with_suffix(db_path.suffix + ".bak")
+        shutil.copy2(db_path, backup_path)
+
+    result = apply_sqlite_migrations(
+        db_path=str(db_path),
+        target_version=args.target_version,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,6 +1,7 @@
 import io
 import json
 import unittest
+from unittest import mock
 
 from eap.protocol.logging_config import configure_logging
 
@@ -39,6 +40,26 @@ class LoggingConfigTest(unittest.TestCase):
         self.assertNotIn("secret", output)
         self.assertNotIn("abc123", output)
         self.assertNotIn("hunter2", output)
+
+    def test_default_logging_is_json(self) -> None:
+        stream = io.StringIO()
+        with mock.patch.dict("os.environ", {}, clear=True):
+            logger = configure_logging(level="INFO", stream=stream)
+            logger.info("default-json")
+
+        payload = json.loads(stream.getvalue().strip())
+        self.assertEqual(payload["level"], "INFO")
+        self.assertEqual(payload["message"], "default-json")
+
+    def test_log_format_env_can_force_plain_text(self) -> None:
+        stream = io.StringIO()
+        with mock.patch.dict("os.environ", {"EAP_LOG_FORMAT": "text"}, clear=True):
+            logger = configure_logging(level="INFO", stream=stream)
+            logger.info("plain-env")
+
+        output = stream.getvalue()
+        self.assertIn("plain-env", output)
+        self.assertNotIn('{"message"', output)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -1,0 +1,102 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+
+from protocol.migrations import LATEST_SCHEMA_VERSION, apply_sqlite_migrations, pending_migrations
+
+
+def _create_legacy_schema(db_path: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS execution_trace_events (
+                event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id TEXT NOT NULL,
+                step_id TEXT NOT NULL,
+                tool_name TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                timestamp_utc TEXT NOT NULL,
+                attempt INTEGER NOT NULL,
+                resolved_arguments TEXT,
+                input_pointer_ids TEXT,
+                output_pointer_id TEXT,
+                duration_ms REAL,
+                retry_delay_seconds REAL,
+                error_payload TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS execution_run_summaries (
+                run_id TEXT PRIMARY KEY,
+                started_at_utc TEXT NOT NULL,
+                completed_at_utc TEXT NOT NULL,
+                total_steps INTEGER NOT NULL,
+                succeeded_steps INTEGER NOT NULL,
+                failed_steps INTEGER NOT NULL,
+                total_duration_ms REAL NOT NULL,
+                final_pointer_id TEXT
+            )
+            """
+        )
+
+
+class SqliteMigrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        fd, self.db_path = tempfile.mkstemp(prefix="eap-migrations-", suffix=".db")
+        os.close(fd)
+        _create_legacy_schema(self.db_path)
+
+    def tearDown(self) -> None:
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_pending_and_dry_run_migrations(self) -> None:
+        pending = pending_migrations(self.db_path)
+        self.assertEqual([step.version for step in pending], list(range(1, LATEST_SCHEMA_VERSION + 1)))
+
+        result = apply_sqlite_migrations(self.db_path, dry_run=True)
+        self.assertEqual(result["planned_versions"], [1, 2, 3])
+        self.assertEqual(result["applied_versions"], [])
+
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_migrations'"
+            ).fetchone()
+            self.assertIsNone(row)
+
+    def test_apply_migrations_is_idempotent(self) -> None:
+        first = apply_sqlite_migrations(self.db_path)
+        self.assertEqual(first["applied_versions"], [1, 2, 3])
+        self.assertEqual(first["final_version"], LATEST_SCHEMA_VERSION)
+
+        with sqlite3.connect(self.db_path) as conn:
+            idx_rows = conn.execute(
+                """
+                SELECT name
+                FROM sqlite_master
+                WHERE type='index'
+                AND name IN (
+                    'idx_execution_trace_events_step_id',
+                    'idx_execution_run_summaries_completed_at'
+                )
+                ORDER BY name
+                """
+            ).fetchall()
+            self.assertEqual(
+                [row[0] for row in idx_rows],
+                [
+                    "idx_execution_run_summaries_completed_at",
+                    "idx_execution_trace_events_step_id",
+                ],
+            )
+
+        second = apply_sqlite_migrations(self.db_path)
+        self.assertEqual(second["applied_versions"], [])
+        self.assertEqual(second["final_version"], LATEST_SCHEMA_VERSION)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_operational_metrics.py
+++ b/tests/unit/test_operational_metrics.py
@@ -1,0 +1,74 @@
+import json
+import os
+import tempfile
+import unittest
+
+from eap.protocol import ExecutionTraceEvent, ExecutionTraceEventType, StateManager
+
+
+class OperationalMetricsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        fd, self.db_path = tempfile.mkstemp(prefix="eap-metrics-", suffix=".db")
+        os.close(fd)
+        self.manager = StateManager(db_path=self.db_path)
+
+    def tearDown(self) -> None:
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_collect_and_export_metrics(self) -> None:
+        self.manager.store_and_point(raw_data={"a": 1}, summary="first")
+        self.manager.store_and_point(raw_data={"b": 2}, summary="expiring", ttl_seconds=1)
+
+        session = self.manager.create_session()
+        self.manager.append_turn(
+            session_id=session["session_id"],
+            role="user",
+            content="hello metrics",
+        )
+
+        run_id = "run_metrics_1"
+        self.manager.store_execution_summary(
+            run_id=run_id,
+            started_at_utc="2026-02-23T00:00:00+00:00",
+            completed_at_utc="2026-02-23T00:00:01+00:00",
+            total_steps=2,
+            succeeded_steps=1,
+            failed_steps=1,
+            total_duration_ms=1000.0,
+            final_pointer_id=None,
+        )
+        self.manager.append_trace_event(
+            ExecutionTraceEvent(
+                run_id=run_id,
+                step_id="step_1",
+                tool_name="tool_a",
+                event_type=ExecutionTraceEventType.QUEUED,
+                attempt=1,
+            )
+        )
+
+        future_now = "2099-01-01T00:00:00+00:00"
+        metrics = self.manager.collect_operational_metrics(now_utc=future_now)
+        self.assertEqual(metrics["pointer_store"]["total_pointers"], 2)
+        self.assertEqual(metrics["pointer_store"]["active_pointers"], 1)
+        self.assertEqual(metrics["pointer_store"]["expired_pointers"], 1)
+        self.assertEqual(metrics["conversation"]["session_count"], 1)
+        self.assertEqual(metrics["conversation"]["turn_count"], 1)
+        self.assertEqual(metrics["execution"]["run_count"], 1)
+        self.assertEqual(metrics["execution"]["failed_run_count"], 1)
+        self.assertEqual(metrics["execution"]["trace_events_by_type"]["queued"], 1)
+
+        with tempfile.TemporaryDirectory(prefix="eap-metrics-out-") as tmpdir:
+            output_path = os.path.join(tmpdir, "latest.json")
+            export_info = self.manager.export_operational_metrics(output_path, now_utc=future_now)
+            self.assertTrue(os.path.exists(output_path))
+            self.assertTrue(export_info["output_path"].endswith("latest.json"))
+
+            payload = json.loads(open(output_path, "r", encoding="utf-8").read())
+            self.assertEqual(payload["execution"]["run_count"], 1)
+            self.assertEqual(payload["conversation"]["turn_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- define migration policy and add migration framework for SQLite state DB (`protocol/migrations.py`)
- add migration and metrics export scripts (`scripts/migrate_state_db.py`, `scripts/export_metrics.py`)
- integrate runtime migration application in `StateManager`
- add operational metrics collection/export path in `StateManager`
- switch structured logging defaults to JSON output with explicit format controls
- add governance assets: `CONTRIBUTING.md`, issue templates, PR template, maintainer runbook
- add migration/observability docs and wire them into README
- add migration + operational metrics tests

## Validation
- `python3 -m pytest -q`
- `python3 -m pre_commit run --all-files`
- `python3 -m pip_audit -r requirements.txt`

Closes #4
