### PR TITLE
Phase 5 Tranche 1: compiler ReDoS hardening and recommendation checklist

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,14 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Add contributor governance docs (`CONTRIBUTING.md`, issue/PR templates, maintainer expectations).
 - Reduce bus factor with maintainer runbooks and reviewer coverage.
 
+## Phase 5: Recommendation Readiness (Next)
+
+- Close all open high-severity code scanning alerts and keep the baseline at zero.
+- Add maintainer/reviewer ownership map (`CODEOWNERS`) for critical runtime paths.
+- Add README quickstart smoke validation in CI so onboarding docs stay executable.
+- Publish a one-page "why EAP vs alternatives" proof sheet with benchmark + failure-mode evidence.
+- Checklist: `docs/phase5_recommendation_readiness_checklist.md`
+
 ## Done
 
 - Branch protection on `main` with required CI checks and PR review.
@@ -40,3 +48,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 2 reliability/contract/perf tranche completed (issue #2).
 - Phase 3 release and security hardening shipped (issue #3).
 - Phase 4 migration/observability/governance tranche completed (issue #4).
+- Phase 5 tranche 1 started: compiler ReDoS hardening and regression tests (EAP-064).

--- a/agent/compiler.py
+++ b/agent/compiler.py
@@ -1,6 +1,5 @@
 # agent/compiler.py
 import json
-import re
 from typing import Any, Dict, Optional, Union
 from protocol.models import (
     BatchedMacroRequest,
@@ -8,6 +7,22 @@ from protocol.models import (
     PersistedWorkflowGraph,
     RetryPolicy,
 )
+
+
+def _extract_first_json_object(raw_payload: str, error_message: str) -> Dict[str, Any]:
+    """Extract the first top-level JSON object embedded in arbitrary text."""
+    decoder = json.JSONDecoder()
+    start_index = raw_payload.find("{")
+    while start_index != -1:
+        try:
+            parsed, _ = decoder.raw_decode(raw_payload, start_index)
+        except json.JSONDecodeError:
+            start_index = raw_payload.find("{", start_index + 1)
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+        start_index = raw_payload.find("{", start_index + 1)
+    raise ValueError(error_message)
 
 class MacroCompiler:
     """
@@ -19,13 +34,10 @@ class MacroCompiler:
         try:
             # 1. Extract JSON from potential markdown or conversational noise
             if isinstance(raw_llm_output, str):
-                # Use regex to find the first '{' and last '}' to strip conversational text
-                match = re.search(r'\{.*\}', raw_llm_output, re.DOTALL)
-                if not match:
-                    raise ValueError("No JSON object found in output.")
-                
-                cleaned_output = match.group(0)
-                parsed_data = json.loads(cleaned_output)
+                parsed_data = _extract_first_json_object(
+                    raw_llm_output,
+                    error_message="No JSON object found in output.",
+                )
             else:
                 parsed_data = raw_llm_output
 
@@ -52,10 +64,10 @@ class WorkflowGraphCompiler:
 
     @staticmethod
     def _extract_json_object(raw_payload: str) -> Dict[str, Any]:
-        match = re.search(r"\{.*\}", raw_payload, re.DOTALL)
-        if not match:
-            raise ValueError("No JSON object found in workflow graph payload.")
-        return json.loads(match.group(0))
+        return _extract_first_json_object(
+            raw_payload,
+            error_message="No JSON object found in workflow graph payload.",
+        )
 
     @staticmethod
     def _coerce_graph_payload(

--- a/docs/phase5_recommendation_readiness_checklist.md
+++ b/docs/phase5_recommendation_readiness_checklist.md
@@ -1,0 +1,15 @@
+# Phase 5 Recommendation Readiness Checklist
+
+This checklist tracks the next ordered tranche after Phase 4 to make EAP recommendable without caveats.
+
+## Tranche 1 (ordered)
+
+1. `EAP-064` Resolve open CodeQL high alert in compiler JSON extraction
+2. `EAP-065` Add `CODEOWNERS` coverage for critical runtime/docs/workflow paths
+3. `EAP-066` Add README quickstart smoke workflow in CI
+
+## Current status
+
+- [x] `EAP-064` Regex-based JSON extraction replaced with parser-based extraction; noisy-payload regression tests added.
+- [ ] `EAP-065` `CODEOWNERS` for `agent/`, `environment/`, `protocol/`, `docs/`, and `.github/workflows/`.
+- [ ] `EAP-066` CI job executes README quickstart path (install + minimal run) on pull requests.

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -31,6 +31,19 @@ class CompilerTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             WorkflowGraphCompiler.compile_graph({"workflow_id": "wf_x", "nodes": [], "edges": []})
 
+    def test_compile_skips_non_json_brace_prefix(self) -> None:
+        raw = "template {placeholder}\n{\"steps\": []}"
+        macro = MacroCompiler.compile(raw)
+        self.assertEqual(len(macro.steps), 0)
+
+    def test_workflow_graph_compiler_extracts_json_from_noisy_text(self) -> None:
+        raw = (
+            "noise before {not-json}\n"
+            '{"workflow_id":"wf_demo","nodes":[{"node_id":"n1","step":{"step_id":"step_1","tool_name":"read_local_file","arguments":{"file_path":"/tmp/a"}}}],"edges":[]}'
+        )
+        graph = WorkflowGraphCompiler.compile_graph(raw)
+        self.assertEqual(graph.workflow_id, "wf_demo")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- replace regex-based JSON extraction in `MacroCompiler`/`WorkflowGraphCompiler` with parser-based extraction (`json.JSONDecoder.raw_decode` scan)
- add regression tests for noisy payloads containing non-JSON brace segments
- start Phase 5 recommendation-readiness tracking in `ROADMAP.md`
- add `docs/phase5_recommendation_readiness_checklist.md` with ordered `EAP-064`..`EAP-066`

## Why
GitHub CodeQL reports an open high-severity ReDoS warning on `agent/compiler.py` (alert #1). This change removes the vulnerable regex pattern and adds tests to prevent regression.

## Validation
- `python3 -m pytest -q tests/unit/test_compiler.py`
- `python3 -m pytest -q tests/integration/test_visual_builder_compile.py`
- `python3 -m pytest -q`
- `python3 -m pre_commit run --all-files`

Part of #10
