### PR TITLE
EAP-080: vertical starter packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ streamlit run app.py
 - Check **Data Inspector** for pointer payloads
 - Check **Execution Trace** for step timing/retries/errors
 
+6. Try starter packs
+
+```bash
+python -m starter_packs.research_assistant --question "What are launch risks?"
+python -m starter_packs.doc_ops --focus "summarize priorities and actions"
+python -m starter_packs.local_etl
+```
+
 ## Programmatic Example
 
 ```python
@@ -136,5 +144,9 @@ python3 -m build
 - `docs/eap_proof_sheet.md`
 - `docs/phase7_competitive_openclaw_roadmap.md`
 - `docs/openclaw_interop.md`
+- `docs/starter_packs/README.md`
+- `docs/starter_packs/research_assistant.md`
+- `docs/starter_packs/doc_ops.md`
+- `docs/starter_packs/local_etl.md`
 - `integrations/openclaw/eap-runtime-plugin/README.md`
 - `integrations/openclaw/eap-runtime-plugin/skills/README.md`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,3 +71,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-077` crash-safe resume/replay added with persisted run checkpoints and resume endpoint.
 - Phase 7 `EAP-078` MCP interoperability added via `invoke_mcp_tool` stdio bridge and runtime integration test.
 - Phase 7 `EAP-079` evaluation harness shipped with CI scorecard artifacts and regression threshold gate.
+- Phase 7 `EAP-080` vertical starter packs added with runnable walkthroughs and smoke tests.

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,8 +1,8 @@
 # OpenClaw Interop Spike (EAP-071)
 
-Status: Updated through EAP-079 (2026-02-23)  
+Status: Updated through EAP-080 (2026-02-23)  
 Owner: EAP maintainers  
-Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079)
+Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080)
 
 ## 1) Version Snapshot
 
@@ -157,8 +157,26 @@ Recommended sequence:
   - fails on regression threshold violations
 - harness reference doc: `docs/evaluation_harness.md`
 
-Proceed to **EAP-080**:
-- Add vertical starter packs with smoke tests + walkthrough docs.
+`EAP-080` follow-up is now complete (see section 10 below).
+
+## 10) Implemented Vertical Starter Packs (EAP-080)
+
+`EAP-080` is now implemented in-repo with:
+- runnable starter pack modules:
+  - `starter_packs/research_assistant.py`
+  - `starter_packs/doc_ops.py`
+  - `starter_packs/local_etl.py`
+- smoke coverage:
+  - `tests/integration/test_starter_packs.py`
+- walkthrough docs and fixtures:
+  - `docs/starter_packs/README.md`
+  - `docs/starter_packs/research_assistant.md`
+  - `docs/starter_packs/doc_ops.md`
+  - `docs/starter_packs/local_etl.md`
+  - `docs/starter_packs/fixtures/*`
+
+Proceed to **EAP-081**:
+- Add operator telemetry pack with dashboard-ready retry/saturation/failure/latency views.
 
 ## References (Primary Sources)
 

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -1,6 +1,6 @@
 # Phase 7 Competitive Roadmap (OpenClaw + Market Positioning)
 
-Status: In progress (through EAP-079, 2026-02-23)
+Status: In progress (through EAP-080, 2026-02-23)
 
 Current status:
 - [x] `EAP-071` interop spike + compatibility matrix published (`docs/openclaw_interop.md`)
@@ -12,7 +12,8 @@ Current status:
 - [x] `EAP-077` crash-safe resume and replay (checkpoint persistence + run resume API)
 - [x] `EAP-078` MCP interoperability (stdio MCP bridge tool + runtime integration test)
 - [x] `EAP-079` evaluation harness + scorecard (CI artifact + regression gate)
-- [ ] `EAP-080` onward
+- [x] `EAP-080` vertical starter packs (research assistant, doc ops, local ETL)
+- [ ] `EAP-081` onward
 
 ## Objective
 
@@ -110,6 +111,7 @@ Optional validation track:
 10. `EAP-080` Vertical starter packs
     - Deliverable: opinionated templates (research assistant, doc ops, local ETL)
     - Done when: each template has green smoke tests and runnable walkthrough docs
+    - Status: complete (`starter_packs/*`, `tests/integration/test_starter_packs.py`, `docs/starter_packs/*`)
 
 11. `EAP-081` Operator telemetry pack
     - Deliverable: first-party dashboards/charts for retries, saturation, fail reasons, and step latency percentiles

