### PR TITLE
EAP-077: crash-safe resume/replay with persisted checkpoints

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,3 +68,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-074` skill pack added (`run`, `inspect`, `retry failed step`, `export trace`) with 5-minute quickstart.
 - Phase 7 `EAP-075` interop CI lane added with pinned OpenClaw version smoke tests.
 - Phase 7 `EAP-076` HITL checkpoints added (step-level pause/approve/reject semantics with trace transitions).
+- Phase 7 `EAP-077` crash-safe resume/replay added with persisted run checkpoints and resume endpoint.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ This document describes the runtime architecture of Efficient Agent Protocol (EA
 ## `protocol/models.py`
 - Core Pydantic contracts (`ToolCall`, `BatchedMacroRequest`, `RetryPolicy`, error payloads).
 - Execution trace model (`ExecutionTraceEvent`) with lifecycle states:
-  - `queued`, `approval_required`, `approved`, `rejected`, `started`, `retried`, `failed`, `completed`
+  - `replayed`, `queued`, `approval_required`, `approved`, `rejected`, `started`, `retried`, `failed`, `completed`
 - Conversation memory models:
   - `ConversationSession`, `ConversationTurn`, `MemoryStrategy`
 - Workflow graph models:
@@ -27,6 +27,7 @@ This document describes the runtime architecture of Efficient Agent Protocol (EA
 - Execution observability persistence:
   - `execution_trace_events`
   - `execution_run_summaries`
+  - `execution_run_checkpoints` (crash-safe run resume/replay state)
 - Conversation persistence:
   - `conversation_sessions`
   - `conversation_turns`
@@ -45,6 +46,7 @@ This document describes the runtime architecture of Efficient Agent Protocol (EA
 - Enforces global/per-tool semaphores and token-bucket rate limits.
 - Applies retry policy with backoff on retryable failures.
 - Writes trace events and run summary metadata.
+- Persists resumable checkpoints and supports `resume_run(...)` replay for interrupted runs.
 - Emits saturation metrics in final result metadata.
 
 ## `environment/distributed_executor.py`

--- a/docs/eap_proof_sheet.md
+++ b/docs/eap_proof_sheet.md
@@ -27,7 +27,7 @@ Source: `docs/benchmarks.md` (baseline date: 2026-02-23)
 | Transient tool failure | Retry and then succeed when policy allows | `tests/integration/test_executor_retries.py` |
 | Non-retryable timeout | Fail fast with typed `tool_execution_error` | `tests/integration/test_reliability_failures.py` |
 | Upstream step fails | Downstream dependency marked `dependency_error` | `tests/integration/test_reliability_failures.py` |
-| Retry/fail/approval trace visibility | `queued/approval_required/approved/rejected/started/retried/failed/completed` persisted with run summary | `tests/integration/test_execution_traces.py`, `tests/integration/test_human_approval.py` |
+| Retry/fail/approval/replay trace visibility | `replayed/queued/approval_required/approved/rejected/started/retried/failed/completed` persisted with run summary | `tests/integration/test_execution_traces.py`, `tests/integration/test_human_approval.py`, `tests/integration/test_resume_replay.py` |
 | Pointer lifecycle cleanup | Expired pointers filtered and cleaned idempotently | `tests/integration/test_pointer_ttl.py` |
 | Distributed worker lease expiry | Expired lease is reassigned; stale completion rejected | `tests/perf/test_distributed_resilience.py` |
 

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,8 +1,8 @@
 # OpenClaw Interop Spike (EAP-071)
 
-Status: Updated through EAP-075 (2026-02-23)  
+Status: Updated through EAP-077 (2026-02-23)  
 Owner: EAP maintainers  
-Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075)
+Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077)
 
 ## 1) Version Snapshot
 
@@ -107,7 +107,7 @@ Recommended sequence:
 
 ## 8) Recommended Next Item
 
-`EAP-075` has now been implemented in-repo with:
+`EAP-077` has now been implemented in-repo with:
 - OpenClaw plugin adapter package at `integrations/openclaw/eap-runtime-plugin`
 - required plugin tools:
   - `run_eap_workflow`
@@ -125,9 +125,17 @@ Recommended sequence:
 - pinned version matrix:
   - `v2026.2.21`
   - `v2026.2.22`
+- HITL approval checkpoints in runtime execution:
+  - `approval_required`
+  - `approved`
+  - `rejected`
+- crash-safe run checkpoint persistence:
+  - `execution_run_checkpoints` state table
+  - executor `resume_run(...)`
+  - HTTP resume endpoint `POST /v1/eap/runs/{run_id}/resume`
 
-Proceed to **EAP-077**:
-- Add crash-safe resume and replay from persisted checkpoints.
+Proceed to **EAP-078**:
+- Add MCP interoperability bridge/server path for reference tools.
 
 ## References (Primary Sources)
 

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -9,7 +9,8 @@ Current status:
 - [x] `EAP-074` OpenClaw skill pack (`integrations/openclaw/eap-runtime-plugin/skills`)
 - [x] `EAP-075` interop CI lane (`.github/workflows/openclaw-interop.yml`)
 - [x] `EAP-076` human approval checkpoints (HITL pause/approve/reject + trace transitions)
-- [ ] `EAP-077` onward
+- [x] `EAP-077` crash-safe resume and replay (checkpoint persistence + run resume API)
+- [ ] `EAP-078` onward
 
 ## Objective
 

--- a/docs/sdk_contract.md
+++ b/docs/sdk_contract.md
@@ -8,6 +8,7 @@ The SDK contract standardizes payloads for:
 - Chat completion (`chat`)
 - Macro generation (`generate_macro`)
 - Macro execution (`execute_macro`)
+- Run resume (`resume_run`) via `POST /v1/eap/runs/{run_id}/resume`
 
 The contract is transport-agnostic but is intended for JSON-over-HTTP.
 
@@ -57,6 +58,38 @@ Response:
   "request_id": "req_123",
   "timestamp_utc": "2026-02-23T12:00:00+00:00",
   "content": "Summary text..."
+}
+```
+
+## Operation: `resume_run`
+
+Resume an interrupted run from persisted checkpoint state.
+
+Request:
+```json
+{
+  "approvals": {
+    "step_1": {"decision": "approve"}
+  }
+}
+```
+
+Endpoint:
+- `POST /v1/eap/runs/{run_id}/resume`
+
+Response:
+```json
+{
+  "request_id": "req_999",
+  "timestamp_utc": "2026-02-23T12:00:03+00:00",
+  "run_id": "run_001",
+  "pointer_id": "ptr_resume1234",
+  "summary": "Completed step step_1 successfully.",
+  "metadata": {
+    "execution_run_id": "run_001",
+    "resumed_from_checkpoint": true,
+    "checkpoint_status": "completed"
+  }
 }
 ```
 

