### PR TITLE
Docs: mark Phase 5 complete and kick off Phase 6 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 > Status: Experimental (pre-1.0). APIs and schema may change.
 > See `STABILITY.md` and `ROADMAP.md` for guarantees and planned milestones.
+> Latest stable release: `v0.1.4`
 
 Efficient Agent Protocol is a local-first framework for multi-step tool workflows.
 It stores large outputs as pointer-backed state (`ptr_*`) and runs dependency-aware DAG steps in parallel.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Add contributor governance docs (`CONTRIBUTING.md`, issue/PR templates, maintainer expectations).
 - Reduce bus factor with maintainer runbooks and reviewer coverage.
 
-## Phase 5: Recommendation Readiness (Next)
+## Phase 5: Recommendation Readiness (Completed)
 
 - Close all open high-severity code scanning alerts and keep the baseline at zero.
 - Add maintainer/reviewer ownership map (`CODEOWNERS`) for critical runtime paths.
@@ -38,6 +38,12 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Publish a one-page "why EAP vs alternatives" proof sheet with benchmark + failure-mode evidence.
 - Checklist: `docs/phase5_recommendation_readiness_checklist.md`
 - Proof sheet: `docs/eap_proof_sheet.md`
+
+## Phase 6: Distribution and V1 Readiness (Next)
+
+- Publish stable package releases to PyPI from tag workflow (configure release secret path).
+- Add post-release install smoke validation against published package artifacts.
+- Finalize `v1.0` stabilization checklist and upgrade notes for external adopters.
 
 ## Done
 
@@ -49,5 +55,5 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 2 reliability/contract/perf tranche completed (issue #2).
 - Phase 3 release and security hardening shipped (issue #3).
 - Phase 4 migration/observability/governance tranche completed (issue #4).
-- Phase 5 tranche 1 started: compiler ReDoS hardening and regression tests (EAP-064).
-- Phase 5 tranche 2 completed: proof sheet with benchmark and failure-mode evidence.
+- Phase 5 recommendation readiness completed (`EAP-064` to `EAP-067`).
+- `v0.1.4` release published with Phase 5 and CodeQL v4 updates.

--- a/docs/phase5_recommendation_readiness_checklist.md
+++ b/docs/phase5_recommendation_readiness_checklist.md
@@ -2,6 +2,8 @@
 
 This checklist tracks the next ordered tranche after Phase 4 to make EAP recommendable without caveats.
 
+Status: Completed (2026-02-23)
+
 ## Tranche 1 (ordered)
 
 1. `EAP-064` Resolve open CodeQL high alert in compiler JSON extraction
@@ -15,3 +17,7 @@ This checklist tracks the next ordered tranche after Phase 4 to make EAP recomme
 - [x] `EAP-065` `CODEOWNERS` for `agent/`, `environment/`, `protocol/`, `docs/`, and `.github/workflows/`.
 - [x] `EAP-066` CI job executes README quickstart path (install + minimal run) on pull requests.
 - [x] `EAP-067` Proof sheet published at `docs/eap_proof_sheet.md` and linked from roadmap/docs index.
+
+## Outcome
+
+- Phase 5 complete and released in `v0.1.4`.


### PR DESCRIPTION
## Summary
- mark Phase 5 recommendation readiness as completed in roadmap/checklist
- add Phase 6 (distribution + v1 readiness) as next roadmap tranche
- add README release line for latest stable tag (`v0.1.4`)
- create tracking issue for Phase 6 scope (`#17`)

## Validation
- `python3 -m pre_commit run --files ROADMAP.md docs/phase5_recommendation_readiness_checklist.md README.md`

Refs #17
