### PR TITLE
Release: v0.1.7 trusted publishing verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > Status: Experimental (pre-1.0). APIs and schema may change.
 > See `STABILITY.md` and `ROADMAP.md` for guarantees and planned milestones.
-> Latest stable release: `v0.1.6`
+> Latest stable release: `v0.1.7`
 
 Efficient Agent Protocol is a local-first framework for multi-step tool workflows.
 It stores large outputs as pointer-backed state (`ptr_*`) and runs dependency-aware DAG steps in parallel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "efficient-agent-protocol"
-version = "0.1.6"
+version = "0.1.7"
 description = "High-performance multi-agent framework for stateful batched execution."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- bump package version to `0.1.7`
- update README latest release line to `v0.1.7`

## Purpose
Trigger one stable tagged release after removing `PYPI_API_TOKEN` to verify PyPI Trusted Publishing works end-to-end.
