### PR TITLE
Phase 5 Tranche 2: publish EAP proof sheet (benchmark + failure evidence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,4 @@ python3 -m build
 - `docs/sdk_contract.md`
 - `docs/distributed_execution.md`
 - `docs/troubleshooting.md`
+- `docs/eap_proof_sheet.md`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,7 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Add README quickstart smoke validation in CI so onboarding docs stay executable.
 - Publish a one-page "why EAP vs alternatives" proof sheet with benchmark + failure-mode evidence.
 - Checklist: `docs/phase5_recommendation_readiness_checklist.md`
+- Proof sheet: `docs/eap_proof_sheet.md`
 
 ## Done
 
@@ -49,3 +50,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 3 release and security hardening shipped (issue #3).
 - Phase 4 migration/observability/governance tranche completed (issue #4).
 - Phase 5 tranche 1 started: compiler ReDoS hardening and regression tests (EAP-064).
+- Phase 5 tranche 2 completed: proof sheet with benchmark and failure-mode evidence.

--- a/docs/eap_proof_sheet.md
+++ b/docs/eap_proof_sheet.md
@@ -1,0 +1,47 @@
+# EAP Proof Sheet: Why Choose EAP
+
+This is a one-page decision brief for teams evaluating EAP against general-purpose agent orchestration stacks.
+
+## Where EAP Is Strong
+
+- Pointer-backed state keeps large intermediate payloads out of LLM context (`ptr_*` references instead of raw payload replay).
+- Dependency-aware DAG execution runs independent steps in parallel with typed retry + failure contracts.
+- Built-in execution traces and run summaries make retries/failures auditable by default.
+- Local-first operation with optional Redis/PostgreSQL backends for pointer storage.
+
+## Evidence Snapshot
+
+Source: `docs/benchmarks.md` (baseline date: 2026-02-23)
+
+- Concurrency-limit perf path: `0.28s` (`test_global_concurrency_limit_caps_parallel_work`)
+- Rate-limit saturation path: `1.70s` (`test_rate_limit_generates_saturation_metrics`)
+- Distributed lease recovery paths: `0.01s` each (`test_expired_lease_is_reassigned`, `test_stale_completion_report_is_rejected_after_reassignment`)
+- CI perf regression guards:
+  - global-concurrency path must stay `< 2.0s`
+  - rate-limit path must stay `< 4.0s`
+
+## Failure-Mode Evidence
+
+| Scenario | Expected behavior | Evidence |
+| --- | --- | --- |
+| Transient tool failure | Retry and then succeed when policy allows | `tests/integration/test_executor_retries.py` |
+| Non-retryable timeout | Fail fast with typed `tool_execution_error` | `tests/integration/test_reliability_failures.py` |
+| Upstream step fails | Downstream dependency marked `dependency_error` | `tests/integration/test_reliability_failures.py` |
+| Retry/fail trace visibility | `queued/started/retried/failed/completed` persisted with run summary | `tests/integration/test_execution_traces.py` |
+| Pointer lifecycle cleanup | Expired pointers filtered and cleaned idempotently | `tests/integration/test_pointer_ttl.py` |
+| Distributed worker lease expiry | Expired lease is reassigned; stale completion rejected | `tests/perf/test_distributed_resilience.py` |
+
+## Quick Verification Commands
+
+```bash
+python3 -m pytest -q tests/integration/test_executor_retries.py
+python3 -m pytest -q tests/integration/test_reliability_failures.py
+python3 -m pytest -q tests/integration/test_execution_traces.py
+python3 -m pytest -q tests/perf --durations=10
+```
+
+## Decision Rule
+
+Choose EAP when you need predictable tool orchestration with strong failure semantics, pointer-based state management, and observable execution behavior.
+
+Choose a broader framework if your priority is large ecosystem integrations over execution-contract rigor.

--- a/docs/phase5_recommendation_readiness_checklist.md
+++ b/docs/phase5_recommendation_readiness_checklist.md
@@ -7,9 +7,11 @@ This checklist tracks the next ordered tranche after Phase 4 to make EAP recomme
 1. `EAP-064` Resolve open CodeQL high alert in compiler JSON extraction
 2. `EAP-065` Add `CODEOWNERS` coverage for critical runtime/docs/workflow paths
 3. `EAP-066` Add README quickstart smoke workflow in CI
+4. `EAP-067` Publish one-page proof sheet (`why EAP`) with benchmark + failure-mode evidence
 
 ## Current status
 
 - [x] `EAP-064` Regex-based JSON extraction replaced with parser-based extraction; noisy-payload regression tests added.
 - [x] `EAP-065` `CODEOWNERS` for `agent/`, `environment/`, `protocol/`, `docs/`, and `.github/workflows/`.
 - [x] `EAP-066` CI job executes README quickstart path (install + minimal run) on pull requests.
+- [x] `EAP-067` Proof sheet published at `docs/eap_proof_sheet.md` and linked from roadmap/docs index.


### PR DESCRIPTION
## Summary
- add `docs/eap_proof_sheet.md` as a concise "why EAP" decision brief
- include benchmark snapshot and failure-mode evidence references
- link proof sheet in `README.md` and `ROADMAP.md`
- update `docs/phase5_recommendation_readiness_checklist.md` with `EAP-067`

## Validation
- `python3 -m pre_commit run --files docs/eap_proof_sheet.md README.md ROADMAP.md docs/phase5_recommendation_readiness_checklist.md`
- `python3 -m pytest -q`

Closes #13