--- a/eap/runtime/http_api.py
+++ b/eap/runtime/http_api.py
@@ -29,6 +29,10 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
         if parsed.path == "/v1/eap/macro/execute":
             self._handle_execute_macro()
             return
+        if parsed.path.startswith("/v1/eap/runs/") and parsed.path.endswith("/resume"):
+            run_id = unquote(parsed.path[len("/v1/eap/runs/") : -len("/resume")]).strip()
+            self._handle_resume_run(run_id=run_id)
+            return
         self._send_error(404, "not_found", f"Path '{parsed.path}' is not registered.")
 
     def do_GET(self) -> None:  # noqa: N802
@@ -63,19 +67,23 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
             return False
         return True
 
-    def _read_json_body(self) -> Optional[Dict[str, Any]]:
+    def _read_json_body(self, required: bool = True) -> Optional[Dict[str, Any]]:
         content_length_header = self.headers.get("Content-Length")
         if not content_length_header:
-            self._send_error(400, "validation_error", "Request body is required.")
-            return None
+            if required:
+                self._send_error(400, "validation_error", "Request body is required.")
+                return None
+            return {}
         try:
             content_length = int(content_length_header)
         except ValueError:
             self._send_error(400, "validation_error", "Invalid Content-Length header.")
             return None
         if content_length <= 0:
-            self._send_error(400, "validation_error", "Request body is required.")
-            return None
+            if required:
+                self._send_error(400, "validation_error", "Request body is required.")
+                return None
+            return {}
 
         raw_body = self.rfile.read(content_length)
         try:
