### PR TITLE
Phase 6: EAP-069 release install smoke + EAP-070 v1 handoff checklist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,3 +97,48 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ env.PYPI_API_TOKEN }}
+
+  verify-pypi-install:
+    name: Verify PyPI install smoke (stable tags)
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc')
+    permissions:
+      contents: read
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install released package with retry
+        env:
+          PACKAGE_VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${PACKAGE_VERSION#v}"
+          python -m pip install --upgrade pip
+          for attempt in {1..8}; do
+            if python -m pip install --no-cache-dir "efficient-agent-protocol==${VERSION}"; then
+              echo "Installed efficient-agent-protocol==${VERSION} on attempt ${attempt}"
+              break
+            fi
+            if [ "${attempt}" -eq 8 ]; then
+              echo "::error title=PyPI install failed::Unable to install efficient-agent-protocol==${VERSION} from PyPI after retries."
+              exit 1
+            fi
+            python -m pip uninstall -y efficient-agent-protocol || true
+            echo "Package not yet available on PyPI. Retrying in 15s..."
+            sleep 15
+          done
+
+      - name: Import smoke
+        run: |
+          python - <<'PY'
+          import eap
+          import eap.agent
+          import eap.environment
+          import eap.protocol
+          print("Import smoke passed for released package.")
+          PY

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ python3 -m build
 - `docs/release_notes_template.md`
 - `docs/benchmarks.md`
 - `docs/release.md`
+- `docs/v1_stabilization_checklist.md`
 - `docs/migrations.md`
 - `docs/observability.md`
 - `docs/maintainer_runbook.md`

--- a/docs/release.md
+++ b/docs/release.md
@@ -60,6 +60,13 @@ Use rollback only when a bad release is published.
 - Security scanning workflows remain green.
 - Roadmap issue/task status updated.
 
+## V1 Readiness Handoff
+
+For `v1.0` cutover, complete and attach:
+
+- `docs/v1_stabilization_checklist.md`
+- Fully populated `Breaking Changes` and `Upgrade Notes` sections from `docs/release_notes_template.md`
+
 ## Security Workflow Notes
 
 - `pip-audit` runs in CI and is always enforced on Python 3.11.

--- a/docs/v1_stabilization_checklist.md
+++ b/docs/v1_stabilization_checklist.md
@@ -1,0 +1,78 @@
+# V1 Stabilization Checklist and Upgrade Handoff
+
+This checklist defines the required handoff criteria before shipping `v1.0`.
+
+## Goal
+
+Ship `v1.0` with a stable contract for core runtime APIs, workflow schema, and upgrade guidance for existing `0.x` adopters.
+
+## Entry Criteria
+
+- `main` CI/Security/CodeQL pipelines are green.
+- Latest release workflow is green, including post-release install smoke checks.
+- Open high-severity code scanning alerts: `0`.
+
+## Stabilization Checklist
+
+### API and Namespace Freeze
+
+- [ ] Freeze exported symbols in `eap.protocol`, `eap.environment`, and `eap.agent`.
+- [ ] Document all symbols considered `v1.0` contract surface.
+- [ ] Identify and remove or deprecate unstable public entry points before tag cut.
+
+### Workflow and Data Contract Freeze
+
+- [ ] Freeze `PersistedWorkflowGraph` required/optional fields and validation rules.
+- [ ] Freeze executor error payload contract (`validation_error`, `dependency_error`, `tool_execution_error`).
+- [ ] Freeze pointer lifecycle semantics (TTL and cleanup behavior).
+
+### Configuration and Operational Defaults
+
+- [ ] Freeze required environment variables and defaults.
+- [ ] Verify migration scripts and migration docs cover upgrade from latest `0.x`.
+- [ ] Verify observability defaults (structured logs + metrics export) remain compatible.
+
+### Reliability and Performance Gates
+
+- [ ] Keep line/branch coverage gates passing in CI.
+- [ ] Keep perf regression thresholds green (`tests/perf` upper bounds).
+- [ ] Validate retry/timeout/dependency failure integration tests pass.
+
+### Security and Supply Chain
+
+- [ ] Dependency audit and secret scan pipelines green.
+- [ ] Code scanning alerts triaged with high-severity baseline at zero.
+- [ ] Release workflow publishes and validates package install from PyPI.
+
+### Documentation and Operator Readiness
+
+- [ ] Update `docs/v1_contract.md` from draft to final `v1.0` contract.
+- [ ] Ensure README quickstart and docs links are current.
+- [ ] Confirm release runbook and maintainer runbook reflect final `v1.0` process.
+
+## Upgrade Notes Handoff (Required Artifact)
+
+For `v1.0`, publish an explicit upgrade handoff with these sections:
+
+1. Scope:
+   - What changed from latest `0.x`.
+   - What is now guaranteed stable.
+2. Breaking changes:
+   - Removed/renamed symbols.
+   - Behavior changes in validation/execution semantics.
+3. Migration actions:
+   - Required code changes.
+   - Required config changes.
+   - Required data/schema migration commands.
+4. Verification steps:
+   - Commands to validate runtime behavior after upgrade.
+5. Rollback guidance:
+   - Safe downgrade path and constraints.
+
+Use `docs/release_notes_template.md` and ensure `Breaking Changes` + `Upgrade Notes` are fully populated.
+
+## Sign-Off
+
+- [ ] Engineering owner approval
+- [ ] Release owner approval
+- [ ] Documentation owner approval


### PR DESCRIPTION
## Summary
- add stable-release post-publish install smoke job to `release.yml`
  - verifies `pip install efficient-agent-protocol==<tag-version>` from PyPI
  - retries for propagation delay, then runs import smoke (`eap.*`)
- add `docs/v1_stabilization_checklist.md` with explicit v1 stabilization gates and upgrade-notes handoff requirements
- update release runbook to reference v1 handoff artifact
- link new v1 checklist doc in README docs index

## Validation
- `python3 -m pre_commit run --files .github/workflows/release.yml docs/release.md docs/v1_stabilization_checklist.md README.md`
- `python3 -m pytest -q`

Refs #17
