### PR TITLE
EAP-072/073/074: runtime endpoints, OpenClaw plugin adapter, and skill pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,7 @@ python3 -m build
 - `docs/distributed_execution.md`
 - `docs/troubleshooting.md`
 - `docs/eap_proof_sheet.md`
+- `docs/phase7_competitive_openclaw_roadmap.md`
+- `docs/openclaw_interop.md`
+- `integrations/openclaw/eap-runtime-plugin/README.md`
+- `integrations/openclaw/eap-runtime-plugin/skills/README.md`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,11 +39,18 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Checklist: `docs/phase5_recommendation_readiness_checklist.md`
 - Proof sheet: `docs/eap_proof_sheet.md`
 
-## Phase 6: Distribution and V1 Readiness (Next)
+## Phase 6: Distribution and V1 Readiness (In Progress)
 
-- Publish stable package releases to PyPI from tag workflow (configure release secret path).
+- Publish stable package releases to PyPI from tag workflow (Trusted Publishing).
 - Add post-release install smoke validation against published package artifacts.
 - Finalize `v1.0` stabilization checklist and upgrade notes for external adopters.
+
+## Phase 7: Competitive Positioning + OpenClaw Interop (Next)
+
+- Execute OpenClaw integration track (plugin + skills + CI interop lane).
+- Close high-impact competitive gaps: HITL checkpoints, crash-safe resume, MCP interop.
+- Publish updated competitive proof artifacts with reproducible evidence.
+- Checklist: `docs/phase7_competitive_openclaw_roadmap.md`
 
 ## Done
 