@@ -134,6 +142,63 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
         response_payload = {
             "request_id": _request_id(),
             "timestamp_utc": _timestamp_utc(),
+            "pointer_id": result["pointer_id"],
+            "summary": result.get("summary", ""),
+            "metadata": result.get("metadata"),
+        }
+        self._send_json(200, response_payload)
+
+    def _handle_resume_run(self, run_id: str) -> None:
+        if not self._require_auth():
+            return
+        if not run_id:
+            self._send_error(400, "validation_error", "run_id is required.")
+            return
+
+        payload = self._read_json_body(required=False)
+        if payload is None:
+            return
+        approvals = payload.get("approvals")
+        if approvals is not None and not isinstance(approvals, dict):
+            self._send_error(400, "validation_error", "Field 'approvals' must be a JSON object.")
+            return
+
+        try:
+            result = asyncio.run(self.server.executor.resume_run(run_id=run_id, approvals=approvals))
+        except KeyError:
+            self._send_error(404, "not_found", f"Execution checkpoint for run '{run_id}' not found.")
+            return
+        except ValueError as exc:
+            self._send_error(400, "validation_error", str(exc))
+            return
+        except ValidationError as exc:
+            self._send_error(
+                400,
+                "validation_error",
+                "Invalid resume approval payload.",
+                details={"errors": exc.errors()},
+            )
+            return
+        except Exception as exc:  # pragma: no cover - defensive safeguard
+            self._send_error(
+                500,
+                "execution_error",
+                f"Run resume failed: {str(exc)}",
+            )
+            return
+
+        if not result or "pointer_id" not in result:
+            self._send_error(
+                500,
+                "execution_error",
+                "Run resume did not return a pointer response.",
+            )
+            return
+
+        response_payload = {
+            "request_id": _request_id(),
+            "timestamp_utc": _timestamp_utc(),
+            "run_id": run_id,
             "pointer_id": result["pointer_id"],
             "summary": result.get("summary", ""),
             "metadata": result.get("metadata"),

--- a/environment/executor.py
+++ b/environment/executor.py
@@ -5,7 +5,7 @@ import re
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 from protocol.models import (
     BatchedMacroRequest,
     ExecutionLimits,
@@ -63,10 +63,15 @@ class AsyncLocalExecutor:
         self.registry = registry
         self.default_execution_limits = default_execution_limits or ExecutionLimits()
 
-    async def execute_macro(self, macro: BatchedMacroRequest) -> dict:
-        run_id = f"run_{uuid.uuid4().hex[:12]}"
+    async def execute_macro(
+        self,
+        macro: BatchedMacroRequest,
+        run_id: Optional[str] = None,
+        resume: bool = False,
+    ) -> dict:
+        run_id = run_id or f"run_{uuid.uuid4().hex[:12]}"
         run_started_at = datetime.now(timezone.utc)
-        run_started_perf = time.perf_counter()
+        replayed_step_ids: Set[str] = set()
         logger.info(
             "received macro batch",
             extra={"step_count": len(macro.steps), "run_id": run_id},
@@ -76,10 +81,90 @@ class AsyncLocalExecutor:
         step_futures: Dict[str, asyncio.Future] = {
             step.step_id: asyncio.Future() for step in macro.steps
         }
-        step_status: Dict[str, Dict[str, str]] = {}
+        step_status: Dict[str, Dict[str, Any]] = {}
         step_contexts: Dict[str, Dict[str, Any]] = {}
         branch_decisions: Dict[str, Set[str]] = {}
         early_exit_event = asyncio.Event()
+        checkpoint_lock = asyncio.Lock()
+
+        if resume:
+            checkpoint = self.state_manager.get_run_checkpoint(run_id)
+            if checkpoint["status"] not in {"active", "awaiting_approval"}:
+                raise ValueError(
+                    f"Run {run_id} is not resumable from status '{checkpoint['status']}'."
+                )
+            run_started_at = datetime.fromisoformat(checkpoint["started_at_utc"])
+            if run_started_at.tzinfo is None:
+                run_started_at = run_started_at.replace(tzinfo=timezone.utc)
+            step_status = dict(checkpoint.get("step_status") or {})
+            branch_decisions = {
+                step_id: set(targets)
+                for step_id, targets in (checkpoint.get("branch_decisions") or {}).items()
+            }
+
+        def _hydrate_pointer_response(pointer_id: Optional[str], step_id: str) -> Dict[str, Any]:
+            if not pointer_id:
+                return {
+                    "pointer_id": "",
+                    "summary": f"Step {step_id} recovered from checkpoint.",
+                    "metadata": {"status": step_status.get(step_id, {}).get("status")},
+                }
+            pointer = next(
+                (
+                    item
+                    for item in self.state_manager.list_pointers(include_expired=True)
+                    if item.get("pointer_id") == pointer_id
+                ),
+                None,
+            )
+            if pointer is None:
+                return {
+                    "pointer_id": pointer_id,
+                    "summary": f"Recovered pointer {pointer_id} for step {step_id}.",
+                    "metadata": {"status": step_status.get(step_id, {}).get("status")},
+                }
+            return {
+                "pointer_id": pointer_id,
+                "summary": pointer.get("summary", f"Recovered pointer {pointer_id}."),
+                "metadata": pointer.get("metadata"),
+            }
+
+        for step_id, status_payload in step_status.items():
+            pointer_id = status_payload.get("pointer_id")
+            status_value = status_payload.get("status")
+            if pointer_id and status_value in {"ok", "error", "skipped", "rejected"}:
+                if step_id in step_futures and not step_futures[step_id].done():
+                    step_futures[step_id].set_result(pointer_id)
+            if pointer_id:
+                step_contexts[step_id] = {
+                    "pointer_id": pointer_id,
+                    "metadata": status_payload.get("metadata"),
+                    "raw_data": None,
+                    "status": status_value,
+                }
+                try:
+                    step_contexts[step_id]["raw_data"] = self.state_manager.retrieve(pointer_id)
+                except Exception:
+                    step_contexts[step_id]["raw_data"] = None
+
+        async def _persist_checkpoint(
+            status: str = "active",
+            final_pointer_id: Optional[str] = None,
+        ) -> None:
+            async with checkpoint_lock:
+                self.state_manager.upsert_run_checkpoint(
+                    run_id=run_id,
+                    started_at_utc=run_started_at.isoformat(),
+                    status=status,
+                    macro_payload=macro.model_dump(mode="json"),
+                    step_status=step_status,
+                    branch_decisions={
+                        step_id: sorted(targets) for step_id, targets in branch_decisions.items()
+                    },
+                    final_pointer_id=final_pointer_id,
+                )
+
+        await _persist_checkpoint(status="active")
 
         resolved_tool_names: Dict[str, str] = {}
         for step in macro.steps:
@@ -250,6 +335,28 @@ class AsyncLocalExecutor:
                     inflight_per_tool[tool_key] = current - 1
 
         async def run_step(step):
+            existing_state = step_status.get(step.step_id, {})
+            existing_status = existing_state.get("status")
+            existing_pointer_id = existing_state.get("pointer_id")
+            if existing_status in {"ok", "error", "skipped", "rejected"} and existing_pointer_id:
+                if not step_futures[step.step_id].done():
+                    step_futures[step.step_id].set_result(existing_pointer_id)
+                replayed_step_ids.add(step.step_id)
+                self.state_manager.append_trace_event(
+                    ExecutionTraceEvent(
+                        run_id=run_id,
+                        step_id=step.step_id,
+                        tool_name=step.tool_name,
+                        event_type=ExecutionTraceEventType.REPLAYED,
+                        output_pointer_id=existing_pointer_id,
+                    )
+                )
+                logger.info(
+                    "task replayed from checkpoint",
+                    extra={"step_id": step.step_id, "tool_name": step.tool_name, "run_id": run_id},
+                )
+                return _hydrate_pointer_response(existing_pointer_id, step.step_id)
+
             logger.info(
                 "task queued",
                 extra={"step_id": step.step_id, "tool_name": step.tool_name, "run_id": run_id},
@@ -295,6 +402,7 @@ class AsyncLocalExecutor:
                             branch_decisions[step.step_id] = set()
                         if not step_futures[step.step_id].done():
                             step_futures[step.step_id].set_result(step_pointer["pointer_id"])
+                        await _persist_checkpoint(status="active")
                         logger.info(
                             "task skipped by branch routing",
                             extra={"step_id": step.step_id, "tool_name": step.tool_name, "run_id": run_id},
@@ -323,6 +431,7 @@ class AsyncLocalExecutor:
                         branch_decisions[step.step_id] = set()
                     if not step_futures[step.step_id].done():
                         step_futures[step.step_id].set_result(step_pointer["pointer_id"])
+                    await _persist_checkpoint(status="active")
                     logger.info(
                         "task skipped due to early exit",
                         extra={"step_id": step.step_id, "tool_name": step.tool_name, "run_id": run_id},
@@ -370,6 +479,7 @@ class AsyncLocalExecutor:
                             branch_decisions[step.step_id] = set()
                         if not step_futures[step.step_id].done():
                             step_futures[step.step_id].set_result(step_pointer["pointer_id"])
+                        await _persist_checkpoint(status="active")
                         logger.info(
                             "task paused awaiting approval",
                             extra={"step_id": step.step_id, "tool_name": step.tool_name, "run_id": run_id},
@@ -414,6 +524,7 @@ class AsyncLocalExecutor:
                         resolve_branch_targets(step, status="error")
                         if not step_futures[step.step_id].done():
                             step_futures[step.step_id].set_result(step_pointer["pointer_id"])
+                        await _persist_checkpoint(status="active")
                         logger.info(
                             "task rejected at approval checkpoint",
                             extra={"step_id": step.step_id, "tool_name": step.tool_name, "run_id": run_id},
@@ -595,6 +706,7 @@ class AsyncLocalExecutor:
                 resolve_branch_targets(step, status="ok")
                 if not step_futures[step.step_id].done():
                     step_futures[step.step_id].set_result(step_pointer["pointer_id"])
+                await _persist_checkpoint(status="active")
                 logger.info(
                     "task finished",
                     extra={"step_id": step.step_id, "tool_name": step.tool_name, "run_id": run_id},
@@ -647,6 +759,7 @@ class AsyncLocalExecutor:
                 resolve_branch_targets(step, status="error")
                 if not step_futures[step.step_id].done():
                     step_futures[step.step_id].set_result(step_pointer["pointer_id"])
+                await _persist_checkpoint(status="active")
                 return step_pointer
 
         tasks = [asyncio.create_task(run_step(step)) for step in macro.steps]
@@ -667,6 +780,15 @@ class AsyncLocalExecutor:
             0,
             approval_required_steps - approval_paused_steps - approval_rejected_steps,
         )
+        total_duration_ms = round(
+            max(0.0, (run_completed_at - run_started_at).total_seconds() * 1000.0),
+            3,
+        )
+        checkpoint_status = "awaiting_approval" if approval_paused_steps > 0 else "completed"
+        await _persist_checkpoint(
+            status=checkpoint_status,
+            final_pointer_id=final_result["pointer_id"] if final_result else None,
+        )
         self.state_manager.store_execution_summary(
             run_id=run_id,
             started_at_utc=run_started_at.isoformat(),
@@ -674,13 +796,16 @@ class AsyncLocalExecutor:
             total_steps=len(macro.steps),
             succeeded_steps=succeeded_steps,
             failed_steps=failed_steps,
-            total_duration_ms=round((time.perf_counter() - run_started_perf) * 1000, 3),
+            total_duration_ms=total_duration_ms,
             final_pointer_id=final_result["pointer_id"] if final_result else None,
         )
 
         if final_result:
             final_result.setdefault("metadata", {})
             final_result["metadata"]["execution_run_id"] = run_id
+            final_result["metadata"]["checkpoint_status"] = checkpoint_status
+            final_result["metadata"]["resumed_from_checkpoint"] = resume
+            final_result["metadata"]["replayed_steps"] = sorted(replayed_step_ids)
             final_result["metadata"]["approval_metrics"] = {
                 "required_steps": approval_required_steps,
                 "approved_steps": approval_approved_steps,
@@ -703,3 +828,21 @@ class AsyncLocalExecutor:
                 ),
             }
         return final_result
+
+    async def resume_run(
+        self,
+        run_id: str,
+        approvals: Optional[Dict[str, Any]] = None,
+    ) -> dict:
+        checkpoint = self.state_manager.get_run_checkpoint(run_id)
+        if checkpoint["status"] not in {"active", "awaiting_approval"}:
+            raise ValueError(
+                f"Run {run_id} is not resumable from status '{checkpoint['status']}'."
+            )
+        macro_payload = checkpoint["macro_payload"]
+        if approvals:
+            merged_approvals = dict(macro_payload.get("approvals") or {})
+            merged_approvals.update(approvals)
+            macro_payload["approvals"] = merged_approvals
+        macro = BatchedMacroRequest.model_validate(macro_payload)
+        return await self.execute_macro(macro=macro, run_id=run_id, resume=True)

--- a/protocol/models.py
+++ b/protocol/models.py
@@ -207,6 +207,7 @@ class ExecutionLimits(BaseModel):
 class ExecutionTraceEventType(str, Enum):
     """Lifecycle states emitted during step execution."""
 
+    REPLAYED = "replayed"
     QUEUED = "queued"
     APPROVAL_REQUIRED = "approval_required"
     APPROVED = "approved"
@@ -258,6 +259,12 @@ class ExecutionTraceEvent(BaseModel):
 
     @model_validator(mode="after")
     def validate_event_contract(self) -> "ExecutionTraceEvent":
+        if self.event_type == ExecutionTraceEventType.REPLAYED:
+            if not self.output_pointer_id:
+                raise ValueError("replayed events must include output_pointer_id")
+            if self.error:
+                raise ValueError("replayed events cannot include error")
+
         if self.event_type == ExecutionTraceEventType.QUEUED:
             if self.output_pointer_id or self.error or self.duration_ms is not None:
                 raise ValueError("queued events cannot include output_pointer_id, error, or duration_ms")

--- a/protocol/state_manager.py
+++ b/protocol/state_manager.py
@@ -73,6 +73,32 @@ class StateManager:
             )
             conn.execute(
                 """
+                CREATE TABLE IF NOT EXISTS execution_run_checkpoints (
+                    run_id TEXT PRIMARY KEY,
+                    started_at_utc TEXT NOT NULL,
+                    updated_at_utc TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    macro_payload TEXT NOT NULL,
+                    step_status_payload TEXT NOT NULL,
+                    branch_decisions_payload TEXT NOT NULL,
+                    final_pointer_id TEXT
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_execution_run_checkpoints_status
+                ON execution_run_checkpoints(status)
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_execution_run_checkpoints_updated
+                ON execution_run_checkpoints(updated_at_utc)
+                """
+            )
+            conn.execute(
+                """
                 CREATE TABLE IF NOT EXISTS conversation_sessions (
                     session_id TEXT PRIMARY KEY,
                     created_at_utc TEXT NOT NULL,
@@ -289,6 +315,89 @@ class StateManager:
                     final_pointer_id,
                 ),
             )
+
+    def upsert_run_checkpoint(
+        self,
+        run_id: str,
+        started_at_utc: str,
+        status: str,
+        macro_payload: Dict[str, Any],
+        step_status: Dict[str, Dict[str, Any]],
+        branch_decisions: Dict[str, List[str]],
+        final_pointer_id: Optional[str] = None,
+    ) -> None:
+        updated_at_utc = self._now_utc_iso()
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO execution_run_checkpoints (
+                    run_id, started_at_utc, updated_at_utc, status, macro_payload,
+                    step_status_payload, branch_decisions_payload, final_pointer_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    started_at_utc,
+                    updated_at_utc,
+                    status,
+                    json.dumps(macro_payload),
+                    json.dumps(step_status),
+                    json.dumps(branch_decisions),
+                    final_pointer_id,
+                ),
+            )
+
+    def get_run_checkpoint(self, run_id: str) -> Dict[str, Any]:
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT started_at_utc, updated_at_utc, status, macro_payload,
+                       step_status_payload, branch_decisions_payload, final_pointer_id
+                FROM execution_run_checkpoints
+                WHERE run_id = ?
+                """,
+                (run_id,),
+            ).fetchone()
+
+        if not row:
+            raise KeyError(f"Execution checkpoint for run {run_id} not found.")
+
+        return {
+            "run_id": run_id,
+            "started_at_utc": row[0],
+            "updated_at_utc": row[1],
+            "status": row[2],
+            "macro_payload": json.loads(row[3]),
+            "step_status": json.loads(row[4]) if row[4] else {},
+            "branch_decisions": json.loads(row[5]) if row[5] else {},
+            "final_pointer_id": row[6],
+        }
+
+    def list_run_checkpoints(self, status: Optional[str] = None, limit: int = 50) -> List[Dict[str, Any]]:
+        query = """
+            SELECT run_id, started_at_utc, updated_at_utc, status, final_pointer_id
+            FROM execution_run_checkpoints
+        """
+        params: tuple[Any, ...] = ()
+        if status is not None:
+            query += " WHERE status = ?"
+            params = (status,)
+        query += " ORDER BY updated_at_utc DESC LIMIT ?"
+        params = params + (limit,)
+
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(query, params).fetchall()
+
+        return [
+            {
+                "run_id": row[0],
+                "started_at_utc": row[1],
+                "updated_at_utc": row[2],
+                "status": row[3],
+                "final_pointer_id": row[4],
+            }
+            for row in rows
+        ]
 
     def get_execution_summary(self, run_id: str) -> Dict[str, Any]:
         with sqlite3.connect(self.db_path) as conn:

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -69,6 +70,26 @@ func (c *Client) GenerateMacro(ctx context.Context, request GenerateMacroRequest
 func (c *Client) ExecuteMacro(ctx context.Context, request ExecuteMacroRequest) (*ExecuteMacroResponse, error) {
 	var response ExecuteMacroResponse
 	if err := c.postJSON(ctx, "/v1/eap/macro/execute", request, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) ResumeRun(
+	ctx context.Context,
+	runID string,
+	request ResumeRunRequest,
+) (*ResumeRunResponse, error) {
+	if strings.TrimSpace(runID) == "" {
+		return nil, fmt.Errorf("runID is required")
+	}
+	var response ResumeRunResponse
+	if err := c.postJSON(
+		ctx,
+		"/v1/eap/runs/"+url.PathEscape(runID)+"/resume",
+		request,
+		&response,
+	); err != nil {
 		return nil, err
 	}
 	return &response, nil

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -102,3 +102,15 @@ type ExecuteMacroResponse struct {
 	Summary   string                 `json:"summary"`
 	Metadata  map[string]interface{} `json:"metadata,omitempty"`
 }
+
+type ResumeRunRequest struct {
+	Approvals map[string]StepApprovalDecision `json:"approvals,omitempty"`
+}
+
+type ResumeRunResponse struct {
+	APIEnvelope
+	RunID     string                 `json:"run_id"`
+	PointerID string                 `json:"pointer_id"`
+	Summary   string                 `json:"summary"`
+	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -7,6 +7,8 @@ import {
   ExecuteMacroResponse,
   GenerateMacroRequest,
   GenerateMacroResponse,
+  ResumeRunRequest,
+  ResumeRunResponse,
 } from "./types.js";
 
 export interface EAPClientOptions {
@@ -62,6 +64,16 @@ export class EAPClient {
 
   async executeMacroFromDefinition(macro: BatchedMacroRequest): Promise<ExecuteMacroResponse> {
     return this.executeMacro({ macro });
+  }
+
+  async resumeRun(runId: string, request: ResumeRunRequest = {}): Promise<ResumeRunResponse> {
+    if (!runId || !runId.trim()) {
+      throw new EAPApiError("runId is required", 400, {
+        error_type: "validation_error",
+        message: "runId is required",
+      });
+    }
+    return this.request<ResumeRunResponse>(`/v1/eap/runs/${encodeURIComponent(runId)}/resume`, request);
   }
 
   private async request<TResponse>(path: string, payload: object): Promise<TResponse> {

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -101,3 +101,14 @@ export interface ExecuteMacroResponse extends ApiEnvelope {
   summary: string;
   metadata?: Record<string, unknown>;
 }
+
+export interface ResumeRunRequest {
+  approvals?: Record<string, StepApprovalDecision>;
+}
+
+export interface ResumeRunResponse extends ApiEnvelope {
+  run_id: string;
+  pointer_id: string;
+  summary: string;
+  metadata?: Record<string, unknown>;
+}

--- a/tests/contract/test_sdk_contracts.py
+++ b/tests/contract/test_sdk_contracts.py
@@ -14,6 +14,7 @@ class SDKContractCompatibilityTest(unittest.TestCase):
         self.assertIn("Operation: `chat`", text)
         self.assertIn("Operation: `generate_macro`", text)
         self.assertIn("Operation: `execute_macro`", text)
+        self.assertIn("Operation: `resume_run`", text)
         self.assertIn("Authorization: Bearer <api_key>", text)
 
     def test_typescript_sdk_exposes_required_types_and_methods(self) -> None:
@@ -30,6 +31,7 @@ class SDKContractCompatibilityTest(unittest.TestCase):
             "interface GenerateMacroRequest",
             "interface ExecuteMacroRequest",
             "interface BatchedMacroRequest",
+            "interface ResumeRunRequest",
         ]:
             self.assertIn(token, types_text)
 
@@ -37,9 +39,11 @@ class SDKContractCompatibilityTest(unittest.TestCase):
             "async chat(",
             "async generateMacro(",
             "async executeMacro(",
+            "async resumeRun(",
             "/v1/eap/chat",
             "/v1/eap/macro/generate",
             "/v1/eap/macro/execute",
+            "/v1/eap/runs/",
         ]:
             self.assertIn(token, client_text)
 
@@ -57,6 +61,7 @@ class SDKContractCompatibilityTest(unittest.TestCase):
             "type GenerateMacroRequest struct",
             "type ExecuteMacroRequest struct",
             "type BatchedMacroRequest struct",
+            "type ResumeRunRequest struct",
             '`json:"request_id"`',
             '`json:"timestamp_utc"`',
         ]:
@@ -66,9 +71,11 @@ class SDKContractCompatibilityTest(unittest.TestCase):
             "func (c *Client) Chat(",
             "func (c *Client) GenerateMacro(",
             "func (c *Client) ExecuteMacro(",
+            "func (c *Client) ResumeRun(",
             '"/v1/eap/chat"',
             '"/v1/eap/macro/generate"',
             '"/v1/eap/macro/execute"',
+            '"/v1/eap/runs/"',
         ]:
             self.assertIn(token, client_text)
 
@@ -88,6 +95,8 @@ class SDKContractCompatibilityTest(unittest.TestCase):
         }
         self.assertTrue(expected.issubset(ts_paths))
         self.assertTrue(expected.issubset(go_paths))
+        self.assertIn("/v1/eap/runs/", ts_client)
+        self.assertIn("/v1/eap/runs/", go_client)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_resume_replay.py
+++ b/tests/integration/test_resume_replay.py
@@ -1,0 +1,120 @@
+import asyncio
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+
+from eap.environment import AsyncLocalExecutor, ToolRegistry
+from eap.protocol import BatchedMacroRequest, ExecutionTraceEventType, StateManager, ToolCall
+
+
+class CountingTool:
+    def __init__(self, prefix: str) -> None:
+        self.prefix = prefix
+        self.calls = 0
+
+    def __call__(self, value: str = "") -> str:
+        self.calls += 1
+        return f"{self.prefix}:{value}"
+
+
+TOOL_SCHEMA = {
+    "name": "step_one",
+    "parameters": {
+        "type": "object",
+        "properties": {"value": {"type": "string"}},
+        "required": [],
+    },
+}
+
+
+class ResumeReplayIntegrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        fd, self.db_path = tempfile.mkstemp(prefix="eap-resume-", suffix=".db")
+        os.close(fd)
+        self.state_manager = StateManager(db_path=self.db_path)
+        self.registry = ToolRegistry()
+        self.step_one_tool = CountingTool("one")
+        self.step_two_tool = CountingTool("two")
+        step_one_schema = dict(TOOL_SCHEMA)
+        step_one_schema["name"] = "step_one"
+        step_two_schema = dict(TOOL_SCHEMA)
+        step_two_schema["name"] = "step_two"
+        self.registry.register("step_one", self.step_one_tool, step_one_schema)
+        self.registry.register("step_two", self.step_two_tool, step_two_schema)
+        self.executor = AsyncLocalExecutor(self.state_manager, self.registry)
+
+    def tearDown(self) -> None:
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_resume_replays_checkpointed_steps_and_executes_pending_steps(self) -> None:
+        macro = BatchedMacroRequest(
+            steps=[
+                ToolCall(step_id="step_1", tool_name="step_one", arguments={"value": "seed"}),
+                ToolCall(step_id="step_2", tool_name="step_two", arguments={"value": "$step:step_1"}),
+            ]
+        )
+        checkpoint_pointer = self.state_manager.store_and_point(
+            raw_data="one:seed",
+            summary="Recovered step_1 output",
+            metadata={"status": "ok"},
+        )
+        run_id = "run_resume_001"
+        self.state_manager.upsert_run_checkpoint(
+            run_id=run_id,
+            started_at_utc=datetime.now(timezone.utc).isoformat(),
+            status="active",
+            macro_payload=macro.model_dump(mode="json"),
+            step_status={"step_1": {"status": "ok", "pointer_id": checkpoint_pointer["pointer_id"]}},
+            branch_decisions={},
+        )
+
+        result = asyncio.run(self.executor.resume_run(run_id))
+        self.assertEqual(result["metadata"]["execution_run_id"], run_id)
+        self.assertTrue(result["metadata"]["resumed_from_checkpoint"])
+        self.assertEqual(result["metadata"]["replayed_steps"], ["step_1"])
+        self.assertEqual(self.step_one_tool.calls, 0)
+        self.assertEqual(self.step_two_tool.calls, 1)
+
+        events = self.state_manager.list_trace_events(run_id)
+        step_one_event_types = [e.event_type for e in events if e.step_id == "step_1"]
+        self.assertEqual(step_one_event_types, [ExecutionTraceEventType.REPLAYED])
+
+        summary = self.state_manager.get_execution_summary(run_id)
+        self.assertEqual(summary["succeeded_steps"], 2)
+        self.assertEqual(summary["failed_steps"], 0)
+
+    def test_resume_advances_awaiting_approval_runs(self) -> None:
+        macro = BatchedMacroRequest(
+            steps=[
+                ToolCall(
+                    step_id="step_1",
+                    tool_name="step_one",
+                    arguments={"value": "approve-me"},
+                    approval={"required": True},
+                )
+            ]
+        )
+        initial = asyncio.run(self.executor.execute_macro(macro))
+        run_id = initial["metadata"]["execution_run_id"]
+        checkpoint = self.state_manager.get_run_checkpoint(run_id)
+        self.assertEqual(checkpoint["status"], "awaiting_approval")
+
+        resumed = asyncio.run(
+            self.executor.resume_run(
+                run_id,
+                approvals={"step_1": {"decision": "approve"}},
+            )
+        )
+        self.assertEqual(resumed["metadata"]["execution_run_id"], run_id)
+        self.assertEqual(resumed["metadata"]["checkpoint_status"], "completed")
+        self.assertEqual(self.step_one_tool.calls, 1)
+
+    def test_resume_missing_checkpoint_raises(self) -> None:
+        with self.assertRaises(KeyError):
+            asyncio.run(self.executor.resume_run("run_missing"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_runtime_http_api.py
+++ b/tests/integration/test_runtime_http_api.py
@@ -118,6 +118,46 @@ class RuntimeHttpApiIntegrationTest(unittest.TestCase):
         self.assertEqual(body["error_type"], "validation_error")
         self.assertIn("Invalid macro payload", body["message"])
 
+    def test_resume_run_with_approval_decision(self) -> None:
+        execute_response = requests.post(
+            f"{self.server.base_url}/v1/eap/macro/execute",
+            headers={"Authorization": "Bearer secret-token"},
+            json={
+                "macro": {
+                    "steps": [
+                        {
+                            "step_id": "step_1",
+                            "tool_name": "echo_text",
+                            "arguments": {"text": "hello"},
+                            "approval": {"required": True},
+                        }
+                    ]
+                }
+            },
+            timeout=5,
+        )
+        self.assertEqual(execute_response.status_code, 200)
+        run_id = execute_response.json()["metadata"]["execution_run_id"]
+
+        resume_response = requests.post(
+            f"{self.server.base_url}/v1/eap/runs/{run_id}/resume",
+            headers={"Authorization": "Bearer secret-token"},
+            json={"approvals": {"step_1": {"decision": "approve"}}},
+            timeout=5,
+        )
+        self.assertEqual(resume_response.status_code, 200)
+        resume_body = resume_response.json()
+        self.assertEqual(resume_body["run_id"], run_id)
+        self.assertTrue(resume_body["metadata"]["resumed_from_checkpoint"])
+
+        run_response = requests.get(
+            f"{self.server.base_url}/v1/eap/runs/{run_id}",
+            headers={"Authorization": "Bearer secret-token"},
+            timeout=5,
+        )
+        self.assertEqual(run_response.status_code, 200)
+        self.assertEqual(run_response.json()["status"], "succeeded")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -77,6 +77,45 @@ class StateManagerTest(unittest.TestCase):
         self.assertEqual(summary["failed_steps"], 1)
         self.assertEqual(summary["final_pointer_id"], "ptr_final")
 
+    def test_upsert_and_get_run_checkpoint(self) -> None:
+        self.manager.upsert_run_checkpoint(
+            run_id="run_ckpt",
+            started_at_utc="2026-02-23T00:00:00+00:00",
+            status="active",
+            macro_payload={"steps": [{"step_id": "s1", "tool_name": "echo", "arguments": {}}]},
+            step_status={"s1": {"status": "ok", "pointer_id": "ptr_1"}},
+            branch_decisions={"s1": ["s2"]},
+            final_pointer_id="ptr_final",
+        )
+        checkpoint = self.manager.get_run_checkpoint("run_ckpt")
+        self.assertEqual(checkpoint["run_id"], "run_ckpt")
+        self.assertEqual(checkpoint["status"], "active")
+        self.assertEqual(checkpoint["step_status"]["s1"]["pointer_id"], "ptr_1")
+        self.assertEqual(checkpoint["branch_decisions"]["s1"], ["s2"])
+        self.assertEqual(checkpoint["final_pointer_id"], "ptr_final")
+
+    def test_list_run_checkpoints_filters_by_status(self) -> None:
+        self.manager.upsert_run_checkpoint(
+            run_id="run_active",
+            started_at_utc="2026-02-23T00:00:00+00:00",
+            status="active",
+            macro_payload={"steps": []},
+            step_status={},
+            branch_decisions={},
+        )
+        self.manager.upsert_run_checkpoint(
+            run_id="run_completed",
+            started_at_utc="2026-02-23T00:00:00+00:00",
+            status="completed",
+            macro_payload={"steps": []},
+            step_status={},
+            branch_decisions={},
+        )
+        active = self.manager.list_run_checkpoints(status="active")
+        completed = self.manager.list_run_checkpoints(status="completed")
+        self.assertEqual([item["run_id"] for item in active], ["run_active"])
+        self.assertEqual([item["run_id"] for item in completed], ["run_completed"])
+
     def test_store_pointer_with_ttl_persists_lifecycle_fields(self) -> None:
         ptr = self.manager.store_and_point(raw_data="hello", summary="done", ttl_seconds=60)
         with sqlite3.connect(self.db_path) as conn:

--- a/tests/unit/test_trace_models.py
+++ b/tests/unit/test_trace_models.py
@@ -14,6 +14,7 @@ class TraceModelTests(unittest.TestCase):
         self.assertEqual(
             {event_type.value for event_type in ExecutionTraceEventType},
             {
+                "replayed",
                 "queued",
                 "approval_required",
                 "approved",
@@ -78,6 +79,15 @@ class TraceModelTests(unittest.TestCase):
                 step_id="s5",
                 tool_name="tool_a",
                 event_type=ExecutionTraceEventType.REJECTED,
+            )
+
+    def test_replayed_event_requires_output_pointer(self) -> None:
+        with self.assertRaises(ValidationError):
+            ExecutionTraceEvent(
+                run_id="run_1",
+                step_id="s6",
+                tool_name="tool_a",
+                event_type=ExecutionTraceEventType.REPLAYED,
             )
 
 


### PR DESCRIPTION
## Summary
- add persistent run checkpoints in `StateManager` (`execution_run_checkpoints`) for crash-safe recovery
- add replay-aware executor resume path via `AsyncLocalExecutor.resume_run(...)`
- add trace lifecycle `replayed` and emit replay events for checkpoint-reused steps
- persist checkpoint state throughout execution and finalize run checkpoint status (`completed` or `awaiting_approval`)
- add runtime HTTP resume endpoint: `POST /v1/eap/runs/{run_id}/resume`
- extend TS/Go SDKs with `resumeRun`/`ResumeRun`
- update roadmap/docs and mark EAP-077 complete

## Validation
- `.venv-eap072b/bin/python -m pytest -q tests/integration/test_resume_replay.py tests/integration/test_runtime_http_api.py tests/integration/test_human_approval.py tests/integration/test_execution_traces.py tests/unit/test_state_manager.py tests/unit/test_trace_models.py tests/unit/test_approval_schema.py tests/contract/test_public_api_contract.py tests/contract/test_sdk_contracts.py`
- `.venv-eap072b/bin/python -m pytest -q tests/integration/test_executor_async.py tests/integration/test_executor_retries.py tests/integration/test_reliability_failures.py tests/integration/test_branching_dag.py tests/unit/test_branching_schema.py tests/unit/test_workflow_schema.py tests/unit/test_migrations.py tests/unit/test_operational_metrics.py tests/integration/test_pointer_flow.py tests/integration/test_pointer_ttl.py`
- `npm --prefix integrations/openclaw/eap-runtime-plugin test`