--- a/docs/starter_packs/README.md
+++ b/docs/starter_packs/README.md
@@ -1,0 +1,26 @@
+# Starter Packs (EAP-080)
+
+These starter packs are opinionated templates for common workflows:
+
+1. Research assistant
+2. Doc ops
+3. Local ETL
+
+Each pack has:
+- runnable module command
+- local fixture input
+- integration smoke test coverage
+
+## Quick Run
+
+```bash
+python -m starter_packs.research_assistant --question "What are launch risks?"
+python -m starter_packs.doc_ops --focus "summarize priorities and actions"
+python -m starter_packs.local_etl
+```
+
+## Walkthroughs
+
+- `docs/starter_packs/research_assistant.md`
+- `docs/starter_packs/doc_ops.md`
+- `docs/starter_packs/local_etl.md`

--- a/docs/starter_packs/doc_ops.md
+++ b/docs/starter_packs/doc_ops.md
@@ -1,0 +1,23 @@
+# Doc Ops Starter Pack
+
+## Goal
+
+Turn local notes into a concise report/action summary using:
+- `read_local_file`
+- `analyze_data`
+- `write_local_file`
+
+## Run
+
+```bash
+python -m starter_packs.doc_ops \
+  --input-file docs/starter_packs/fixtures/doc_ops_notes.md \
+  --output-file artifacts/starter_pack_doc_ops/report.md \
+  --focus "summarize risks and next actions"
+```
+
+## Expected Result
+
+- Command prints JSON with `output_file`, `report`, `run_id`, and `pointer_id`.
+- Output file exists at `artifacts/starter_pack_doc_ops/report.md`.
+- Output report contains `Analysis complete.`

--- a/docs/starter_packs/fixtures/doc_ops_notes.md
+++ b/docs/starter_packs/fixtures/doc_ops_notes.md
@@ -1,0 +1,6 @@
+# Weekly Ops Notes
+
+- Customer success backlog is up 18%.
+- Two incidents were caused by stale integration credentials.
+- Team asks for a tighter checklist before release cut.
+- Next review meeting is Friday 10:00 AM.

--- a/docs/starter_packs/fixtures/local_etl_orders.jsonl
+++ b/docs/starter_packs/fixtures/local_etl_orders.jsonl
@@ -1,0 +1,4 @@
+{"order_id":"o-1001","region":"us-east","amount":120.5}
+{"order_id":"o-1002","region":"us-west","amount":85.25}
+{"order_id":"o-1003","region":"us-east","amount":40}
+{"order_id":"o-1004","region":"eu-central","amount":230}

--- a/docs/starter_packs/fixtures/research_source.html
+++ b/docs/starter_packs/fixtures/research_source.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Northstar AI Launch Notes</title>
+  </head>
+  <body>
+    <h1>Northstar AI Product Launch</h1>
+    <p>Northstar AI launches in two regions during Q2 with a staged rollout plan.</p>
+    <p>Primary risks include data-quality drift and onboarding delays.</p>
+    <p>Success metric: activate 50 pilot customers and keep support response under 6 hours.</p>
+  </body>
+</html>

--- a/docs/starter_packs/local_etl.md
+++ b/docs/starter_packs/local_etl.md
@@ -1,0 +1,25 @@
+# Local ETL Starter Pack
+
+## Goal
+
+Aggregate local JSONL sales data into a compact metrics JSON using:
+- `read_local_file`
+- custom transform tool: `transform_sales_jsonl`
+- `write_local_file`
+
+## Run
+
+```bash
+python -m starter_packs.local_etl \
+  --input-file docs/starter_packs/fixtures/local_etl_orders.jsonl \
+  --output-file artifacts/starter_pack_local_etl/aggregates.json
+```
+
+## Expected Result
+
+- Command prints JSON with `metrics`, `run_id`, and `pointer_id`.
+- Output file exists at `artifacts/starter_pack_local_etl/aggregates.json`.
+- Output JSON includes:
+  - `record_count`
+  - `total_amount`
+  - `region_totals`

