### PR TITLE
Release: align version to 0.1.6 + tag/version guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,25 @@ jobs:
             pyproject.toml
             requirements.txt
 
+      - name: Validate tag and package version alignment
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${REF_NAME#v}"
+          PACKAGE_VERSION="$(python - <<'PY'
+          import tomllib
+          with open("pyproject.toml", "rb") as f:
+              data = tomllib.load(f)
+          print(data["project"]["version"])
+          PY
+          )"
+          if [ "${TAG_VERSION}" != "${PACKAGE_VERSION}" ]; then
+            echo "::error title=Version mismatch::Tag ${REF_NAME} does not match pyproject version ${PACKAGE_VERSION}."
+            exit 1
+          fi
+
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > Status: Experimental (pre-1.0). APIs and schema may change.
 > See `STABILITY.md` and `ROADMAP.md` for guarantees and planned milestones.
-> Latest stable release: `v0.1.4`
+> Latest stable release: `v0.1.6`
 
 Efficient Agent Protocol is a local-first framework for multi-step tool workflows.
 It stores large outputs as pointer-backed state (`ptr_*`) and runs dependency-aware DAG steps in parallel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "efficient-agent-protocol"
-version = "0.1.0"
+version = "0.1.6"
 description = "High-performance multi-agent framework for stateful batched execution."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- bump Python package version to `0.1.6`
- add release workflow guard to fail early when tag != pyproject version
- update README latest stable release line to `v0.1.6`

## Why
`v0.1.5` failed smoke install because package metadata was still `0.1.0`.
This change prevents recurrence and prepares a clean next release.
