### PR TITLE
Phase 5 Tranche 1: CODEOWNERS and README quickstart smoke CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Default owner
+* @GenieWeenie
+
+# Critical runtime paths
+/agent/ @GenieWeenie
+/environment/ @GenieWeenie
+/protocol/ @GenieWeenie
+/eap/ @GenieWeenie
+
+# Delivery and governance
+/docs/ @GenieWeenie
+/.github/workflows/ @GenieWeenie

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,43 @@ jobs:
         run: |
           python -m pip_audit -r requirements.txt
 
+  quickstart-smoke:
+    name: Quickstart smoke (py3.11)
+    runs-on: ubuntu-latest
+    needs: lint-test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Prepare .env
+        run: |
+          cp .env.example .env
+
+      - name: Run README smoke example
+        run: |
+          python -m examples.01_minimal
+
   build:
     name: Build package (py3.11)
     runs-on: ubuntu-latest
-    needs: lint-test
+    needs:
+      - lint-test
+      - quickstart-smoke
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Requirements:
 git clone https://github.com/GenieWeenie/efficient-agent-protocol.git
 cd efficient-agent-protocol
 pip install -e .
-pip install streamlit pandas
 ```
 
 2. Configure
@@ -54,13 +53,20 @@ EAP_MODEL=nemotron-orchestrator-8b
 EAP_API_KEY=not-needed
 ```
 
-3. Run dashboard
+3. Smoke test
 
 ```bash
+python -m examples.01_minimal
+```
+
+4. Run dashboard
+
+```bash
+pip install streamlit pandas
 streamlit run app.py
 ```
 
-4. Use it
+5. Use it
 
 - Open `http://localhost:8501`
 - In **Agent Chat**, ask for a task

--- a/docs/phase5_recommendation_readiness_checklist.md
+++ b/docs/phase5_recommendation_readiness_checklist.md
@@ -11,5 +11,5 @@ This checklist tracks the next ordered tranche after Phase 4 to make EAP recomme
 ## Current status
 
 - [x] `EAP-064` Regex-based JSON extraction replaced with parser-based extraction; noisy-payload regression tests added.
-- [ ] `EAP-065` `CODEOWNERS` for `agent/`, `environment/`, `protocol/`, `docs/`, and `.github/workflows/`.
-- [ ] `EAP-066` CI job executes README quickstart path (install + minimal run) on pull requests.
+- [x] `EAP-065` `CODEOWNERS` for `agent/`, `environment/`, `protocol/`, `docs/`, and `.github/workflows/`.
+- [x] `EAP-066` CI job executes README quickstart path (install + minimal run) on pull requests.


### PR DESCRIPTION
## Summary
- add `.github/CODEOWNERS` ownership coverage for critical runtime/docs/workflow paths
- update README quickstart to include a deterministic smoke step (`python -m examples.01_minimal`)
- add a `quickstart-smoke` CI job to execute install + env prep + smoke example on every PR
- mark `EAP-065` and `EAP-066` complete in `docs/phase5_recommendation_readiness_checklist.md`

## Validation
- `python3 -m examples.01_minimal`
- `python3 -m pytest -q tests/unit/test_compiler.py tests/packaging/test_install_smoke.py`
- `python3 -m pytest -q`
- `python3 -m pre_commit run --all-files`

Closes #10
