### PR TITLE
EAP-078: MCP interoperability bridge

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 ## Phase 7: Competitive Positioning + OpenClaw Interop (Next)
 
 - Execute OpenClaw integration track (plugin + skills + CI interop lane).
-- Close high-impact competitive gaps: HITL checkpoints, crash-safe resume, MCP interop.
+- Close remaining high-impact competitive gaps after HITL checkpoints, crash-safe resume, and MCP interop.
 - Publish updated competitive proof artifacts with reproducible evidence.
 - Checklist: `docs/phase7_competitive_openclaw_roadmap.md`
 
@@ -69,3 +69,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-075` interop CI lane added with pinned OpenClaw version smoke tests.
 - Phase 7 `EAP-076` HITL checkpoints added (step-level pause/approve/reject semantics with trace transitions).
 - Phase 7 `EAP-077` crash-safe resume/replay added with persisted run checkpoints and resume endpoint.
+- Phase 7 `EAP-078` MCP interoperability added via `invoke_mcp_tool` stdio bridge and runtime integration test.

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,8 +1,8 @@
 # OpenClaw Interop Spike (EAP-071)
 
-Status: Updated through EAP-077 (2026-02-23)  
+Status: Updated through EAP-078 (2026-02-23)  
 Owner: EAP maintainers  
-Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077)
+Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078)
 
 ## 1) Version Snapshot
 
@@ -105,9 +105,18 @@ Recommended sequence:
 - [x] Plugin vs skill tradeoffs documented.
 - [x] Known limits captured with concrete next actions.
 
-## 8) Recommended Next Item
+## 8) Implemented MCP Bridge (EAP-078)
 
-`EAP-077` has now been implemented in-repo with:
+`EAP-078` is now implemented in-repo with:
+- MCP stdio client bridge at `environment/mcp_client.py`
+- built-in bridge tool:
+  - `invoke_mcp_tool` (`environment/tools/mcp_tools.py`)
+  - schema export in `environment.tools` and `eap.environment.tools`
+- integration test proving runtime execution of a reference MCP tool:
+  - `tests/integration/test_mcp_interop.py`
+  - mock MCP server fixture: `tests/fixtures/mock_mcp_stdio_server.py`
+
+`EAP-077` remains implemented in-repo with:
 - OpenClaw plugin adapter package at `integrations/openclaw/eap-runtime-plugin`
 - required plugin tools:
   - `run_eap_workflow`
@@ -134,8 +143,8 @@ Recommended sequence:
   - executor `resume_run(...)`
   - HTTP resume endpoint `POST /v1/eap/runs/{run_id}/resume`
 
-Proceed to **EAP-078**:
-- Add MCP interoperability bridge/server path for reference tools.
+Proceed to **EAP-079**:
+- Add evaluation harness + scorecard with CI-published trends and regression thresholds.
 
 ## References (Primary Sources)
 

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -1,6 +1,6 @@
 # Phase 7 Competitive Roadmap (OpenClaw + Market Positioning)
 
-Status: Planned (2026-02-23)
+Status: In progress (through EAP-078, 2026-02-23)
 
 Current status:
 - [x] `EAP-071` interop spike + compatibility matrix published (`docs/openclaw_interop.md`)
@@ -10,7 +10,8 @@ Current status:
 - [x] `EAP-075` interop CI lane (`.github/workflows/openclaw-interop.yml`)
 - [x] `EAP-076` human approval checkpoints (HITL pause/approve/reject + trace transitions)
 - [x] `EAP-077` crash-safe resume and replay (checkpoint persistence + run resume API)
-- [ ] `EAP-078` onward
+- [x] `EAP-078` MCP interoperability (stdio MCP bridge tool + runtime integration test)
+- [ ] `EAP-079` onward
 
 ## Objective
 
@@ -96,6 +97,7 @@ Optional validation track:
 8. `EAP-078` MCP interoperability
    - Add MCP server export for selected EAP tools or a client bridge for MCP tools
    - Done when: at least one reference MCP tool can be executed via EAP runtime
+   - Status: complete (added `invoke_mcp_tool` bridge + `tests/integration/test_mcp_interop.py`)
 
 9. `EAP-079` Evaluation harness and scorecard
    - Deliverable: repeatable eval suite (reliability + correctness + latency)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -74,6 +74,23 @@ This document describes the built-in tools shipped in `environment.tools`.
   - Output includes `links`, `link_count`, and `truncated`.
   - Schema uses `additionalProperties: false`.
 
+## Interop tools
+
+### `invoke_mcp_tool`
+- Purpose: Call a tool exposed by an external MCP stdio server and return the MCP `tools/call` JSON result.
+- Parameters:
+  - `server_command` (`string`, required, `minLength=1`)
+  - `tool_name` (`string`, required, `minLength=1`)
+  - `tool_arguments` (`object`, optional)
+  - `timeout_seconds` (`integer`, optional, `1..120`)
+  - `working_directory` (`string`, optional, `minLength=1`)
+  - `require_listed_tool` (`boolean`, optional)
+- Notes:
+  - Initializes MCP handshake (`initialize` + `notifications/initialized`) before invocation.
+  - Can enforce that the target tool appears in `tools/list` before `tools/call`.
+  - Returns JSON text payload from MCP result so downstream steps can parse it.
+  - Schema uses `additionalProperties: false`.
+
 ## Validation contract
 
 Tool inputs are validated by `ToolRegistry.validate_arguments` before execution.

--- a/eap/environment/tools/__init__.py
+++ b/eap/environment/tools/__init__.py
@@ -1,6 +1,7 @@
 from environment.tools import (
     ANALYZE_SCHEMA,
     FETCH_SCHEMA,
+    INVOKE_MCP_TOOL_SCHEMA,
     LIST_DIRECTORY_SCHEMA,
     READ_FILE_SCHEMA,
     EXTRACT_LINKS_SCHEMA,
@@ -11,6 +12,7 @@ from environment.tools import (
     extract_links_from_url,
     fetch_json_url,
     fetch_user_data,
+    invoke_mcp_tool,
     list_local_directory,
     read_local_file,
     scrape_url,
@@ -34,4 +36,6 @@ __all__ = [
     "SCRAPE_SCHEMA",
     "FETCH_JSON_SCHEMA",
     "EXTRACT_LINKS_SCHEMA",
+    "invoke_mcp_tool",
+    "INVOKE_MCP_TOOL_SCHEMA",
 ]

--- a/eap/environment/tools/mcp_tools.py
+++ b/eap/environment/tools/mcp_tools.py
@@ -1,0 +1,3 @@
+from environment.tools.mcp_tools import INVOKE_MCP_TOOL_SCHEMA, invoke_mcp_tool
+
+__all__ = ["invoke_mcp_tool", "INVOKE_MCP_TOOL_SCHEMA"]

--- a/environment/mcp_client.py
+++ b/environment/mcp_client.py
@@ -1,0 +1,214 @@
+import json
+import os
+import select
+import shlex
+import subprocess
+import time
+from typing import Any, Dict, List, Optional
+
+
+class MCPClientError(RuntimeError):
+    """Raised when MCP transport/protocol interactions fail."""
+
+
+class MCPStdioClient:
+    """Minimal stdio MCP client for tools/list and tools/call."""
+
+    def __init__(
+        self,
+        server_command: str,
+        timeout_seconds: int = 30,
+        working_directory: Optional[str] = None,
+    ) -> None:
+        self.server_command = server_command
+        self.timeout_seconds = timeout_seconds
+        self.working_directory = working_directory
+        self._process: Optional[subprocess.Popen] = None
+        self._request_id = 0
+
+    def __enter__(self) -> "MCPStdioClient":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def start(self) -> None:
+        if self._process is not None:
+            return
+        command_parts = shlex.split(self.server_command)
+        if not command_parts:
+            raise MCPClientError("MCP server_command must not be empty.")
+
+        self._process = subprocess.Popen(
+            command_parts,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.working_directory or None,
+        )
+        self.initialize()
+
+    def close(self) -> None:
+        if self._process is None:
+            return
+        if self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=1.5)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._process.wait(timeout=1.0)
+        self._process = None
+
+    def initialize(self) -> Dict[str, Any]:
+        payload = {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "eap-mcp-bridge", "version": "0.1.0"},
+        }
+        response = self.request("initialize", payload)
+        self.notify("notifications/initialized", {})
+        return response
+
+    def list_tools(self) -> Dict[str, Any]:
+        return self.request("tools/list", {})
+
+    def call_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        return self.request(
+            "tools/call",
+            {
+                "name": tool_name,
+                "arguments": arguments,
+            },
+        )
+
+    def notify(self, method: str, params: Dict[str, Any]) -> None:
+        message = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        }
+        self._write_message(message)
+
+    def request(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        self._request_id += 1
+        request_id = self._request_id
+        message = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        self._write_message(message)
+
+        deadline = time.time() + float(self.timeout_seconds)
+        while True:
+            incoming = self._read_message(deadline=deadline)
+            if "id" not in incoming:
+                continue
+            if incoming.get("id") != request_id:
+                continue
+            if "error" in incoming:
+                raise MCPClientError(f"MCP error response: {incoming['error']}")
+            return incoming.get("result", {})
+
+    def _write_message(self, payload: Dict[str, Any]) -> None:
+        process = self._require_process()
+        if process.stdin is None:
+            raise MCPClientError("MCP process stdin is unavailable.")
+
+        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        framed = f"Content-Length: {len(raw)}\r\n\r\n".encode("utf-8") + raw
+        process.stdin.write(framed)
+        process.stdin.flush()
+
+    def _read_message(self, deadline: float) -> Dict[str, Any]:
+        process = self._require_process()
+        if process.stdout is None:
+            raise MCPClientError("MCP process stdout is unavailable.")
+
+        header = self._read_until(process.stdout.fileno(), b"\r\n\r\n", deadline)
+        if not header:
+            raise MCPClientError("MCP server closed stream before header.")
+        header_text = header.decode("utf-8", errors="replace")
+        content_length = self._parse_content_length(header_text)
+        body = self._read_exact(process.stdout.fileno(), content_length, deadline)
+        try:
+            return json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise MCPClientError(f"Failed to decode MCP message: {str(exc)}") from exc
+
+    @staticmethod
+    def _parse_content_length(header_text: str) -> int:
+        for line in header_text.split("\r\n"):
+            if line.lower().startswith("content-length:"):
+                _, value = line.split(":", 1)
+                return int(value.strip())
+        raise MCPClientError("Missing Content-Length header from MCP message.")
+
+    @staticmethod
+    def _read_until(fd: int, delimiter: bytes, deadline: float) -> bytes:
+        data = bytearray()
+        while delimiter not in data:
+            if time.time() > deadline:
+                raise MCPClientError("Timed out waiting for MCP response header.")
+            timeout = max(0.0, deadline - time.time())
+            readable, _, _ = select.select([fd], [], [], timeout)
+            if not readable:
+                continue
+            chunk = os.read(fd, 1)
+            if not chunk:
+                break
+            data.extend(chunk)
+        return bytes(data)
+
+    @staticmethod
+    def _read_exact(fd: int, byte_count: int, deadline: float) -> bytes:
+        data = bytearray()
+        while len(data) < byte_count:
+            if time.time() > deadline:
+                raise MCPClientError("Timed out waiting for MCP response body.")
+            timeout = max(0.0, deadline - time.time())
+            readable, _, _ = select.select([fd], [], [], timeout)
+            if not readable:
+                continue
+            chunk = os.read(fd, byte_count - len(data))
+            if not chunk:
+                raise MCPClientError("MCP server closed stream before full response body.")
+            data.extend(chunk)
+        return bytes(data)
+
+    def _require_process(self) -> subprocess.Popen:
+        if self._process is None:
+            raise MCPClientError("MCP client not started.")
+        if self._process.poll() is not None:
+            raise MCPClientError("MCP server process exited unexpectedly.")
+        return self._process
+
+
+def invoke_mcp_tool_stdio(
+    server_command: str,
+    tool_name: str,
+    tool_arguments: Dict[str, Any],
+    timeout_seconds: int = 30,
+    working_directory: Optional[str] = None,
+    require_listed_tool: bool = True,
+) -> Dict[str, Any]:
+    """Execute an MCP tool call through a stdio server command."""
+
+    with MCPStdioClient(
+        server_command=server_command,
+        timeout_seconds=timeout_seconds,
+        working_directory=working_directory,
+    ) as client:
+        if require_listed_tool:
+            listed = client.list_tools()
+            tools: List[Dict[str, Any]] = listed.get("tools", [])
+            available_names = {tool.get("name") for tool in tools if isinstance(tool, dict)}
+            if tool_name not in available_names:
+                raise MCPClientError(
+                    f"MCP tool '{tool_name}' is not advertised by server. "
+                    f"Available tools: {sorted(name for name in available_names if name)}"
+                )
+        return client.call_tool(tool_name=tool_name, arguments=tool_arguments)

--- a/environment/tools/__init__.py
+++ b/environment/tools/__init__.py
@@ -16,11 +16,16 @@ from .web_tools import (
     fetch_json_url,
     scrape_url,
 )
+from .mcp_tools import (
+    INVOKE_MCP_TOOL_SCHEMA,
+    invoke_mcp_tool,
+)
 
 __all__ = [
     "fetch_user_data", "analyze_data", "FETCH_SCHEMA", "ANALYZE_SCHEMA",
     "read_local_file", "write_local_file", "list_local_directory",
     "READ_FILE_SCHEMA", "WRITE_FILE_SCHEMA", "LIST_DIRECTORY_SCHEMA",
     "scrape_url", "fetch_json_url", "extract_links_from_url",
-    "SCRAPE_SCHEMA", "FETCH_JSON_SCHEMA", "EXTRACT_LINKS_SCHEMA"
+    "SCRAPE_SCHEMA", "FETCH_JSON_SCHEMA", "EXTRACT_LINKS_SCHEMA",
+    "invoke_mcp_tool", "INVOKE_MCP_TOOL_SCHEMA",
 ]

--- a/environment/tools/mcp_tools.py
+++ b/environment/tools/mcp_tools.py
@@ -1,0 +1,50 @@
+import json
+from typing import Any, Dict, Optional
+
+from environment.mcp_client import MCPClientError, invoke_mcp_tool_stdio
+
+
+def invoke_mcp_tool(
+    server_command: str,
+    tool_name: str,
+    tool_arguments: Optional[Dict[str, Any]] = None,
+    timeout_seconds: int = 30,
+    working_directory: Optional[str] = None,
+    require_listed_tool: bool = True,
+) -> str:
+    """
+    Invoke a tool exposed by an external MCP stdio server.
+
+    Returns JSON-encoded MCP tools/call result payload so downstream tools can parse it.
+    """
+    try:
+        result = invoke_mcp_tool_stdio(
+            server_command=server_command,
+            tool_name=tool_name,
+            tool_arguments=tool_arguments or {},
+            timeout_seconds=timeout_seconds,
+            working_directory=working_directory,
+            require_listed_tool=require_listed_tool,
+        )
+    except MCPClientError as exc:
+        raise RuntimeError(str(exc)) from exc
+    return json.dumps(result, sort_keys=True)
+
+
+INVOKE_MCP_TOOL_SCHEMA = {
+    "name": "invoke_mcp_tool",
+    "description": "Invoke a tool on an external MCP stdio server and return its JSON result payload.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "server_command": {"type": "string", "minLength": 1},
+            "tool_name": {"type": "string", "minLength": 1},
+            "tool_arguments": {"type": "object"},
+            "timeout_seconds": {"type": "integer", "minimum": 1, "maximum": 120},
+            "working_directory": {"type": "string", "minLength": 1},
+            "require_listed_tool": {"type": "boolean"},
+        },
+        "required": ["server_command", "tool_name"],
+        "additionalProperties": False,
+    },
+}

--- a/tests/fixtures/mock_mcp_stdio_server.py
+++ b/tests/fixtures/mock_mcp_stdio_server.py
@@ -1,0 +1,114 @@
+import json
+import sys
+from typing import Any, Dict, Optional
+
+
+def _read_message() -> Optional[Dict[str, Any]]:
+    headers: Dict[str, str] = {}
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        decoded = line.decode("utf-8", errors="replace").strip()
+        if ":" in decoded:
+            key, value = decoded.split(":", 1)
+            headers[key.strip().lower()] = value.strip()
+
+    try:
+        content_length = int(headers.get("content-length", "0"))
+    except ValueError:
+        content_length = 0
+    if content_length <= 0:
+        return None
+
+    payload = sys.stdin.buffer.read(content_length)
+    if not payload:
+        return None
+    return json.loads(payload.decode("utf-8"))
+
+
+def _write_message(payload: Dict[str, Any]) -> None:
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    sys.stdout.buffer.write(f"Content-Length: {len(encoded)}\r\n\r\n".encode("utf-8"))
+    sys.stdout.buffer.write(encoded)
+    sys.stdout.buffer.flush()
+
+
+def _reply(request: Dict[str, Any], result: Dict[str, Any]) -> None:
+    if "id" not in request:
+        return
+    _write_message({"jsonrpc": "2.0", "id": request["id"], "result": result})
+
+
+def _reply_error(request: Dict[str, Any], code: int, message: str) -> None:
+    if "id" not in request:
+        return
+    _write_message({"jsonrpc": "2.0", "id": request["id"], "error": {"code": code, "message": message}})
+
+
+def main() -> int:
+    while True:
+        request = _read_message()
+        if request is None:
+            return 0
+
+        method = request.get("method")
+        params = request.get("params", {})
+
+        if method == "initialize":
+            _reply(
+                request,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "mock-mcp-stdio", "version": "0.0.1"},
+                },
+            )
+            continue
+
+        if method == "notifications/initialized":
+            continue
+
+        if method == "tools/list":
+            _reply(
+                request,
+                {
+                    "tools": [
+                        {
+                            "name": "echo_upper",
+                            "description": "Return uppercase text.",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {"text": {"type": "string"}},
+                                "required": ["text"],
+                                "additionalProperties": False,
+                            },
+                        }
+                    ]
+                },
+            )
+            continue
+
+        if method == "tools/call":
+            tool_name = params.get("name")
+            arguments = params.get("arguments", {})
+            if tool_name != "echo_upper":
+                _reply_error(request, -32602, f"Unknown tool '{tool_name}'.")
+                continue
+            text = str(arguments.get("text", ""))
+            _reply(
+                request,
+                {
+                    "content": [{"type": "text", "text": text.upper()}],
+                    "isError": False,
+                },
+            )
+            continue
+
+        _reply_error(request, -32601, f"Unknown method '{method}'.")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_mcp_interop.py
+++ b/tests/integration/test_mcp_interop.py
@@ -1,0 +1,87 @@
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+import requests
+
+from eap.environment import AsyncLocalExecutor, ToolRegistry
+from eap.environment.tools import INVOKE_MCP_TOOL_SCHEMA, invoke_mcp_tool
+from eap.protocol import StateManager
+from eap.runtime import EAPRuntimeHTTPServer
+
+
+class MCPInteropIntegrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        fd, self.db_path = tempfile.mkstemp(prefix="eap-mcp-interop-", suffix=".db")
+        os.close(fd)
+
+        self.state_manager = StateManager(db_path=self.db_path)
+        registry = ToolRegistry()
+        registry.register("invoke_mcp_tool", invoke_mcp_tool, INVOKE_MCP_TOOL_SCHEMA)
+        executor = AsyncLocalExecutor(self.state_manager, registry)
+
+        self.server = EAPRuntimeHTTPServer(
+            executor=executor,
+            state_manager=self.state_manager,
+            required_bearer_token="secret-token",
+        ).start()
+        time.sleep(0.05)
+
+        self.mock_server_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "fixtures", "mock_mcp_stdio_server.py")
+        )
+
+    def tearDown(self) -> None:
+        self.server.stop()
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_runtime_executes_reference_mcp_tool(self) -> None:
+        self.assertTrue(os.path.exists(self.mock_server_path))
+        server_command = f"{sys.executable} -u {self.mock_server_path}"
+        execute_response = requests.post(
+            f"{self.server.base_url}/v1/eap/macro/execute",
+            headers={"Authorization": "Bearer secret-token"},
+            json={
+                "macro": {
+                    "steps": [
+                        {
+                            "step_id": "step_mcp",
+                            "tool_name": "invoke_mcp_tool",
+                            "arguments": {
+                                "server_command": server_command,
+                                "tool_name": "echo_upper",
+                                "tool_arguments": {"text": "hello mcp"},
+                                "timeout_seconds": 10,
+                                "require_listed_tool": True,
+                            },
+                        }
+                    ]
+                }
+            },
+            timeout=10,
+        )
+        self.assertEqual(execute_response.status_code, 200)
+        body = execute_response.json()
+        pointer_id = body["pointer_id"]
+        raw_output = self.state_manager.retrieve(pointer_id)
+        payload = json.loads(raw_output)
+        self.assertEqual(payload["content"][0]["type"], "text")
+        self.assertEqual(payload["content"][0]["text"], "HELLO MCP")
+        self.assertFalse(payload.get("isError", False))
+
+        run_id = body["metadata"]["execution_run_id"]
+        run_response = requests.get(
+            f"{self.server.base_url}/v1/eap/runs/{run_id}",
+            headers={"Authorization": "Bearer secret-token"},
+            timeout=5,
+        )
+        self.assertEqual(run_response.status_code, 200)
+        self.assertEqual(run_response.json()["status"], "succeeded")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_tool_schemas.py
+++ b/tests/unit/test_tool_schemas.py
@@ -6,6 +6,7 @@ from eap.environment.tools import (
     ANALYZE_SCHEMA,
     EXTRACT_LINKS_SCHEMA,
     FETCH_JSON_SCHEMA,
+    INVOKE_MCP_TOOL_SCHEMA,
     LIST_DIRECTORY_SCHEMA,
     READ_FILE_SCHEMA,
     SCRAPE_SCHEMA,
@@ -13,6 +14,7 @@ from eap.environment.tools import (
     analyze_data,
     extract_links_from_url,
     fetch_json_url,
+    invoke_mcp_tool,
     list_local_directory,
     read_local_file,
     scrape_url,
@@ -30,6 +32,7 @@ class ToolSchemaValidationTest(unittest.TestCase):
         self.registry.register("scrape_url", scrape_url, SCRAPE_SCHEMA)
         self.registry.register("fetch_json_url", fetch_json_url, FETCH_JSON_SCHEMA)
         self.registry.register("extract_links_from_url", extract_links_from_url, EXTRACT_LINKS_SCHEMA)
+        self.registry.register("invoke_mcp_tool", invoke_mcp_tool, INVOKE_MCP_TOOL_SCHEMA)
 
     def test_valid_payload_passes_validation(self) -> None:
         self.registry.validate_arguments("analyze_data", {"raw_data": "payload", "focus": "summary"})
@@ -74,6 +77,28 @@ class ToolSchemaValidationTest(unittest.TestCase):
     def test_web_schema_string_length_constraint_is_enforced(self) -> None:
         with self.assertRaises(InputValidationError):
             self.registry.validate_arguments("fetch_json_url", {"url": ""})
+
+    def test_mcp_schema_enforces_timeout_bounds(self) -> None:
+        with self.assertRaises(InputValidationError):
+            self.registry.validate_arguments(
+                "invoke_mcp_tool",
+                {
+                    "server_command": "python -u /tmp/server.py",
+                    "tool_name": "echo",
+                    "timeout_seconds": 0,
+                },
+            )
+
+    def test_mcp_schema_rejects_non_object_tool_arguments(self) -> None:
+        with self.assertRaises(InputValidationError):
+            self.registry.validate_arguments(
+                "invoke_mcp_tool",
+                {
+                    "server_command": "python -u /tmp/server.py",
+                    "tool_name": "echo",
+                    "tool_arguments": "not-an-object",
+                },
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a minimal stdio MCP client bridge in environment/mcp_client.py
- add built-in invoke_mcp_tool with strict schema export in both tool namespaces
- add integration test proving a reference MCP tool executes via EAP runtime
- update tool docs and Phase 7 roadmap status to mark EAP-078 complete

## Validation
- /Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python -m pytest -q tests/unit/test_tool_schemas.py tests/unit/test_tools.py
- /Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python -m pytest -q tests/integration/test_mcp_interop.py tests/integration/test_runtime_http_api.py