--- a/docs/starter_packs/research_assistant.md
+++ b/docs/starter_packs/research_assistant.md
@@ -1,0 +1,28 @@
+# Research Assistant Starter Pack
+
+## Goal
+
+Answer a focused question from a source HTML document using:
+- `scrape_url`
+- `analyze_data`
+
+## Run
+
+```bash
+python -m starter_packs.research_assistant \
+  --question "What risks are called out in the launch?" \
+  --html-file docs/starter_packs/fixtures/research_source.html
+```
+
+## Expected Result
+
+Command prints JSON with:
+- `question`
+- `source_url`
+- `answer`
+- `run_id`
+- `pointer_id`
+
+The `answer` field should include:
+- `Analysis complete.`
+- the focus question text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["agent*", "environment*", "protocol*", "eap*"]
+include = ["agent*", "environment*", "protocol*", "eap*", "starter_packs*"]
 exclude = ["examples*"]
 
 [tool.pytest.ini_options]
@@ -44,4 +44,4 @@ markers = [
 
 [tool.coverage.run]
 branch = true
-source = ["protocol", "agent", "environment", "eap"]
+source = ["protocol", "agent", "environment", "eap", "starter_packs"]

--- a/starter_packs/__init__.py
+++ b/starter_packs/__init__.py
@@ -1,0 +1,2 @@
+"""Opinionated starter packs for common EAP workflow patterns."""
+

--- a/starter_packs/doc_ops.py
+++ b/starter_packs/doc_ops.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from eap.environment import AsyncLocalExecutor, ToolRegistry
+from eap.environment.tools import (
+    ANALYZE_SCHEMA,
+    READ_FILE_SCHEMA,
+    WRITE_FILE_SCHEMA,
+    analyze_data,
+    read_local_file,
+    write_local_file,
+)
+from eap.protocol import BatchedMacroRequest, StateManager, ToolCall
+
+
+def run_doc_ops(
+    input_file: str,
+    output_file: str,
+    focus: str = "extract concise summary and action items",
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    input_path = Path(input_file).resolve()
+    if not input_path.exists():
+        raise FileNotFoundError(f"Doc ops input file does not exist: {input_path}")
+
+    output_path = Path(output_file).resolve()
+
+    owns_db = db_path is None
+    if owns_db:
+        fd, generated_path = tempfile.mkstemp(prefix="eap-starter-docops-", suffix=".db")
+        os.close(fd)
+        db_path = generated_path
+
+    state_manager = StateManager(db_path=db_path)
+    registry = ToolRegistry()
+    registry.register("read_local_file", read_local_file, READ_FILE_SCHEMA)
+    registry.register("analyze_data", analyze_data, ANALYZE_SCHEMA)
+    registry.register("write_local_file", write_local_file, WRITE_FILE_SCHEMA)
+    executor = AsyncLocalExecutor(state_manager, registry)
+
+    try:
+        macro = BatchedMacroRequest(
+            steps=[
+                ToolCall(
+                    step_id="read_source_doc",
+                    tool_name="read_local_file",
+                    arguments={"file_path": str(input_path)},
+                ),
+                ToolCall(
+                    step_id="build_doc_summary",
+                    tool_name="analyze_data",
+                    arguments={
+                        "raw_data": "$step:read_source_doc",
+                        "focus": focus,
+                    },
+                ),
+                ToolCall(
+                    step_id="write_report",
+                    tool_name="write_local_file",
+                    arguments={
+                        "file_path": str(output_path),
+                        "content": "$step:build_doc_summary",
+                        "mode": "overwrite",
+                        "create_directories": True,
+                    },
+                ),
+            ]
+        )
+        result = asyncio.run(executor.execute_macro(macro))
+        report = output_path.read_text(encoding="utf-8")
+        return {
+            "input_file": str(input_path),
+            "output_file": str(output_path),
+            "focus": focus,
+            "report": report,
+            "run_id": result["metadata"]["execution_run_id"],
+            "pointer_id": result["pointer_id"],
+        }
+    finally:
+        if owns_db and db_path and os.path.exists(db_path):
+            os.remove(db_path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the doc-ops starter pack on a local markdown/text file.")
+    parser.add_argument(
+        "--input-file",
+        default="docs/starter_packs/fixtures/doc_ops_notes.md",
+        help="Path to input markdown/text file.",
+    )
+    parser.add_argument(
+        "--output-file",
+        default="artifacts/starter_pack_doc_ops/report.md",
+        help="Path for generated summary/action report.",
+    )
+    parser.add_argument(
+        "--focus",
+        default="extract concise summary and action items",
+        help="Analysis focus instruction.",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="Optional SQLite state DB path (temporary by default).",
+    )
+    args = parser.parse_args()
+    payload = run_doc_ops(
+        input_file=args.input_file,
+        output_file=args.output_file,
+        focus=args.focus,
+        db_path=args.db_path,
+    )
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/starter_packs/local_etl.py
+++ b/starter_packs/local_etl.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from eap.environment import AsyncLocalExecutor, ToolRegistry
+from eap.environment.tools import (
+    READ_FILE_SCHEMA,
+    WRITE_FILE_SCHEMA,
+    read_local_file,
+    write_local_file,
+)
+from eap.protocol import BatchedMacroRequest, StateManager, ToolCall
+
+
+def transform_sales_jsonl(raw_data: str) -> str:
+    rows = [line.strip() for line in raw_data.splitlines() if line.strip()]
+    parsed_rows = [json.loads(row) for row in rows]
+    total_amount = sum(float(row.get("amount", 0.0)) for row in parsed_rows)
+    region_totals: Dict[str, float] = {}
+    for row in parsed_rows:
+        region = str(row.get("region", "unknown"))
+        region_totals[region] = region_totals.get(region, 0.0) + float(row.get("amount", 0.0))
+
+    payload = {
+        "record_count": len(parsed_rows),
+        "total_amount": round(total_amount, 2),
+        "region_totals": {key: round(value, 2) for key, value in sorted(region_totals.items())},
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+TRANSFORM_SALES_SCHEMA = {
+    "name": "transform_sales_jsonl",
+    "description": "Transforms JSONL sales records into aggregate metrics.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "raw_data": {"type": "string"},
+        },
+        "required": ["raw_data"],
+        "additionalProperties": False,
+    },
+}
+
+
+def run_local_etl(
+    input_file: str,
+    output_file: str,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    input_path = Path(input_file).resolve()
+    if not input_path.exists():
+        raise FileNotFoundError(f"ETL input file does not exist: {input_path}")
+
+    output_path = Path(output_file).resolve()
+
+    owns_db = db_path is None
+    if owns_db:
+        fd, generated_path = tempfile.mkstemp(prefix="eap-starter-etl-", suffix=".db")
+        os.close(fd)
+        db_path = generated_path
+
+    state_manager = StateManager(db_path=db_path)
+    registry = ToolRegistry()
+    registry.register("read_local_file", read_local_file, READ_FILE_SCHEMA)
+    registry.register("transform_sales_jsonl", transform_sales_jsonl, TRANSFORM_SALES_SCHEMA)
+    registry.register("write_local_file", write_local_file, WRITE_FILE_SCHEMA)
+    executor = AsyncLocalExecutor(state_manager, registry)
+
+    try:
+        macro = BatchedMacroRequest(
+            steps=[
+                ToolCall(
+                    step_id="read_input_jsonl",
+                    tool_name="read_local_file",
+                    arguments={"file_path": str(input_path)},
+                ),
+                ToolCall(
+                    step_id="transform_payload",
+                    tool_name="transform_sales_jsonl",
+                    arguments={"raw_data": "$step:read_input_jsonl"},
+                ),
+                ToolCall(
+                    step_id="write_output_json",
+                    tool_name="write_local_file",
+                    arguments={
+                        "file_path": str(output_path),
+                        "content": "$step:transform_payload",
+                        "mode": "overwrite",
+                        "create_directories": True,
+                    },
+                ),
+            ]
+        )
+        result = asyncio.run(executor.execute_macro(macro))
+        output_payload = json.loads(output_path.read_text(encoding="utf-8"))
+        return {
+            "input_file": str(input_path),
+            "output_file": str(output_path),
+            "metrics": output_payload,
+            "run_id": result["metadata"]["execution_run_id"],
+            "pointer_id": result["pointer_id"],
+        }
+    finally:
+        if owns_db and db_path and os.path.exists(db_path):
+            os.remove(db_path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the local ETL starter pack on JSONL input.")
+    parser.add_argument(
+        "--input-file",
+        default="docs/starter_packs/fixtures/local_etl_orders.jsonl",
+        help="Path to source JSONL file.",
+    )
+    parser.add_argument(
+        "--output-file",
+        default="artifacts/starter_pack_local_etl/aggregates.json",
+        help="Path for transformed JSON metrics output.",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="Optional SQLite state DB path (temporary by default).",
+    )
+    args = parser.parse_args()
+    payload = run_local_etl(
+        input_file=args.input_file,
+        output_file=args.output_file,
+        db_path=args.db_path,
+    )
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/starter_packs/research_assistant.py
+++ b/starter_packs/research_assistant.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import tempfile
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from eap.environment import AsyncLocalExecutor, ToolRegistry
+from eap.environment.tools import ANALYZE_SCHEMA, SCRAPE_SCHEMA, analyze_data, scrape_url
+from eap.protocol import BatchedMacroRequest, StateManager, ToolCall
+
+
+class _SilentHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format: str, *args) -> None:  # noqa: A003
+        return
+
+
+def run_research_assistant(
+    question: str,
+    html_file: str,
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    html_path = Path(html_file).resolve()
+    if not html_path.exists():
+        raise FileNotFoundError(f"Research source file does not exist: {html_path}")
+
+    owns_db = db_path is None
+    if owns_db:
+        fd, generated_path = tempfile.mkstemp(prefix="eap-starter-research-", suffix=".db")
+        os.close(fd)
+        db_path = generated_path
+
+    source_dir = str(html_path.parent)
+    handler_cls = partial(_SilentHandler, directory=source_dir)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    source_url = f"http://127.0.0.1:{server.server_address[1]}/{html_path.name}"
+    state_manager = StateManager(db_path=db_path)
+    registry = ToolRegistry()
+    registry.register("scrape_url", scrape_url, SCRAPE_SCHEMA)
+    registry.register("analyze_data", analyze_data, ANALYZE_SCHEMA)
+    executor = AsyncLocalExecutor(state_manager, registry)
+
+    try:
+        macro = BatchedMacroRequest(
+            steps=[
+                ToolCall(
+                    step_id="collect_source_text",
+                    tool_name="scrape_url",
+                    arguments={"url": source_url},
+                ),
+                ToolCall(
+                    step_id="answer_question",
+                    tool_name="analyze_data",
+                    arguments={
+                        "raw_data": "$step:collect_source_text",
+                        "focus": question,
+                    },
+                ),
+            ]
+        )
+        result = asyncio.run(executor.execute_macro(macro))
+        answer = state_manager.retrieve(result["pointer_id"])
+        return {
+            "question": question,
+            "source_url": source_url,
+            "answer": answer,
+            "run_id": result["metadata"]["execution_run_id"],
+            "pointer_id": result["pointer_id"],
+        }
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=1.0)
+        if owns_db and db_path and os.path.exists(db_path):
+            os.remove(db_path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the research-assistant starter pack over a local HTML source."
+    )
+    parser.add_argument(
+        "--question",
+        required=True,
+        help="Research question to answer from the source page.",
+    )
+    parser.add_argument(
+        "--html-file",
+        default="docs/starter_packs/fixtures/research_source.html",
+        help="Path to local HTML file used as the source corpus.",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="Optional SQLite state DB path (temporary by default).",
+    )
+    args = parser.parse_args()
+    payload = run_research_assistant(
+        question=args.question,
+        html_file=args.html_file,
+        db_path=args.db_path,
+    )
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_starter_packs.py
+++ b/tests/integration/test_starter_packs.py
@@ -1,0 +1,132 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from starter_packs.doc_ops import run_doc_ops
+from starter_packs.local_etl import run_local_etl
+from starter_packs.research_assistant import run_research_assistant
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class StarterPacksIntegrationTest(unittest.TestCase):
+    def test_research_assistant_smoke(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="eap-starter-research-") as temp_dir:
+            html_path = Path(temp_dir) / "source.html"
+            html_path.write_text(
+                (
+                    "<html><body><h1>Launch Plan</h1>"
+                    "<p>Risk: delayed onboarding</p>"
+                    "<p>Risk: data quality drift</p>"
+                    "</body></html>"
+                ),
+                encoding="utf-8",
+            )
+            result = run_research_assistant(
+                question="list risks",
+                html_file=str(html_path),
+            )
+            self.assertIn("Analysis complete.", result["answer"])
+            self.assertIn("list risks", result["answer"])
+            self.assertIn("run_id", result)
+            self.assertIn("pointer_id", result)
+
+    def test_doc_ops_smoke(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="eap-starter-docops-") as temp_dir:
+            input_path = Path(temp_dir) / "notes.md"
+            output_path = Path(temp_dir) / "report.md"
+            input_path.write_text("- Blockers: access provisioning\n- Next: tighten release checklist\n", encoding="utf-8")
+            result = run_doc_ops(
+                input_file=str(input_path),
+                output_file=str(output_path),
+                focus="summarize blockers and next actions",
+            )
+            self.assertTrue(output_path.exists())
+            self.assertIn("Analysis complete.", result["report"])
+            self.assertIn("summarize blockers and next actions", result["report"])
+
+    def test_local_etl_smoke(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="eap-starter-etl-") as temp_dir:
+            input_path = Path(temp_dir) / "orders.jsonl"
+            output_path = Path(temp_dir) / "aggregates.json"
+            input_path.write_text(
+                "\n".join(
+                    [
+                        '{"order_id":"1","region":"us","amount":100}',
+                        '{"order_id":"2","region":"eu","amount":50.5}',
+                        '{"order_id":"3","region":"us","amount":25}',
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            result = run_local_etl(
+                input_file=str(input_path),
+                output_file=str(output_path),
+            )
+            self.assertTrue(output_path.exists())
+            self.assertEqual(result["metrics"]["record_count"], 3)
+            self.assertEqual(result["metrics"]["total_amount"], 175.5)
+            self.assertEqual(result["metrics"]["region_totals"]["us"], 125.0)
+            self.assertEqual(result["metrics"]["region_totals"]["eu"], 50.5)
+
+    def test_walkthrough_commands_are_runnable(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="eap-starter-cli-") as temp_dir:
+            doc_ops_output = Path(temp_dir) / "doc_ops_report.md"
+            etl_output = Path(temp_dir) / "etl_output.json"
+
+            commands = [
+                [
+                    sys.executable,
+                    "-m",
+                    "starter_packs.research_assistant",
+                    "--question",
+                    "what risks are in this source?",
+                    "--html-file",
+                    "docs/starter_packs/fixtures/research_source.html",
+                ],
+                [
+                    sys.executable,
+                    "-m",
+                    "starter_packs.doc_ops",
+                    "--input-file",
+                    "docs/starter_packs/fixtures/doc_ops_notes.md",
+                    "--output-file",
+                    str(doc_ops_output),
+                    "--focus",
+                    "summarize key actions",
+                ],
+                [
+                    sys.executable,
+                    "-m",
+                    "starter_packs.local_etl",
+                    "--input-file",
+                    "docs/starter_packs/fixtures/local_etl_orders.jsonl",
+                    "--output-file",
+                    str(etl_output),
+                ],
+            ]
+
+            for command in commands:
+                completed = subprocess.run(
+                    command,
+                    cwd=str(REPO_ROOT),
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(completed.returncode, 0, msg=completed.stdout + completed.stderr)
+                payload = json.loads(completed.stdout)
+                self.assertIn("run_id", payload)
+                self.assertIn("pointer_id", payload)
+
+            self.assertTrue(doc_ops_output.exists())
+            self.assertTrue(etl_output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add three opinionated starter packs in `starter_packs/`:
  - `research_assistant.py`
  - `doc_ops.py`
  - `local_etl.py`
- add runnable walkthrough docs and local fixtures under `docs/starter_packs/`
- add integration smoke suite `tests/integration/test_starter_packs.py` covering function and CLI execution paths
- update roadmap/docs status to mark EAP-080 complete and advance next item to EAP-081
- include `starter_packs` in packaging discovery + coverage sources in `pyproject.toml`

## Validation
- /Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python -m pytest -q tests/integration/test_starter_packs.py
- /Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python -m pytest -q tests/integration/test_starter_packs.py tests/integration/test_eval_scorecard.py tests/integration/test_mcp_interop.py tests/perf
- /Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python -m starter_packs.research_assistant --question "What risks are called out?" --html-file docs/starter_packs/fixtures/research_source.html
- /Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python -m starter_packs.doc_ops --input-file docs/starter_packs/fixtures/doc_ops_notes.md --output-file /tmp/eap-docops-report.md --focus "summarize key actions"
- /Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python -m starter_packs.local_etl --input-file docs/starter_packs/fixtures/local_etl_orders.jsonl --output-file /tmp/eap-etl-output.json