@@ -57,3 +64,5 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 4 migration/observability/governance tranche completed (issue #4).
 - Phase 5 recommendation readiness completed (`EAP-064` to `EAP-067`).
 - `v0.1.4` release published with Phase 5 and CodeQL v4 updates.
+- Phase 7 interop foundation started with `EAP-071` (interop matrix), `EAP-072` (runtime HTTP endpoints), and `EAP-073` (OpenClaw plugin adapter MVP).
+- Phase 7 `EAP-074` skill pack added (`run`, `inspect`, `retry failed step`, `export trace`) with 5-minute quickstart.

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,0 +1,134 @@
+# OpenClaw Interop Spike (EAP-071)
+
+Status: Updated through EAP-074 (2026-02-23)  
+Owner: EAP maintainers  
+Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074)
+
+## 1) Version Snapshot
+
+This spike captures compatibility against these versions at analysis time:
+
+- **EAP**: `0.1.7` (`/Users/ct/Desktop/efficient-agent-protocol/pyproject.toml`)
+- **OpenClaw release**: `v2026.2.22` (published 2026-02-23)
+- **OpenClaw docs/repo baseline**: `main` branch on 2026-02-23 (`package.json` currently `2026.2.23`)
+
+Implication:
+- Treat this as a moving-target snapshot for OpenClaw `main`.
+- Pin explicit OpenClaw release versions in CI once EAP-075 starts.
+
+## 2) Interop Surfaces (What We Checked)
+
+OpenClaw-side surfaces:
+- Gateway OpenAI-compatible HTTP endpoint: `POST /v1/chat/completions` (disabled by default).
+- Gateway tools invoke HTTP endpoint: `POST /tools/invoke` (always enabled, policy-gated).
+- Plugin system (TypeScript modules + required `openclaw.plugin.json` manifest).
+- Skills system (`SKILL.md` directories, AgentSkills-compatible, with plugin-shipped skills support).
+
+EAP-side surfaces:
+- OpenAI-compatible provider adapter using `base_url + /v1/chat/completions`.
+- Bearer auth header support.
+- Python plugin system via `importlib.metadata` entry points (`eap.tool_plugins`).
+- EAP runtime HTTP endpoints for `/v1/eap/*` execution/status/pointer summary.
+
+## 3) Compatibility Matrix
+
+| Capability | OpenClaw contract | EAP current state | Compatibility | Notes / EAP action |
+| --- | --- | --- | --- | --- |
+| LLM chat transport | `POST /v1/chat/completions` (OpenAI shape) | `OpenAIProvider` posts to `/v1/chat/completions` | **Compatible now** | Configure `EAP_BASE_URL` to OpenClaw gateway URL; endpoint must be enabled in OpenClaw config. |
+| Gateway auth model | Bearer token, gateway auth mode token/password | EAP OpenAI provider sends `Authorization: Bearer <api_key>` | **Compatible now** | Set `EAP_API_KEY` to gateway token/password value used by OpenClaw auth mode. |
+| OpenClaw agent selection | Preferred: `model: "openclaw:<agentId>"`; optional header `x-openclaw-agent-id` | EAP controls `model`, but does not set custom gateway headers | **Partial** | Use `EAP_MODEL=openclaw:<agentId>`; header-based routing would require EAP provider header extension. |
+| Streaming chat | SSE for OpenAI endpoint when `stream=true` | EAP provider has SSE stream parsing for `data:` + `[DONE]` | **Compatible now** | Verify with real gateway in EAP-075 CI smoke. |
+| OpenResponses API | `POST /v1/responses` (disabled by default) | No EAP provider for Responses API | **Gap** | Optional future adapter (not required for MVP interop). |
+| Tool invocation API | `POST /tools/invoke`, policy + denylist enforced | No EAP client for this endpoint | **Gap** | Add dedicated client only if we need direct OpenClaw tool calls outside agent-turn flow. |
+| Plugin runtime model | TypeScript/JavaScript in-process plugin modules, required `openclaw.plugin.json` | Adapter package added at `integrations/openclaw/eap-runtime-plugin` | **Compatible now (MVP)** | Plugin exports required tools and maps directly to EAP runtime endpoints. |
+| Skills model | AgentSkills-style `SKILL.md`; plugin can ship skills via manifest `skills` field | Skill pack added at `integrations/openclaw/eap-runtime-plugin/skills` | **Compatible now (MVP)** | Includes `run`, `inspect`, `retry failed step`, and `export trace` skill workflows with quickstart docs. |
+| External EAP control plane | OpenClaw plugins/tools can call external HTTP services | EAP runtime service now serves execute/run/pointer summary endpoints | **Compatible now (MVP)** | Bearer auth and JSON error envelopes are implemented and covered by integration tests. |
+
+## 4) Auth Model Mapping
+
+OpenClaw gateway auth (for HTTP endpoints):
+- Bearer token required.
+- Auth source depends on gateway mode:
+  - `gateway.auth.mode="token"` -> token value
+  - `gateway.auth.mode="password"` -> password value
+- Excess failed auth attempts can return `429` with `Retry-After`.
+
+EAP mapping:
+- `EAP_API_KEY` maps directly to the bearer credential.
+- No EAP auth handshake changes are required for `/v1/chat/completions` interop.
+
+## 5) Plugin vs Skill Tradeoff (OpenClaw Integration Strategy)
+
+### Plugin path (recommended for primary integration)
+
+Pros:
+- Can register real tools, HTTP handlers, RPC methods, background services.
+- Best path for deep integration and controlled policy behavior.
+- Can ship skills alongside plugin via manifest `skills` directories.
+
+Cons:
+- Requires Node/TypeScript packaging and OpenClaw plugin manifest/schema discipline.
+- Higher implementation and maintenance cost than skills-only.
+
+### Skill path (recommended as fast follow)
+
+Pros:
+- Fastest user-facing onboarding path.
+- Good for operational commands and guardrailed workflows.
+- Fits existing OpenClaw skill distribution model.
+
+Cons:
+- Skills are instructional/orchestration layer; not a full replacement for plugin-level runtime hooks.
+- Less suited for deep protocol bridging without backing plugin/tool endpoints.
+
+Recommended sequence:
+1. Build minimal EAP HTTP runtime endpoints (EAP-072).
+2. Build OpenClaw plugin adapter against those endpoints (EAP-073).
+3. Ship OpenClaw skills that call the plugin/tooling path for common operations (EAP-074).
+
+## 6) Known Limits / Risks Identified
+
+1. **Agent routing header not configurable in EAP provider**
+   - OpenClaw supports `x-openclaw-agent-id`; EAP currently cannot set custom headers in `OpenAIProvider`.
+2. **OpenClaw endpoint toggles**
+   - `/v1/chat/completions` is disabled by default; operators must enable it.
+3. **Plugin model mismatch**
+   - OpenClaw plugin system is TypeScript + manifest; EAP plugin system is Python entry points.
+   - This is expected and should be handled via adapter package, not by forcing one model into the other.
+
+## 7) Exit Criteria Check (EAP-071)
+
+- [x] Compatibility matrix produced.
+- [x] Auth model mapping documented.
+- [x] Plugin vs skill tradeoffs documented.
+- [x] Known limits captured with concrete next actions.
+
+## 8) Recommended Next Item
+
+`EAP-074` has now been implemented in-repo with:
+- OpenClaw plugin adapter package at `integrations/openclaw/eap-runtime-plugin`
+- required plugin tools:
+  - `run_eap_workflow`
+  - `get_eap_run_status`
+  - `get_eap_pointer_summary`
+- plugin manifest (`openclaw.plugin.json`) and local verification guide (`README.md`)
+- bundled OpenClaw skill pack:
+  - `eap_run_workflow`
+  - `eap_inspect_run`
+  - `eap_retry_failed_step`
+  - `eap_export_trace`
+- 5-minute skill quickstart at `integrations/openclaw/eap-runtime-plugin/skills/README.md`
+
+Proceed to **EAP-075**:
+- Add an interop CI lane that validates plugin + skills against pinned OpenClaw versions.
+
+## References (Primary Sources)
+
+- OpenClaw release: [github.com/openclaw/openclaw/releases/tag/v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)
+- OpenClaw plugin system: [docs/tools/plugin.md](https://raw.githubusercontent.com/openclaw/openclaw/main/docs/tools/plugin.md)
+- OpenClaw plugin manifest: [docs/plugins/manifest.md](https://raw.githubusercontent.com/openclaw/openclaw/main/docs/plugins/manifest.md)
+- OpenClaw plugin agent tools: [docs/plugins/agent-tools.md](https://raw.githubusercontent.com/openclaw/openclaw/main/docs/plugins/agent-tools.md)
+- OpenClaw skills: [docs/tools/skills.md](https://raw.githubusercontent.com/openclaw/openclaw/main/docs/tools/skills.md)
+- OpenClaw OpenAI HTTP API: [docs/gateway/openai-http-api.md](https://raw.githubusercontent.com/openclaw/openclaw/main/docs/gateway/openai-http-api.md)
+- OpenClaw tools invoke API: [docs/gateway/tools-invoke-http-api.md](https://raw.githubusercontent.com/openclaw/openclaw/main/docs/gateway/tools-invoke-http-api.md)
+- OpenClaw security baseline: [docs/gateway/security/index.md](https://raw.githubusercontent.com/openclaw/openclaw/main/docs/gateway/security/index.md)

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -1,0 +1,126 @@
+# Phase 7 Competitive Roadmap (OpenClaw + Market Positioning)
+
+Status: Planned (2026-02-23)
+
+Current status:
+- [x] `EAP-071` interop spike + compatibility matrix published (`docs/openclaw_interop.md`)
+- [x] `EAP-072` minimal EAP runtime HTTP endpoints + auth hooks + integration tests
+- [x] `EAP-073` OpenClaw plugin adapter MVP (`integrations/openclaw/eap-runtime-plugin`)
+- [x] `EAP-074` OpenClaw skill pack (`integrations/openclaw/eap-runtime-plugin/skills`)
+- [ ] `EAP-075` onward
+
+## Objective
+
+Make EAP easier to adopt and harder to replace by:
+
+1. Integrating cleanly with OpenClaw workflows.
+2. Closing high-impact capability gaps seen in top orchestration stacks.
+3. Doubling down on EAP's differentiator: deterministic, observable, pointer-backed execution.
+
+## Research Snapshot (2026-02-23)
+
+- LangGraph positions around durable execution, agent workflows, and production controls.
+- AutoGen positions around multi-agent orchestration and framework-level flexibility.
+- CrewAI positions around teams/flows for production workflows.
+- PydanticAI emphasizes typed outputs and provider abstraction.
+- OpenClaw exposes a plugin/skills model and secured API surface (`/v1/*`) with auth controls.
+
+External reference points (snapshot links):
+- LangGraph: https://github.com/langchain-ai/langgraph
+- AutoGen: https://github.com/microsoft/autogen
+- CrewAI: https://github.com/crewAIInc/crewAI
+- PydanticAI: https://github.com/pydantic/pydantic-ai
+- OpenClaw repo: https://github.com/openclaw/openclaw
+- OpenClaw skills docs: https://docs.openclaw.ai/skills
+- OpenClaw plugin docs: https://docs.openclaw.ai/tools/plugin
+- OpenClaw security docs: https://docs.openclaw.ai/security
+
+Implication:
+- EAP should not try to out-market full platform suites immediately.
+- EAP should become the "reliability engine" that can run standalone or plug into OpenClaw.
+
+## OpenClaw Fit Assessment
+
+Strong fit, with two practical integration surfaces:
+
+1. Plugin path (recommended first):
+   - Build an OpenClaw plugin that exposes EAP workflow operations as OpenClaw tools.
+2. Skill path:
+   - Ship OpenClaw skills that run curated EAP commands/workflows for common tasks.
+
+Optional validation track:
+- Verify whether OpenClaw's `/v1/*` surface can be consumed directly by EAP provider adapters without compatibility shims.
+
+## Ordered Checklist
+
+## Tranche 1: OpenClaw Interop Foundation
+
+1. `EAP-071` OpenClaw interoperability spike and compatibility matrix
+   - Deliverable: `docs/openclaw_interop.md`
+   - Include: supported versions, auth model, plugin vs skill tradeoffs, known limits
+   - Done when: matrix is reproducible and reviewed
+
+2. `EAP-072` EAP HTTP runtime endpoints for external orchestrators
+   - Deliverable: minimal API endpoints to run workflow, inspect run status, fetch pointer payload metadata
+   - Include: request/response schemas and auth hooks
+   - Done when: integration tests pass for happy path + auth failure + invalid payload
+
+3. `EAP-073` OpenClaw plugin adapter (MVP)
+   - Deliverable: plugin exposing at least:
+     - `run_eap_workflow`
+     - `get_eap_run_status`
+     - `get_eap_pointer_summary`
+   - Done when: OpenClaw can invoke all three operations end-to-end in local env
+
+4. `EAP-074` OpenClaw skill pack for common EAP operations
+   - Deliverable: skills for "run", "inspect", "retry failed step", and "export trace"
+   - Done when: skills are installable and documented with a 5-minute quickstart
+
+5. `EAP-075` Interop CI lane
+   - Deliverable: CI workflow that runs smoke interop tests against pinned OpenClaw versions
+   - Done when: branch protection includes this job
+
+## Tranche 2: Competitive Capability Upgrades
+
+6. `EAP-076` Human approval checkpoints (HITL)
+   - Add optional step-level pause/approve/reject semantics
+   - Done when: execution trace captures approval transitions and rejection reasons
+
+7. `EAP-077` Crash-safe resume and replay
+   - Add resumable macro runs from persisted checkpoints
+   - Done when: forced process termination can recover and continue without corrupting state
+
+8. `EAP-078` MCP interoperability
+   - Add MCP server export for selected EAP tools or a client bridge for MCP tools
+   - Done when: at least one reference MCP tool can be executed via EAP runtime
+
+9. `EAP-079` Evaluation harness and scorecard
+   - Deliverable: repeatable eval suite (reliability + correctness + latency)
+   - Done when: CI publishes trend artifacts and fails on regression thresholds
+
+## Tranche 3: Differentiation and Adoption
+
+10. `EAP-080` Vertical starter packs
+    - Deliverable: opinionated templates (research assistant, doc ops, local ETL)
+    - Done when: each template has green smoke tests and runnable walkthrough docs
+
+11. `EAP-081` Operator telemetry pack
+    - Deliverable: first-party dashboards/charts for retries, saturation, fail reasons, and step latency percentiles
+    - Done when: maintainer can diagnose a failed run from telemetry alone
+
+12. `EAP-082` "Why EAP now" competitive page refresh
+    - Deliverable: refresh `docs/eap_proof_sheet.md` with new interop and eval evidence
+    - Done when: proof sheet includes side-by-side capability table + reproducible commands
+
+## Guardrails
+
+- Do not chase every platform feature from larger ecosystems.
+- Prioritize reliability, debuggability, and local-first portability.
+- Treat OpenClaw integration as a force multiplier, not a rewrite target.
+
+## Success Criteria
+
+- OpenClaw plugin + skill pack both work in local reference setup.
+- New interop lane is required in CI.
+- EAP can recover interrupted runs deterministically.
+- External users can onboard via a starter pack in under 10 minutes.

--- a/eap/runtime/__init__.py
+++ b/eap/runtime/__init__.py
@@ -1,0 +1,3 @@
+from .http_api import EAPRuntimeHTTPServer
+
+__all__ = ["EAPRuntimeHTTPServer"]

--- a/eap/runtime/http_api.py
+++ b/eap/runtime/http_api.py
@@ -1,0 +1,296 @@
+import asyncio
+import json
+import threading
+import uuid
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Optional
+from urllib.parse import unquote, urlparse
+
+from pydantic import ValidationError
+
+from eap.environment import AsyncLocalExecutor
+from eap.protocol import BatchedMacroRequest, StateManager
+
+
+def _timestamp_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _request_id() -> str:
+    return f"req_{uuid.uuid4().hex[:12]}"
+
+
+class _RuntimeRequestHandler(BaseHTTPRequestHandler):
+    server: "_RuntimeHTTPServer"
+
+    def do_POST(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path == "/v1/eap/macro/execute":
+            self._handle_execute_macro()
+            return
+        self._send_error(404, "not_found", f"Path '{parsed.path}' is not registered.")
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path.startswith("/v1/eap/runs/"):
+            run_id = unquote(parsed.path[len("/v1/eap/runs/") :]).strip()
+            self._handle_get_run(run_id=run_id)
+            return
+        if parsed.path.startswith("/v1/eap/pointers/") and parsed.path.endswith("/summary"):
+            pointer_id = unquote(parsed.path[len("/v1/eap/pointers/") : -len("/summary")]).strip()
+            self._handle_get_pointer_summary(pointer_id=pointer_id)
+            return
+        self._send_error(404, "not_found", f"Path '{parsed.path}' is not registered.")
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+        # Keep test/runtime output quiet unless callers choose to add logging.
+        return
+
+    def _require_auth(self) -> bool:
+        required = self.server.required_bearer_token
+        if not required:
+            return True
+
+        auth_header = (self.headers.get("Authorization") or "").strip()
+        if not auth_header.startswith("Bearer "):
+            self._send_error(401, "unauthorized", "Missing or invalid bearer token.")
+            return False
+
+        token = auth_header[len("Bearer ") :].strip()
+        if token != required:
+            self._send_error(401, "unauthorized", "Missing or invalid bearer token.")
+            return False
+        return True
+
+    def _read_json_body(self) -> Optional[Dict[str, Any]]:
+        content_length_header = self.headers.get("Content-Length")
+        if not content_length_header:
+            self._send_error(400, "validation_error", "Request body is required.")
+            return None
+        try:
+            content_length = int(content_length_header)
+        except ValueError:
+            self._send_error(400, "validation_error", "Invalid Content-Length header.")
+            return None
+        if content_length <= 0:
+            self._send_error(400, "validation_error", "Request body is required.")
+            return None
+
+        raw_body = self.rfile.read(content_length)
+        try:
+            payload = json.loads(raw_body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            self._send_error(400, "validation_error", "Request body must be valid JSON.")
+            return None
+
+        if not isinstance(payload, dict):
+            self._send_error(400, "validation_error", "Request body must be a JSON object.")
+            return None
+        return payload
+
+    def _handle_execute_macro(self) -> None:
+        if not self._require_auth():
+            return
+
+        payload = self._read_json_body()
+        if payload is None:
+            return
+
+        macro_payload = payload.get("macro")
+        if macro_payload is None:
+            self._send_error(400, "validation_error", "Field 'macro' is required.")
+            return
+
+        try:
+            macro = BatchedMacroRequest.model_validate(macro_payload)
+        except ValidationError as exc:
+            self._send_error(
+                400,
+                "validation_error",
+                "Invalid macro payload.",
+                details={"errors": exc.errors()},
+            )
+            return
+
+        try:
+            result = asyncio.run(self.server.executor.execute_macro(macro))
+        except Exception as exc:  # pragma: no cover - defensive safeguard
+            self._send_error(
+                500,
+                "execution_error",
+                f"Macro execution failed: {str(exc)}",
+            )
+            return
+
+        if not result or "pointer_id" not in result:
+            self._send_error(
+                500,
+                "execution_error",
+                "Macro execution did not return a pointer response.",
+            )
+            return
+
+        response_payload = {
+            "request_id": _request_id(),
+            "timestamp_utc": _timestamp_utc(),
+            "pointer_id": result["pointer_id"],
+            "summary": result.get("summary", ""),
+            "metadata": result.get("metadata"),
+        }
+        self._send_json(200, response_payload)
+
+    def _handle_get_run(self, run_id: str) -> None:
+        if not self._require_auth():
+            return
+        if not run_id:
+            self._send_error(400, "validation_error", "run_id is required.")
+            return
+
+        try:
+            summary = self.server.state_manager.get_execution_summary(run_id)
+        except KeyError:
+            self._send_error(404, "not_found", f"Execution summary for run '{run_id}' not found.")
+            return
+
+        trace_events = [
+            event.model_dump(mode="json")
+            for event in self.server.state_manager.list_trace_events(run_id)
+        ]
+        status = "failed" if summary.get("failed_steps", 0) > 0 else "succeeded"
+
+        response_payload = {
+            "request_id": _request_id(),
+            "timestamp_utc": _timestamp_utc(),
+            "run_id": run_id,
+            "status": status,
+            "summary": summary,
+            "trace_event_count": len(trace_events),
+            "trace_events": trace_events,
+        }
+        self._send_json(200, response_payload)
+
+    def _handle_get_pointer_summary(self, pointer_id: str) -> None:
+        if not self._require_auth():
+            return
+        if not pointer_id:
+            self._send_error(400, "validation_error", "pointer_id is required.")
+            return
+
+        pointer = next(
+            (
+                item
+                for item in self.server.state_manager.list_pointers(include_expired=True)
+                if item.get("pointer_id") == pointer_id
+            ),
+            None,
+        )
+        if pointer is None:
+            self._send_error(404, "not_found", f"Pointer '{pointer_id}' not found.")
+            return
+
+        response_payload = {
+            "request_id": _request_id(),
+            "timestamp_utc": _timestamp_utc(),
+            "pointer": {
+                "pointer_id": pointer["pointer_id"],
+                "summary": pointer.get("summary"),
+                "metadata": pointer.get("metadata"),
+                "created_at_utc": pointer.get("created_at_utc"),
+                "ttl_seconds": pointer.get("ttl_seconds"),
+                "expires_at_utc": pointer.get("expires_at_utc"),
+                "is_expired": pointer.get("is_expired", False),
+            },
+        }
+        self._send_json(200, response_payload)
+
+    def _send_json(self, status_code: int, payload: Dict[str, Any]) -> None:
+        encoded = json.dumps(payload, sort_keys=True).encode("utf-8")
+        self.send_response(status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def _send_error(
+        self,
+        status_code: int,
+        error_type: str,
+        message: str,
+        details: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        payload: Dict[str, Any] = {
+            "error_type": error_type,
+            "message": message,
+        }
+        if details is not None:
+            payload["details"] = details
+        self._send_json(status_code, payload)
+
+
+class _RuntimeHTTPServer(ThreadingHTTPServer):
+    def __init__(
+        self,
+        server_address,
+        RequestHandlerClass,  # noqa: N803
+        executor: AsyncLocalExecutor,
+        state_manager: StateManager,
+        required_bearer_token: Optional[str],
+    ):
+        super().__init__(server_address, RequestHandlerClass)
+        self.executor = executor
+        self.state_manager = state_manager
+        self.required_bearer_token = required_bearer_token
+
+
+class EAPRuntimeHTTPServer:
+    """Minimal HTTP runtime endpoints for external orchestrator integration."""
+
+    def __init__(
+        self,
+        executor: AsyncLocalExecutor,
+        state_manager: StateManager,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        required_bearer_token: Optional[str] = None,
+    ):
+        self._host = host
+        self._httpd = _RuntimeHTTPServer(
+            (host, port),
+            _RuntimeRequestHandler,
+            executor=executor,
+            state_manager=state_manager,
+            required_bearer_token=required_bearer_token,
+        )
+        self._thread: Optional[threading.Thread] = None
+
+    @property
+    def host(self) -> str:
+        return self._host
+
+    @property
+    def port(self) -> int:
+        return int(self._httpd.server_address[1])
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def start(self) -> "EAPRuntimeHTTPServer":
+        if self._thread and self._thread.is_alive():
+            return self
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5)
+
+    def __enter__(self) -> "EAPRuntimeHTTPServer":
+        return self.start()
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()

--- a/integrations/openclaw/eap-runtime-plugin/README.md
+++ b/integrations/openclaw/eap-runtime-plugin/README.md
@@ -1,0 +1,68 @@
+# OpenClaw EAP Runtime Plugin (EAP-073)
+
+This plugin exposes EAP runtime HTTP operations as OpenClaw tools:
+
+- `run_eap_workflow`
+- `get_eap_run_status`
+- `get_eap_pointer_summary`
+
+It also ships an OpenClaw skill pack for common operations:
+
+- `eap_run_workflow`
+- `eap_inspect_run`
+- `eap_retry_failed_step`
+- `eap_export_trace`
+
+## Requirements
+
+- OpenClaw with plugin support enabled
+- EAP runtime HTTP server reachable (EAP-072 endpoints)
+- Node.js 18+
+
+## Tool Mapping
+
+- `run_eap_workflow` -> `POST /v1/eap/macro/execute`
+- `get_eap_run_status` -> `GET /v1/eap/runs/{run_id}`
+- `get_eap_pointer_summary` -> `GET /v1/eap/pointers/{pointer_id}/summary`
+
+## Plugin Config
+
+`openclaw.plugin.json` defines:
+
+- `baseUrl` (required): EAP runtime base URL
+- `apiKey` (optional): bearer token if EAP runtime requires auth
+- `timeoutMs` (optional): request timeout in milliseconds (default `15000`)
+
+You can also override with environment variables:
+
+- `EAP_RUNTIME_BASE_URL`
+- `EAP_RUNTIME_API_KEY`
+- `EAP_RUNTIME_TIMEOUT_MS`
+
+## Local Verification
+
+1. Start EAP runtime server in your local setup.
+2. Install plugin dependencies:
+
+```bash
+cd integrations/openclaw/eap-runtime-plugin
+npm install
+```
+
+3. Run plugin unit tests:
+
+```bash
+npm test
+```
+
+4. Register plugin in OpenClaw and allow these tools:
+   - `run_eap_workflow`
+   - `get_eap_run_status`
+   - `get_eap_pointer_summary`
+5. Enable the bundled skills from `./skills/`.
+6. Invoke `run_eap_workflow` with a valid EAP macro payload.
+7. Use returned `metadata.execution_run_id` with `get_eap_run_status`.
+8. Use returned `pointer_id` with `get_eap_pointer_summary`.
+
+Successful completion of steps 6-8 is the EAP-073 acceptance check.
+For EAP-074 skill-pack acceptance, run the flow in `skills/README.md`.

--- a/integrations/openclaw/eap-runtime-plugin/index.js
+++ b/integrations/openclaw/eap-runtime-plugin/index.js
@@ -1,0 +1,256 @@
+const DEFAULT_TIMEOUT_MS = 15_000;
+const PLUGIN_ID = "eap-runtime";
+
+/**
+ * @typedef {{ baseUrl: string, apiKey?: string, timeoutMs?: number }} EAPRuntimeConfig
+ */
+
+/**
+ * @typedef {{
+ *   registerTool: (name: string, spec: Record<string, unknown>, handler: (args: Record<string, unknown>) => Promise<Record<string, unknown>>) => void,
+ *   config?: Record<string, unknown>,
+ *   plugin?: { config?: Record<string, unknown> },
+ * }} OpenClawPluginAPI
+ */
+
+function parseTimeout(value) {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_TIMEOUT_MS;
+}
+
+export function normalizeBaseUrl(baseUrl) {
+  return String(baseUrl || "").trim().replace(/\/+$/, "");
+}
+
+function readConfigObject(api) {
+  if (api?.plugin && typeof api.plugin === "object" && api.plugin.config) {
+    return api.plugin.config;
+  }
+  const entries = api?.config?.plugins?.entries;
+  if (entries && typeof entries === "object") {
+    const pluginEntry = entries[PLUGIN_ID];
+    if (pluginEntry && typeof pluginEntry === "object" && pluginEntry.config) {
+      return pluginEntry.config;
+    }
+  }
+  return {};
+}
+
+export function resolvePluginConfig(api) {
+  const pluginConfig = readConfigObject(api);
+  const env = typeof process === "object" ? process.env : {};
+
+  const baseUrl = normalizeBaseUrl(env?.EAP_RUNTIME_BASE_URL ?? pluginConfig.baseUrl);
+  const apiKey = env?.EAP_RUNTIME_API_KEY ?? pluginConfig.apiKey;
+  const timeoutMs = parseTimeout(env?.EAP_RUNTIME_TIMEOUT_MS ?? pluginConfig.timeoutMs);
+
+  if (!baseUrl) {
+    throw new Error("EAP runtime plugin requires `baseUrl` configuration.");
+  }
+
+  return {
+    baseUrl,
+    apiKey: apiKey ? String(apiKey) : undefined,
+    timeoutMs,
+  };
+}
+
+function makeAuthHeaders(apiKey) {
+  /** @type {Record<string, string>} */
+  const headers = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  return headers;
+}
+
+async function parseResponseBody(response) {
+  const raw = await response.text();
+  if (!raw) {
+    return {};
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return { message: raw };
+  }
+}
+
+async function requestJson(fetchImpl, config, method, path, body, timeoutMsOverride) {
+  const timeoutMs = parseTimeout(timeoutMsOverride ?? config.timeoutMs);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(`${config.baseUrl}${path}`, {
+      method,
+      headers: makeAuthHeaders(config.apiKey),
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const parsedBody = await parseResponseBody(response);
+    if (!response.ok) {
+      const message =
+        (parsedBody && typeof parsedBody.message === "string" && parsedBody.message) ||
+        `EAP runtime request failed (${response.status}).`;
+      const error = new Error(message);
+      error.statusCode = response.status;
+      error.payload = parsedBody;
+      throw error;
+    }
+    return parsedBody;
+  } catch (error) {
+    if (error && typeof error === "object" && error.name === "AbortError") {
+      throw new Error(`EAP runtime request timed out after ${timeoutMs}ms.`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function createEAPRuntimeClient(config, fetchImpl = fetch) {
+  return {
+    async runEapWorkflow(macro, timeoutMs) {
+      return requestJson(
+        fetchImpl,
+        config,
+        "POST",
+        "/v1/eap/macro/execute",
+        { macro },
+        timeoutMs,
+      );
+    },
+    async getEapRunStatus(runId, timeoutMs) {
+      return requestJson(
+        fetchImpl,
+        config,
+        "GET",
+        `/v1/eap/runs/${encodeURIComponent(String(runId))}`,
+        undefined,
+        timeoutMs,
+      );
+    },
+    async getEapPointerSummary(pointerId, timeoutMs) {
+      return requestJson(
+        fetchImpl,
+        config,
+        "GET",
+        `/v1/eap/pointers/${encodeURIComponent(String(pointerId))}/summary`,
+        undefined,
+        timeoutMs,
+      );
+    },
+  };
+}
+
+function asToolResult(payload) {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+export default function activate(api) {
+  const config = resolvePluginConfig(api);
+  const client = createEAPRuntimeClient(config);
+
+  api.registerTool(
+    "run_eap_workflow",
+    {
+      description: "Execute an EAP BatchedMacroRequest and return pointer metadata.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          macro: {
+            type: "object",
+            description: "BatchedMacroRequest payload accepted by /v1/eap/macro/execute.",
+          },
+          requestTimeoutMs: {
+            type: "integer",
+            minimum: 1000,
+            maximum: 120000,
+            description: "Optional request timeout override.",
+          },
+        },
+        required: ["macro"],
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: "object",
+      },
+    },
+    async (args) => {
+      const result = await client.runEapWorkflow(args.macro, args.requestTimeoutMs);
+      return asToolResult(result);
+    },
+  );
+
+  api.registerTool(
+    "get_eap_run_status",
+    {
+      description: "Fetch run summary and trace events for a specific execution run.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          run_id: { type: "string", minLength: 1 },
+          requestTimeoutMs: {
+            type: "integer",
+            minimum: 1000,
+            maximum: 120000,
+          },
+        },
+        required: ["run_id"],
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: "object",
+      },
+    },
+    async (args) => {
+      const result = await client.getEapRunStatus(args.run_id, args.requestTimeoutMs);
+      return asToolResult(result);
+    },
+  );
+
+  api.registerTool(
+    "get_eap_pointer_summary",
+    {
+      description: "Fetch EAP pointer summary metadata without downloading pointer payload.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          pointer_id: { type: "string", minLength: 1 },
+          requestTimeoutMs: {
+            type: "integer",
+            minimum: 1000,
+            maximum: 120000,
+          },
+        },
+        required: ["pointer_id"],
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: "object",
+      },
+    },
+    async (args) => {
+      const result = await client.getEapPointerSummary(args.pointer_id, args.requestTimeoutMs);
+      return asToolResult(result);
+    },
+  );
+}

--- a/integrations/openclaw/eap-runtime-plugin/openclaw.plugin.json
+++ b/integrations/openclaw/eap-runtime-plugin/openclaw.plugin.json
@@ -1,0 +1,44 @@
+{
+  "id": "eap-runtime",
+  "name": "EAP Runtime Adapter",
+  "version": "0.1.0",
+  "description": "Expose EAP runtime workflow execution and inspection endpoints as OpenClaw tools.",
+  "entry": "./index.js",
+  "main": "./index.js",
+  "skills": [
+    "./skills/eap_run_workflow",
+    "./skills/eap_inspect_run",
+    "./skills/eap_retry_failed_step",
+    "./skills/eap_export_trace"
+  ],
+  "category": "integration",
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "baseUrl": {
+        "type": "string",
+        "format": "uri",
+        "description": "Base URL for the EAP runtime API (for example http://127.0.0.1:8080)."
+      },
+      "apiKey": {
+        "type": "string",
+        "description": "Bearer token used by the EAP runtime API."
+      },
+      "timeoutMs": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 120000,
+        "default": 15000,
+        "description": "HTTP timeout per request in milliseconds."
+      }
+    },
+    "required": [
+      "baseUrl"
+    ]
+  },
+  "uiHints": {
+    "sensitive": [
+      "apiKey"
+    ]
+  }
+}

--- a/integrations/openclaw/eap-runtime-plugin/package.json
+++ b/integrations/openclaw/eap-runtime-plugin/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@eap/openclaw-runtime-plugin",
+  "version": "0.1.0",
+  "description": "OpenClaw plugin adapter for EAP runtime HTTP endpoints",
+  "type": "module",
+  "private": true,
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  },
+  "scripts": {
+    "test": "node --test ./test/*.test.js"
+  }
+}

--- a/integrations/openclaw/eap-runtime-plugin/skills/README.md
+++ b/integrations/openclaw/eap-runtime-plugin/skills/README.md
@@ -1,0 +1,28 @@
+# OpenClaw Skill Pack (EAP-074)
+
+This skill pack is shipped with the EAP OpenClaw plugin and covers common runtime operations:
+
+- `eap_run_workflow`
+- `eap_inspect_run`
+- `eap_retry_failed_step`
+- `eap_export_trace`
+
+## 5-Minute Quickstart
+
+1. Ensure plugin config points to a live EAP runtime (`baseUrl`, optional `apiKey`).
+2. Allow plugin tools:
+   - `run_eap_workflow`
+   - `get_eap_run_status`
+   - `get_eap_pointer_summary`
+3. Enable all four skills from `integrations/openclaw/eap-runtime-plugin/skills/`.
+4. Execute a macro using the `eap_run_workflow` skill.
+5. Inspect with `eap_inspect_run`.
+6. If failed steps exist, use `eap_retry_failed_step`.
+7. Generate a shareable report with `eap_export_trace`.
+
+## Files
+
+- `skills/eap_run_workflow/SKILL.md`
+- `skills/eap_inspect_run/SKILL.md`
+- `skills/eap_retry_failed_step/SKILL.md`
+- `skills/eap_export_trace/SKILL.md`

--- a/integrations/openclaw/eap-runtime-plugin/skills/eap_export_trace/SKILL.md
+++ b/integrations/openclaw/eap-runtime-plugin/skills/eap_export_trace/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: eap_export_trace
+description: Export a concise diagnostic trace report for a run, optionally enriched with pointer summary metadata.
+---
+
+# EAP Export Trace
+
+Use this skill when you need a shareable failure/success report for debugging or incident review.
+
+## Required Tools
+
+- `get_eap_run_status`
+- `get_eap_pointer_summary` (optional if `pointer_id` is provided)
+
+## Inputs
+
+- `run_id` (string)
+- `pointer_id` (optional string)
+- `requestTimeoutMs` (optional integer)
+
+## Procedure
+
+1. Call `get_eap_run_status` using `run_id`.
+2. Build a report with:
+   - run status and totals
+   - trace event count
+   - a compact event timeline (`event_type`, `step_id`, `timestamp_utc` if present)
+3. If `pointer_id` is provided, call `get_eap_pointer_summary` and append pointer lifecycle metadata.
+4. Return report as Markdown fenced block for easy copy/paste into issues.
+
+## Output Contract
+
+Return:
+
+- `run_id`
+- `status`
+- `trace_event_count`
+- `report_markdown`

--- a/integrations/openclaw/eap-runtime-plugin/skills/eap_inspect_run/SKILL.md
+++ b/integrations/openclaw/eap-runtime-plugin/skills/eap_inspect_run/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: eap_inspect_run
+description: Inspect execution state for an EAP run and summarize pass/fail outcomes with trace counts.
+---
+
+# EAP Inspect Run
+
+Use this skill to check run health, completion status, and trace detail after execution starts.
+
+## Required Tool
+
+- `get_eap_run_status`
+
+## Inputs
+
+- `run_id` (string)
+- `requestTimeoutMs` (optional integer)
+
+## Procedure
+
+1. Call `get_eap_run_status` for `run_id`.
+2. Extract:
+   - `status`
+   - `summary.total_steps`
+   - `summary.succeeded_steps`
+   - `summary.failed_steps`
+   - `trace_event_count`
+3. If `failed_steps > 0`, recommend `eap_retry_failed_step`.
+4. If no failures, report run as healthy.
+
+## Output Contract
+
+Return:
+
+- `run_id`
+- `status`
+- `totals`: `{ total_steps, succeeded_steps, failed_steps }`
+- `trace_event_count`
+- `next_recommended_skill` (`eap_retry_failed_step` or `none`)

--- a/integrations/openclaw/eap-runtime-plugin/skills/eap_retry_failed_step/SKILL.md
+++ b/integrations/openclaw/eap-runtime-plugin/skills/eap_retry_failed_step/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: eap_retry_failed_step
+description: Retry failed macro steps by re-running a reduced macro built from failed step trace data.
+---
+
+# EAP Retry Failed Step
+
+Use this skill when an EAP run has one or more failed steps.
+
+## Required Tools
+
+- `get_eap_run_status`
+- `run_eap_workflow`
+
+## Inputs
+
+- `run_id` (string)
+- `requestTimeoutMs` (optional integer)
+
+## Procedure
+
+1. Call `get_eap_run_status` for `run_id`.
+2. Validate `summary.failed_steps > 0`. If not, stop and report "no failed steps to retry."
+3. Inspect `trace_events` and collect failed step call details:
+   - `step_id`
+   - `tool_name`
+   - `arguments`
+4. Build a retry macro:
+   - `steps`: failed steps only
+   - preserve each failed step `step_id`, `tool_name`, and `arguments`
+5. Call `run_eap_workflow` with this retry macro.
+6. Return retry identifiers and a comparison of old vs new failed counts.
+
+## Safety Rules
+
+- Do not invent missing arguments.
+- If failed step arguments are unavailable in trace, stop and return a manual-retry warning.
+- Keep retry macro scoped only to failed steps.
+
+## Output Contract
+
+Return:
+
+- `original_run_id`
+- `retry_run_id`
+- `retry_pointer_id`
+- `retry_summary`
+- `notes` (including any manual-retry requirement)

--- a/integrations/openclaw/eap-runtime-plugin/skills/eap_run_workflow/SKILL.md
+++ b/integrations/openclaw/eap-runtime-plugin/skills/eap_run_workflow/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: eap_run_workflow
+description: Execute an EAP macro and capture run and pointer identifiers for follow-up operations.
+---
+
+# EAP Run Workflow
+
+Use this skill when you already have a valid EAP `macro` payload and need to start execution.
+
+## Required Tool
+
+- `run_eap_workflow`
+
+## Inputs
+
+- `macro` (object): valid EAP `BatchedMacroRequest`
+- `requestTimeoutMs` (optional integer)
+
+## Procedure
+
+1. Call `run_eap_workflow` with the supplied `macro`.
+2. Parse and return:
+   - `pointer_id`
+   - `metadata.execution_run_id` as `run_id`
+   - `summary`
+3. If the response is an error, include the upstream `error_type`/`message` and stop.
+
+## Output Contract
+
+Return a short structured summary:
+
+- `run_id`
+- `pointer_id`
+- `summary`
+- `next_recommended_skill`: `eap_inspect_run`

--- a/integrations/openclaw/eap-runtime-plugin/test/client.test.js
+++ b/integrations/openclaw/eap-runtime-plugin/test/client.test.js
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createEAPRuntimeClient, normalizeBaseUrl } from "../index.js";
+
+test("normalizeBaseUrl strips trailing slashes", () => {
+  assert.equal(normalizeBaseUrl("http://127.0.0.1:8080///"), "http://127.0.0.1:8080");
+});
+
+test("runEapWorkflow posts macro payload with auth header", async () => {
+  const calls = [];
+  const fetchStub = async (url, options) => {
+    calls.push({ url, options });
+    return new Response(
+      JSON.stringify({ request_id: "req_1", pointer_id: "ptr_1", summary: "ok" }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+  const client = createEAPRuntimeClient(
+    { baseUrl: "http://localhost:9000", apiKey: "secret", timeoutMs: 5000 },
+    fetchStub,
+  );
+  const macro = { steps: [{ step_id: "s1", tool_name: "echo", arguments: {} }] };
+  const response = await client.runEapWorkflow(macro);
+
+  assert.equal(response.pointer_id, "ptr_1");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "http://localhost:9000/v1/eap/macro/execute");
+  assert.equal(calls[0].options.method, "POST");
+  assert.equal(calls[0].options.headers.Authorization, "Bearer secret");
+  assert.deepEqual(JSON.parse(calls[0].options.body), { macro });
+});
+
+test("getEapRunStatus and getEapPointerSummary use expected GET paths", async () => {
+  const calledUrls = [];
+  const fetchStub = async (url) => {
+    calledUrls.push(url);
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+  const client = createEAPRuntimeClient({ baseUrl: "http://localhost:9000" }, fetchStub);
+
+  await client.getEapRunStatus("run_123");
+  await client.getEapPointerSummary("ptr_abc");
+
+  assert.deepEqual(calledUrls, [
+    "http://localhost:9000/v1/eap/runs/run_123",
+    "http://localhost:9000/v1/eap/pointers/ptr_abc/summary",
+  ]);
+});
+
+test("request errors include upstream message", async () => {
+  const fetchStub = async () =>
+    new Response(JSON.stringify({ error_type: "not_found", message: "missing run" }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    });
+  const client = createEAPRuntimeClient({ baseUrl: "http://localhost:9000" }, fetchStub);
+
+  await assert.rejects(
+    async () => client.getEapRunStatus("run_missing"),
+    (error) => error instanceof Error && error.message === "missing run",
+  );
+});

--- a/tests/contract/test_openclaw_skill_pack.py
+++ b/tests/contract/test_openclaw_skill_pack.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "integrations" / "openclaw" / "eap-runtime-plugin"
+MANIFEST_PATH = PLUGIN_DIR / "openclaw.plugin.json"
+SKILL_ROOT = PLUGIN_DIR / "skills"
+EXPECTED_SKILLS = (
+    "eap_run_workflow",
+    "eap_inspect_run",
+    "eap_retry_failed_step",
+    "eap_export_trace",
+)
+
+
+def test_openclaw_manifest_declares_skill_directories() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    assert "skills" in manifest
+    manifest_skills = tuple(manifest["skills"])
+    expected_paths = tuple(f"./skills/{name}" for name in EXPECTED_SKILLS)
+    assert manifest_skills == expected_paths
+
+
+def test_skill_pack_contains_expected_skill_files() -> None:
+    for skill_name in EXPECTED_SKILLS:
+        skill_file = SKILL_ROOT / skill_name / "SKILL.md"
+        assert skill_file.exists(), f"missing skill file: {skill_file}"
+        content = skill_file.read_text(encoding="utf-8")
+        assert content.startswith("---\n"), f"missing frontmatter in {skill_file}"
+        assert f"name: {skill_name}" in content, f"missing name frontmatter in {skill_file}"
+        assert "description:" in content, f"missing description frontmatter in {skill_file}"

--- a/tests/integration/test_runtime_http_api.py
+++ b/tests/integration/test_runtime_http_api.py
@@ -1,0 +1,123 @@
+import os
+import tempfile
+import time
+import unittest
+
+import requests
+
+from eap.environment import AsyncLocalExecutor, ToolRegistry
+from eap.protocol import StateManager
+from eap.runtime import EAPRuntimeHTTPServer
+
+
+def echo_text(text: str) -> str:
+    return f"echo:{text}"
+
+
+ECHO_SCHEMA = {
+    "name": "echo_text",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string"},
+        },
+        "required": ["text"],
+        "additionalProperties": False,
+    },
+}
+
+
+class RuntimeHttpApiIntegrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        fd, self.db_path = tempfile.mkstemp(prefix="eap-runtime-api-", suffix=".db")
+        os.close(fd)
+
+        self.state_manager = StateManager(db_path=self.db_path)
+        registry = ToolRegistry()
+        registry.register("echo_text", echo_text, ECHO_SCHEMA)
+        executor = AsyncLocalExecutor(self.state_manager, registry)
+
+        self.server = EAPRuntimeHTTPServer(
+            executor=executor,
+            state_manager=self.state_manager,
+            required_bearer_token="secret-token",
+        ).start()
+        # Small startup buffer for thread scheduling stability in CI.
+        time.sleep(0.05)
+
+    def tearDown(self) -> None:
+        self.server.stop()
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_execute_macro_and_fetch_run_and_pointer_summary(self) -> None:
+        execute_response = requests.post(
+            f"{self.server.base_url}/v1/eap/macro/execute",
+            headers={"Authorization": "Bearer secret-token"},
+            json={
+                "macro": {
+                    "steps": [
+                        {
+                            "step_id": "step_1",
+                            "tool_name": "echo_text",
+                            "arguments": {"text": "hello"},
+                        }
+                    ]
+                }
+            },
+            timeout=5,
+        )
+        self.assertEqual(execute_response.status_code, 200)
+        execute_body = execute_response.json()
+        self.assertIn("pointer_id", execute_body)
+        self.assertIn("metadata", execute_body)
+        run_id = execute_body["metadata"]["execution_run_id"]
+
+        run_response = requests.get(
+            f"{self.server.base_url}/v1/eap/runs/{run_id}",
+            headers={"Authorization": "Bearer secret-token"},
+            timeout=5,
+        )
+        self.assertEqual(run_response.status_code, 200)
+        run_body = run_response.json()
+        self.assertEqual(run_body["run_id"], run_id)
+        self.assertEqual(run_body["status"], "succeeded")
+        self.assertEqual(run_body["summary"]["total_steps"], 1)
+        self.assertGreater(run_body["trace_event_count"], 0)
+
+        pointer_id = execute_body["pointer_id"]
+        pointer_response = requests.get(
+            f"{self.server.base_url}/v1/eap/pointers/{pointer_id}/summary",
+            headers={"Authorization": "Bearer secret-token"},
+            timeout=5,
+        )
+        self.assertEqual(pointer_response.status_code, 200)
+        pointer_body = pointer_response.json()
+        self.assertEqual(pointer_body["pointer"]["pointer_id"], pointer_id)
+        self.assertIn("summary", pointer_body["pointer"])
+        self.assertIn("metadata", pointer_body["pointer"])
+
+    def test_execute_macro_rejects_missing_auth(self) -> None:
+        response = requests.post(
+            f"{self.server.base_url}/v1/eap/macro/execute",
+            json={"macro": {"steps": []}},
+            timeout=5,
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["error_type"], "unauthorized")
+
+    def test_execute_macro_rejects_invalid_payload(self) -> None:
+        response = requests.post(
+            f"{self.server.base_url}/v1/eap/macro/execute",
+            headers={"Authorization": "Bearer secret-token"},
+            json={"macro": {"steps": [{"tool_name": "echo_text", "arguments": {"text": "hello"}}]}},
+            timeout=5,
+        )
+        self.assertEqual(response.status_code, 400)
+        body = response.json()
+        self.assertEqual(body["error_type"], "validation_error")
+        self.assertIn("Invalid macro payload", body["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- implement EAP runtime HTTP server endpoints for macro execute, run status, and pointer summary\n- add OpenClaw plugin adapter MVP exposing run/inspect/pointer tools\n- add OpenClaw skill pack (run, inspect, retry failed step, export trace) with quickstart\n- update phase 7 roadmap + interop docs and add contract/integration tests\n\n## Validation\n- npm test (integrations/openclaw/eap-runtime-plugin)\n- .venv-eap072b/bin/python -m pytest -q tests/contract/test_openclaw_skill_pack.py tests/integration/test_runtime_http_api.py tests/contract/test_public_api_contract.py tests/contract/test_sdk_contracts.py\n