### PR TITLE
EAP-075: add pinned OpenClaw interop CI lane

### DIFF
--- a/.github/workflows/openclaw-interop.yml
+++ b/.github/workflows/openclaw-interop.yml
@@ -1,0 +1,74 @@
+name: OpenClaw Interop
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron: "41 3 * * 1"
+
+jobs:
+  smoke:
+    name: OpenClaw interop smoke (${{ matrix.openclaw-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        openclaw-version:
+          - v2026.2.21
+          - v2026.2.22
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: integrations/openclaw/eap-runtime-plugin/package-lock.json
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Install plugin dependencies
+        run: npm --prefix integrations/openclaw/eap-runtime-plugin ci
+
+      - name: Run plugin unit tests
+        run: npm --prefix integrations/openclaw/eap-runtime-plugin test
+
+      - name: Run OpenClaw compatibility smoke
+        run: ./scripts/interop_openclaw_smoke.sh "${{ matrix.openclaw-version }}"
+
+      - name: Run EAP runtime contract tests
+        run: |
+          python -m pytest -q \
+            tests/contract/test_openclaw_skill_pack.py \
+            tests/integration/test_runtime_http_api.py \
+            tests/contract/test_public_api_contract.py \
+            tests/contract/test_sdk_contracts.py
+
+  required:
+    name: OpenClaw interop required
+    runs-on: ubuntu-latest
+    needs: smoke
+    if: always()
+    steps:
+      - name: Enforce interop smoke success
+        run: |
+          if [[ "${{ needs.smoke.result }}" != "success" ]]; then
+            echo "OpenClaw interop smoke failed."
+            exit 1
+          fi
+          echo "OpenClaw interop smoke passed."

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ python3 -m pytest -q
 pre-commit run --all-files
 python3 scripts/migrate_state_db.py --db-path agent_state.db --dry-run
 python3 scripts/export_metrics.py --db-path agent_state.db --output metrics/latest.json
+./scripts/interop_openclaw_smoke.sh v2026.2.22
 python3 -m build
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,3 +66,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - `v0.1.4` release published with Phase 5 and CodeQL v4 updates.
 - Phase 7 interop foundation started with `EAP-071` (interop matrix), `EAP-072` (runtime HTTP endpoints), and `EAP-073` (OpenClaw plugin adapter MVP).
 - Phase 7 `EAP-074` skill pack added (`run`, `inspect`, `retry failed step`, `export trace`) with 5-minute quickstart.
+- Phase 7 `EAP-075` interop CI lane added with pinned OpenClaw version smoke tests.

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,8 +1,8 @@
 # OpenClaw Interop Spike (EAP-071)
 
-Status: Updated through EAP-074 (2026-02-23)  
+Status: Updated through EAP-075 (2026-02-23)  
 Owner: EAP maintainers  
-Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074)
+Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075)
 
 ## 1) Version Snapshot
 
@@ -14,7 +14,9 @@ This spike captures compatibility against these versions at analysis time:
 
 Implication:
 - Treat this as a moving-target snapshot for OpenClaw `main`.
-- Pin explicit OpenClaw release versions in CI once EAP-075 starts.
+- Interop CI pins and validates against:
+  - `v2026.2.21`
+  - `v2026.2.22`
 
 ## 2) Interop Surfaces (What We Checked)
 
@@ -105,7 +107,7 @@ Recommended sequence:
 
 ## 8) Recommended Next Item
 
-`EAP-074` has now been implemented in-repo with:
+`EAP-075` has now been implemented in-repo with:
 - OpenClaw plugin adapter package at `integrations/openclaw/eap-runtime-plugin`
 - required plugin tools:
   - `run_eap_workflow`
@@ -118,9 +120,14 @@ Recommended sequence:
   - `eap_retry_failed_step`
   - `eap_export_trace`
 - 5-minute skill quickstart at `integrations/openclaw/eap-runtime-plugin/skills/README.md`
+- dedicated interop workflow: `.github/workflows/openclaw-interop.yml`
+- OpenClaw compatibility smoke script: `scripts/interop_openclaw_smoke.sh`
+- pinned version matrix:
+  - `v2026.2.21`
+  - `v2026.2.22`
 
-Proceed to **EAP-075**:
-- Add an interop CI lane that validates plugin + skills against pinned OpenClaw versions.
+Proceed to **EAP-076**:
+- Add human approval checkpoints (HITL) for step-level pause/approve/reject.
 
 ## References (Primary Sources)
 

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -7,7 +7,8 @@ Current status:
 - [x] `EAP-072` minimal EAP runtime HTTP endpoints + auth hooks + integration tests
 - [x] `EAP-073` OpenClaw plugin adapter MVP (`integrations/openclaw/eap-runtime-plugin`)
 - [x] `EAP-074` OpenClaw skill pack (`integrations/openclaw/eap-runtime-plugin/skills`)
-- [ ] `EAP-075` onward
+- [x] `EAP-075` interop CI lane (`.github/workflows/openclaw-interop.yml`)
+- [ ] `EAP-076` onward
 
 ## Objective
 

--- a/integrations/openclaw/eap-runtime-plugin/package-lock.json
+++ b/integrations/openclaw/eap-runtime-plugin/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "@eap/openclaw-runtime-plugin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@eap/openclaw-runtime-plugin",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/scripts/interop_openclaw_smoke.sh
+++ b/scripts/interop_openclaw_smoke.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OPENCLAW_VERSION="${1:-}"
+if [[ -z "${OPENCLAW_VERSION}" ]]; then
+  echo "usage: $0 <openclaw-version-tag>" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_DIR="${REPO_ROOT}/integrations/openclaw/eap-runtime-plugin"
+MANIFEST_PATH="${PLUGIN_DIR}/openclaw.plugin.json"
+SKILLS_ROOT="${PLUGIN_DIR}/skills"
+
+if [[ ! -f "${MANIFEST_PATH}" ]]; then
+  echo "missing plugin manifest: ${MANIFEST_PATH}" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+RAW_BASE="https://raw.githubusercontent.com/openclaw/openclaw/${OPENCLAW_VERSION}"
+curl -fsSL "${RAW_BASE}/src/plugins/manifest.ts" -o "${TMP_DIR}/manifest.ts"
+curl -fsSL "${RAW_BASE}/docs/plugins/manifest.md" -o "${TMP_DIR}/manifest.md"
+curl -fsSL "${RAW_BASE}/docs/tools/skills.md" -o "${TMP_DIR}/skills.md"
+
+# Guard that OpenClaw still requires manifest + config schema.
+grep -Fq "plugin manifest requires id" "${TMP_DIR}/manifest.ts"
+grep -Fq "plugin manifest requires configSchema" "${TMP_DIR}/manifest.ts"
+grep -Fq "skills?: string[]" "${TMP_DIR}/manifest.ts"
+
+# Guard docs still advertise the key compatibility points this plugin relies on.
+grep -Fq -- "- \`id\` (string): canonical plugin id." "${TMP_DIR}/manifest.md"
+grep -Fq -- "- \`configSchema\` (object): JSON Schema for plugin config (inline)." "${TMP_DIR}/manifest.md"
+grep -Fq -- "- \`skills\` (array): skill directories to load (relative to the plugin root)." "${TMP_DIR}/manifest.md"
+grep -Fq "SKILL.md" "${TMP_DIR}/skills.md"
+
+python3 - "${MANIFEST_PATH}" "${SKILLS_ROOT}" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+skills_root = Path(sys.argv[2])
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+assert isinstance(manifest.get("id"), str) and manifest["id"], "manifest id is required"
+assert isinstance(manifest.get("configSchema"), dict), "manifest configSchema must be an object"
+assert isinstance(manifest.get("skills"), list) and manifest["skills"], "manifest skills list is required"
+
+for entry in manifest["skills"]:
+    assert isinstance(entry, str) and entry.startswith("./skills/"), f"invalid skills entry: {entry!r}"
+    skill_dir = manifest_path.parent / entry[2:]
+    skill_file = skill_dir / "SKILL.md"
+    assert skill_file.exists(), f"missing skill file: {skill_file}"
+    text = skill_file.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"missing frontmatter in {skill_file}"
+    assert "name:" in text and "description:" in text, f"missing required metadata in {skill_file}"
+
+for expected in (
+    "eap_run_workflow",
+    "eap_inspect_run",
+    "eap_retry_failed_step",
+    "eap_export_trace",
+):
+    path = skills_root / expected / "SKILL.md"
+    assert path.exists(), f"expected skill missing: {path}"
+PY
+
+echo "OpenClaw interop smoke passed for ${OPENCLAW_VERSION}"


### PR DESCRIPTION
## Summary\n- add dedicated OpenClaw interop workflow with pinned version matrix (v2026.2.21, v2026.2.22)\n- add interop smoke script validating plugin manifest/skills compatibility against each OpenClaw tag\n- add stable required gate job (`OpenClaw interop required`)\n- update Phase 7 roadmap + interop docs to mark EAP-075 complete and move to EAP-076\n\n## Validation\n- ./scripts/interop_openclaw_smoke.sh v2026.2.21\n- ./scripts/interop_openclaw_smoke.sh v2026.2.22\n- npm --prefix integrations/openclaw/eap-runtime-plugin test\n