### PR TITLE
EAP-081: operator telemetry pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ python3 -m pytest -q
 pre-commit run --all-files
 python3 scripts/migrate_state_db.py --db-path agent_state.db --dry-run
 python3 scripts/export_metrics.py --db-path agent_state.db --output metrics/latest.json
+python3 scripts/export_telemetry_pack.py --db-path agent_state.db --output-dir artifacts/telemetry
 ./scripts/interop_openclaw_smoke.sh v2026.2.22
 python3 -m build
 ```
@@ -128,6 +129,7 @@ python3 -m build
 - `docs/v1_stabilization_checklist.md`
 - `docs/migrations.md`
 - `docs/observability.md`
+- `docs/operator_telemetry_pack.md`
 - `docs/maintainer_runbook.md`
 - `SECURITY.md`
 - `CONTRIBUTING.md`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,3 +72,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-078` MCP interoperability added via `invoke_mcp_tool` stdio bridge and runtime integration test.
 - Phase 7 `EAP-079` evaluation harness shipped with CI scorecard artifacts and regression threshold gate.
 - Phase 7 `EAP-080` vertical starter packs added with runnable walkthroughs and smoke tests.
+- Phase 7 `EAP-081` operator telemetry pack added with dashboard-ready diagnostics and failed-run triage artifacts.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -32,3 +32,26 @@ Snapshot fields include:
 - conversation session/turn counts
 
 This path is intended for operational diagnostics and periodic health snapshots.
+
+## Telemetry Pack Export
+
+For dashboard-ready diagnostics with retries, saturation, failure reasons, and latency percentiles:
+
+```bash
+python3 scripts/export_telemetry_pack.py \
+  --db-path agent_state.db \
+  --output-dir artifacts/telemetry
+```
+
+This writes structured artifacts plus a triage report:
+
+- `overview.json`
+- `retries.json`
+- `fail_reasons.json`
+- `latency_percentiles.json`
+- `saturation.json`
+- `failed_run_diagnostics.json`
+- `operator_report.md`
+- `manifest.json`
+
+Use `failed_run_diagnostics.json` and `operator_report.md` as the first stop for root-cause analysis.

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,8 +1,8 @@
 # OpenClaw Interop Spike (EAP-071)
 
-Status: Updated through EAP-080 (2026-02-23)  
+Status: Updated through EAP-081 (2026-02-23)  
 Owner: EAP maintainers  
-Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080)
+Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081)
 
 ## 1) Version Snapshot
 
@@ -175,8 +175,22 @@ Recommended sequence:
   - `docs/starter_packs/local_etl.md`
   - `docs/starter_packs/fixtures/*`
 
-Proceed to **EAP-081**:
-- Add operator telemetry pack with dashboard-ready retry/saturation/failure/latency views.
+`EAP-081` follow-up is now complete (see section 11 below).
+
+## 11) Implemented Operator Telemetry Pack (EAP-081)
+
+`EAP-081` is now implemented in-repo with:
+- telemetry exporter:
+  - `scripts/export_telemetry_pack.py`
+- persisted run diagnostics for saturation and approval metadata:
+  - `execution_run_diagnostics` store via `StateManager`
+- operator-focused telemetry guide:
+  - `docs/operator_telemetry_pack.md`
+- integration validation:
+  - `tests/integration/test_telemetry_pack.py`
+
+Proceed to **EAP-082**:
+- refresh competitive proof sheet with interop + eval + telemetry evidence.
 
 ## References (Primary Sources)
 

--- a/docs/operator_telemetry_pack.md
+++ b/docs/operator_telemetry_pack.md
@@ -1,0 +1,53 @@
+# Operator Telemetry Pack (EAP-081)
+
+This pack exports dashboard-ready telemetry so maintainers can diagnose failures from artifacts alone.
+
+## Export Command
+
+```bash
+python3 scripts/export_telemetry_pack.py \
+  --db-path agent_state.db \
+  --output-dir artifacts/telemetry
+```
+
+Optional:
+
+- `--limit-runs 500` (default)
+- `--failed-run-id <run_id>` to force diagnosis focus on one run
+
+## Artifacts
+
+The exporter writes:
+
+- `overview.json`
+  - run totals, failure rate, retry totals
+  - aggregate latency percentiles
+  - aggregate saturation metrics
+- `retries.json`
+  - retry counts by tool, step, and run
+- `fail_reasons.json`
+  - failure counts by `error_type`
+  - top failure tools/messages
+  - recent failure events
+- `latency_percentiles.json`
+  - overall and per-tool latency (`p50/p95/p99/max`)
+- `saturation.json`
+  - aggregate and per-run saturation metrics
+  - includes wait times and rate-limit pressure
+- `failed_run_diagnostics.json`
+  - run summary
+  - root failure event
+  - event timeline
+  - dependency cascade count
+- `operator_report.md`
+  - compact triage report with recommended actions
+- `manifest.json`
+  - generation metadata and file list
+
+## Diagnostic Workflow
+
+1. Open `operator_report.md` for quick triage.
+2. Confirm root cause in `failed_run_diagnostics.json`.
+3. Use `fail_reasons.json` to validate whether issue class is systemic.
+4. Use `saturation.json` and `latency_percentiles.json` to determine if contention/rate limits contributed.
+5. Use `retries.json` to identify retry hotspots by tool/step.

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -1,6 +1,6 @@
 # Phase 7 Competitive Roadmap (OpenClaw + Market Positioning)
 
-Status: In progress (through EAP-080, 2026-02-23)
+Status: In progress (through EAP-081, 2026-02-23)
 
 Current status:
 - [x] `EAP-071` interop spike + compatibility matrix published (`docs/openclaw_interop.md`)
@@ -13,7 +13,8 @@ Current status:
 - [x] `EAP-078` MCP interoperability (stdio MCP bridge tool + runtime integration test)
 - [x] `EAP-079` evaluation harness + scorecard (CI artifact + regression gate)
 - [x] `EAP-080` vertical starter packs (research assistant, doc ops, local ETL)
-- [ ] `EAP-081` onward
+- [x] `EAP-081` operator telemetry pack (dashboard-ready triage artifacts)
+- [ ] `EAP-082` onward
 
 ## Objective
 
@@ -116,6 +117,7 @@ Optional validation track:
 11. `EAP-081` Operator telemetry pack
     - Deliverable: first-party dashboards/charts for retries, saturation, fail reasons, and step latency percentiles
     - Done when: maintainer can diagnose a failed run from telemetry alone
+    - Status: complete (`scripts/export_telemetry_pack.py`, `docs/operator_telemetry_pack.md`, `tests/integration/test_telemetry_pack.py`)
 
 12. `EAP-082` "Why EAP now" competitive page refresh
     - Deliverable: refresh `docs/eap_proof_sheet.md` with new interop and eval evidence

--- a/environment/executor.py
+++ b/environment/executor.py
@@ -780,6 +780,27 @@ class AsyncLocalExecutor:
             0,
             approval_required_steps - approval_paused_steps - approval_rejected_steps,
         )
+        final_saturation_metrics = {
+            **saturation_metrics,
+            "global_concurrency_wait_seconds": round(
+                saturation_metrics["global_concurrency_wait_seconds"], 6
+            ),
+            "per_tool_concurrency_wait_seconds": round(
+                saturation_metrics["per_tool_concurrency_wait_seconds"], 6
+            ),
+            "global_rate_wait_seconds": round(
+                saturation_metrics["global_rate_wait_seconds"], 6
+            ),
+            "per_tool_rate_wait_seconds": round(
+                saturation_metrics["per_tool_rate_wait_seconds"], 6
+            ),
+        }
+        approval_metrics = {
+            "required_steps": approval_required_steps,
+            "approved_steps": approval_approved_steps,
+            "rejected_steps": approval_rejected_steps,
+            "paused_steps": approval_paused_steps,
+        }
         total_duration_ms = round(
             max(0.0, (run_completed_at - run_started_at).total_seconds() * 1000.0),
             3,
@@ -799,6 +820,19 @@ class AsyncLocalExecutor:
             total_duration_ms=total_duration_ms,
             final_pointer_id=final_result["pointer_id"] if final_result else None,
         )
+        self.state_manager.store_execution_diagnostics(
+            run_id=run_id,
+            payload={
+                "run_id": run_id,
+                "captured_at_utc": run_completed_at.isoformat(),
+                "checkpoint_status": checkpoint_status,
+                "resumed_from_checkpoint": resume,
+                "replayed_steps": sorted(replayed_step_ids),
+                "approval_metrics": approval_metrics,
+                "saturation_metrics": final_saturation_metrics,
+                "step_status": step_status,
+            },
+        )
 
         if final_result:
             final_result.setdefault("metadata", {})
@@ -806,27 +840,8 @@ class AsyncLocalExecutor:
             final_result["metadata"]["checkpoint_status"] = checkpoint_status
             final_result["metadata"]["resumed_from_checkpoint"] = resume
             final_result["metadata"]["replayed_steps"] = sorted(replayed_step_ids)
-            final_result["metadata"]["approval_metrics"] = {
-                "required_steps": approval_required_steps,
-                "approved_steps": approval_approved_steps,
-                "rejected_steps": approval_rejected_steps,
-                "paused_steps": approval_paused_steps,
-            }
-            final_result["metadata"]["saturation_metrics"] = {
-                **saturation_metrics,
-                "global_concurrency_wait_seconds": round(
-                    saturation_metrics["global_concurrency_wait_seconds"], 6
-                ),
-                "per_tool_concurrency_wait_seconds": round(
-                    saturation_metrics["per_tool_concurrency_wait_seconds"], 6
-                ),
-                "global_rate_wait_seconds": round(
-                    saturation_metrics["global_rate_wait_seconds"], 6
-                ),
-                "per_tool_rate_wait_seconds": round(
-                    saturation_metrics["per_tool_rate_wait_seconds"], 6
-                ),
-            }
+            final_result["metadata"]["approval_metrics"] = approval_metrics
+            final_result["metadata"]["saturation_metrics"] = final_saturation_metrics
         return final_result
 
     async def resume_run(

--- a/protocol/migrations.py
+++ b/protocol/migrations.py
@@ -41,6 +41,23 @@ MIGRATIONS: List[MigrationStep] = [
             "CREATE INDEX IF NOT EXISTS idx_execution_run_summaries_completed_at ON execution_run_summaries(completed_at_utc)"
         ],
     ),
+    MigrationStep(
+        version=4,
+        description="Add execution run diagnostics table for telemetry exports",
+        statements=[
+            """
+            CREATE TABLE IF NOT EXISTS execution_run_diagnostics (
+                run_id TEXT PRIMARY KEY,
+                updated_at_utc TEXT NOT NULL,
+                payload_json TEXT NOT NULL
+            )
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS idx_execution_run_diagnostics_updated
+            ON execution_run_diagnostics(updated_at_utc)
+            """,
+        ],
+    ),
 ]
 
 

--- a/protocol/state_manager.py
+++ b/protocol/state_manager.py
@@ -99,6 +99,21 @@ class StateManager:
             )
             conn.execute(
                 """
+                CREATE TABLE IF NOT EXISTS execution_run_diagnostics (
+                    run_id TEXT PRIMARY KEY,
+                    updated_at_utc TEXT NOT NULL,
+                    payload_json TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_execution_run_diagnostics_updated
+                ON execution_run_diagnostics(updated_at_utc)
+                """
+            )
+            conn.execute(
+                """
                 CREATE TABLE IF NOT EXISTS conversation_sessions (
                     session_id TEXT PRIMARY KEY,
                     created_at_utc TEXT NOT NULL,
@@ -425,6 +440,66 @@ class StateManager:
             "final_pointer_id": row[6],
         }
 
+    def store_execution_diagnostics(self, run_id: str, payload: Dict[str, Any]) -> None:
+        updated_at_utc = self._now_utc_iso()
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO execution_run_diagnostics (
+                    run_id, updated_at_utc, payload_json
+                ) VALUES (?, ?, ?)
+                """,
+                (
+                    run_id,
+                    updated_at_utc,
+                    json.dumps(payload),
+                ),
+            )
+
+    def get_execution_diagnostics(self, run_id: str) -> Dict[str, Any]:
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT updated_at_utc, payload_json
+                FROM execution_run_diagnostics
+                WHERE run_id = ?
+                """,
+                (run_id,),
+            ).fetchone()
+
+        if not row:
+            raise KeyError(f"Execution diagnostics for run {run_id} not found.")
+
+        payload = json.loads(row[1]) if row[1] else {}
+        return {
+            "run_id": run_id,
+            "updated_at_utc": row[0],
+            "payload": payload,
+        }
+
+    def list_execution_diagnostics(self, limit: int = 100) -> List[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                """
+                SELECT run_id, updated_at_utc, payload_json
+                FROM execution_run_diagnostics
+                ORDER BY updated_at_utc DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+
+        diagnostics: List[Dict[str, Any]] = []
+        for row in rows:
+            diagnostics.append(
+                {
+                    "run_id": row[0],
+                    "updated_at_utc": row[1],
+                    "payload": json.loads(row[2]) if row[2] else {},
+                }
+            )
+        return diagnostics
+
     def _generate_session_id(self) -> str:
         return f"sess_{uuid.uuid4().hex[:10]}"
 
@@ -734,6 +809,9 @@ class StateManager:
                 """
             ).fetchall()
             trace_event_total = conn.execute("SELECT COUNT(*) FROM execution_trace_events").fetchone()[0]
+            diagnostics_run_count = conn.execute(
+                "SELECT COUNT(*) FROM execution_run_diagnostics"
+            ).fetchone()[0]
 
             session_count = conn.execute("SELECT COUNT(*) FROM conversation_sessions").fetchone()[0]
             turn_count = conn.execute("SELECT COUNT(*) FROM conversation_turns").fetchone()[0]
@@ -754,6 +832,7 @@ class StateManager:
                 "failed_steps": int(run_row[3]),
                 "avg_duration_ms": float(run_row[4]),
                 "trace_event_total": int(trace_event_total),
+                "diagnostics_run_count": int(diagnostics_run_count),
                 "trace_events_by_type": {row[0]: int(row[1]) for row in event_rows},
             },
             "conversation": {

--- a/scripts/export_telemetry_pack.py
+++ b/scripts/export_telemetry_pack.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+
+def _now_utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    if len(sorted_values) == 1:
+        return float(sorted_values[0])
+
+    rank = (percentile / 100.0) * (len(sorted_values) - 1)
+    lower_index = int(math.floor(rank))
+    upper_index = int(math.ceil(rank))
+    lower = float(sorted_values[lower_index])
+    upper = float(sorted_values[upper_index])
+    if lower_index == upper_index:
+        return lower
+    weight = rank - lower_index
+    return lower + (upper - lower) * weight
+
+
+def _safe_json_load(text: Optional[str]) -> Dict[str, Any]:
+    if not text:
+        return {}
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _aggregate_numeric(values: Sequence[float]) -> Dict[str, float]:
+    if not values:
+        return {
+            "count": 0,
+            "avg": 0.0,
+            "p50": 0.0,
+            "p95": 0.0,
+            "p99": 0.0,
+            "max": 0.0,
+        }
+    float_values = [float(value) for value in values]
+    return {
+        "count": len(float_values),
+        "avg": round(sum(float_values) / len(float_values), 6),
+        "p50": round(_percentile(float_values, 50.0), 6),
+        "p95": round(_percentile(float_values, 95.0), 6),
+        "p99": round(_percentile(float_values, 99.0), 6),
+        "max": round(max(float_values), 6),
+    }
+
+
+def _load_runs(conn: sqlite3.Connection, limit: int) -> List[Dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT run_id, started_at_utc, completed_at_utc, total_steps, succeeded_steps, failed_steps, total_duration_ms
+        FROM execution_run_summaries
+        ORDER BY completed_at_utc DESC
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+    runs: List[Dict[str, Any]] = []
+    for row in rows:
+        runs.append(
+            {
+                "run_id": row[0],
+                "started_at_utc": row[1],
+                "completed_at_utc": row[2],
+                "total_steps": int(row[3]),
+                "succeeded_steps": int(row[4]),
+                "failed_steps": int(row[5]),
+                "total_duration_ms": float(row[6]),
+            }
+        )
+    return runs
+
+
+def _load_trace_rows(conn: sqlite3.Connection, run_ids: Sequence[str]) -> List[Dict[str, Any]]:
+    if not run_ids:
+        return []
+    placeholders = ",".join("?" for _ in run_ids)
+    rows = conn.execute(
+        f"""
+        SELECT event_id, run_id, step_id, tool_name, event_type, timestamp_utc, attempt, duration_ms,
+               retry_delay_seconds, error_payload
+        FROM execution_trace_events
+        WHERE run_id IN ({placeholders})
+        ORDER BY event_id ASC
+        """,
+        tuple(run_ids),
+    ).fetchall()
+    payload: List[Dict[str, Any]] = []
+    for row in rows:
+        error_payload = _safe_json_load(row[9])
+        payload.append(
+            {
+                "event_id": int(row[0]),
+                "run_id": row[1],
+                "step_id": row[2],
+                "tool_name": row[3],
+                "event_type": row[4],
+                "timestamp_utc": row[5],
+                "attempt": int(row[6]),
+                "duration_ms": float(row[7]) if row[7] is not None else None,
+                "retry_delay_seconds": float(row[8]) if row[8] is not None else None,
+                "error_payload": error_payload,
+            }
+        )
+    return payload
+
+
+def _load_diagnostics(conn: sqlite3.Connection, run_ids: Sequence[str]) -> Dict[str, Dict[str, Any]]:
+    if not run_ids:
+        return {}
+    placeholders = ",".join("?" for _ in run_ids)
+    rows = conn.execute(
+        f"""
+        SELECT run_id, updated_at_utc, payload_json
+        FROM execution_run_diagnostics
+        WHERE run_id IN ({placeholders})
+        ORDER BY updated_at_utc DESC
+        """,
+        tuple(run_ids),
+    ).fetchall()
+    diagnostics: Dict[str, Dict[str, Any]] = {}
+    for row in rows:
+        run_id = row[0]
+        if run_id in diagnostics:
+            continue
+        diagnostics[run_id] = {
+            "updated_at_utc": row[1],
+            "payload": _safe_json_load(row[2]),
+        }
+    return diagnostics
+
+
+def _build_retries_view(trace_rows: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    retry_rows = [row for row in trace_rows if row["event_type"] == "retried"]
+    tool_counts: Dict[str, int] = {}
+    step_counts: Dict[str, int] = {}
+    run_counts: Dict[str, int] = {}
+
+    for row in retry_rows:
+        tool_name = row["tool_name"]
+        step_key = f"{row['run_id']}::{row['step_id']}"
+        run_id = row["run_id"]
+        tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
+        step_counts[step_key] = step_counts.get(step_key, 0) + 1
+        run_counts[run_id] = run_counts.get(run_id, 0) + 1
+
+    return {
+        "retry_event_total": len(retry_rows),
+        "runs_with_retries": len(run_counts),
+        "by_tool": [
+            {"tool_name": tool_name, "retry_count": count}
+            for tool_name, count in sorted(tool_counts.items(), key=lambda item: item[1], reverse=True)
+        ],
+        "by_step": [
+            {"run_step": run_step, "retry_count": count}
+            for run_step, count in sorted(step_counts.items(), key=lambda item: item[1], reverse=True)
+        ],
+        "by_run": [
+            {"run_id": run_id, "retry_count": count}
+            for run_id, count in sorted(run_counts.items(), key=lambda item: item[1], reverse=True)
+        ],
+    }
+
+
+def _build_fail_reasons_view(trace_rows: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    failed_rows = [row for row in trace_rows if row["event_type"] == "failed"]
+    error_type_counts: Dict[str, int] = {}
+    tool_counts: Dict[str, int] = {}
+    message_counts: Dict[str, int] = {}
+
+    recent_failures: List[Dict[str, Any]] = []
+    for row in reversed(failed_rows):
+        error_payload = row.get("error_payload") or {}
+        error_type = error_payload.get("error_type", "unknown")
+        message = error_payload.get("message", "")
+
+        error_type_counts[error_type] = error_type_counts.get(error_type, 0) + 1
+        tool_counts[row["tool_name"]] = tool_counts.get(row["tool_name"], 0) + 1
+        if message:
+            message_counts[message] = message_counts.get(message, 0) + 1
+
+        recent_failures.append(
+            {
+                "run_id": row["run_id"],
+                "step_id": row["step_id"],
+                "tool_name": row["tool_name"],
+                "timestamp_utc": row["timestamp_utc"],
+                "error_type": error_type,
+                "message": message,
+            }
+        )
+        if len(recent_failures) >= 20:
+            break
+
+    return {
+        "failed_event_total": len(failed_rows),
+        "error_type_counts": error_type_counts,
+        "top_failure_tools": [
+            {"tool_name": tool_name, "failure_count": count}
+            for tool_name, count in sorted(tool_counts.items(), key=lambda item: item[1], reverse=True)
+        ],
+        "top_failure_messages": [
+            {"message": message, "count": count}
+            for message, count in sorted(message_counts.items(), key=lambda item: item[1], reverse=True)[:20]
+        ],
+        "recent_failures": recent_failures,
+    }
+
+
+def _build_latency_view(trace_rows: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    completed_durations = [
+        float(row["duration_ms"])
+        for row in trace_rows
+        if row["event_type"] == "completed" and row["duration_ms"] is not None
+    ]
+    per_tool: Dict[str, List[float]] = {}
+    for row in trace_rows:
+        if row["event_type"] != "completed" or row["duration_ms"] is None:
+            continue
+        per_tool.setdefault(row["tool_name"], []).append(float(row["duration_ms"]))
+
+    return {
+        "overall": _aggregate_numeric(completed_durations),
+        "per_tool": {
+            tool_name: _aggregate_numeric(values)
+            for tool_name, values in sorted(per_tool.items())
+        },
+    }
+
+
+def _build_saturation_view(
+    runs: Sequence[Dict[str, Any]],
+    diagnostics_by_run: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    metric_names = [
+        "global_concurrency_wait_seconds",
+        "per_tool_concurrency_wait_seconds",
+        "global_rate_wait_seconds",
+        "per_tool_rate_wait_seconds",
+        "max_inflight_global",
+        "total_rate_limited_attempts",
+    ]
+    per_run_rows: List[Dict[str, Any]] = []
+    metric_values: Dict[str, List[float]] = {name: [] for name in metric_names}
+
+    for run in runs:
+        run_id = run["run_id"]
+        diagnostics = diagnostics_by_run.get(run_id, {})
+        payload = diagnostics.get("payload", {})
+        saturation = payload.get("saturation_metrics") if isinstance(payload, dict) else {}
+        saturation = saturation if isinstance(saturation, dict) else {}
+        row = {
+            "run_id": run_id,
+            "completed_at_utc": run["completed_at_utc"],
+            "failed_steps": run["failed_steps"],
+            "metrics": {},
+        }
+        for name in metric_names:
+            value = saturation.get(name, 0.0)
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError):
+                numeric = 0.0
+            row["metrics"][name] = round(numeric, 6)
+            metric_values[name].append(numeric)
+        per_run_rows.append(row)
+
+    aggregate = {
+        name: _aggregate_numeric(values)
+        for name, values in metric_values.items()
+    }
+    return {"aggregate": aggregate, "per_run": per_run_rows[:100]}
+
+
+def _select_failed_run(
+    runs: Sequence[Dict[str, Any]],
+    requested_run_id: Optional[str] = None,
+) -> Optional[str]:
+    if requested_run_id:
+        for run in runs:
+            if run["run_id"] == requested_run_id:
+                return requested_run_id
+        return None
+    for run in runs:
+        if run["failed_steps"] > 0:
+            return run["run_id"]
+    return None
+
+
+def _build_failed_run_diagnostics(
+    runs: Sequence[Dict[str, Any]],
+    trace_rows: Sequence[Dict[str, Any]],
+    diagnostics_by_run: Dict[str, Dict[str, Any]],
+    failed_run_id: Optional[str],
+) -> Dict[str, Any]:
+    if not failed_run_id:
+        return {
+            "failed_run_id": None,
+            "message": "No failed runs found in selected window.",
+            "timeline": [],
+            "root_failure": None,
+            "dependency_cascade_count": 0,
+        }
+
+    run_row = next((run for run in runs if run["run_id"] == failed_run_id), None)
+    run_trace = [row for row in trace_rows if row["run_id"] == failed_run_id]
+    failed_events = [row for row in run_trace if row["event_type"] == "failed"]
+
+    root_failure = None
+    for event in failed_events:
+        error_type = (event.get("error_payload") or {}).get("error_type")
+        if error_type and error_type != "dependency_error":
+            root_failure = event
+            break
+    if root_failure is None and failed_events:
+        root_failure = failed_events[0]
+
+    dependency_cascade_count = 0
+    for event in failed_events:
+        error_type = (event.get("error_payload") or {}).get("error_type")
+        if error_type == "dependency_error":
+            dependency_cascade_count += 1
+
+    timeline = []
+    for event in run_trace:
+        error_payload = event.get("error_payload") or {}
+        timeline.append(
+            {
+                "timestamp_utc": event["timestamp_utc"],
+                "step_id": event["step_id"],
+                "tool_name": event["tool_name"],
+                "event_type": event["event_type"],
+                "attempt": event["attempt"],
+                "duration_ms": event["duration_ms"],
+                "error_type": error_payload.get("error_type"),
+                "message": error_payload.get("message"),
+            }
+        )
+
+    root_failure_payload = None
+    if root_failure is not None:
+        error_payload = root_failure.get("error_payload") or {}
+        root_failure_payload = {
+            "run_id": root_failure["run_id"],
+            "step_id": root_failure["step_id"],
+            "tool_name": root_failure["tool_name"],
+            "timestamp_utc": root_failure["timestamp_utc"],
+            "error_type": error_payload.get("error_type"),
+            "message": error_payload.get("message"),
+        }
+
+    diagnostics_payload = diagnostics_by_run.get(failed_run_id, {}).get("payload", {})
+    return {
+        "failed_run_id": failed_run_id,
+        "run_summary": run_row,
+        "root_failure": root_failure_payload,
+        "dependency_cascade_count": dependency_cascade_count,
+        "timeline": timeline,
+        "run_diagnostics": diagnostics_payload,
+    }
+
+
+def _build_overview(
+    runs: Sequence[Dict[str, Any]],
+    retries_view: Dict[str, Any],
+    fail_reasons_view: Dict[str, Any],
+    latency_view: Dict[str, Any],
+    saturation_view: Dict[str, Any],
+) -> Dict[str, Any]:
+    run_count = len(runs)
+    failed_run_count = sum(1 for run in runs if run["failed_steps"] > 0)
+    failure_rate = (float(failed_run_count) / float(run_count)) if run_count else 0.0
+    return {
+        "run_count": run_count,
+        "failed_run_count": failed_run_count,
+        "failed_run_rate": round(failure_rate, 6),
+        "retry_event_total": retries_view["retry_event_total"],
+        "failed_event_total": fail_reasons_view["failed_event_total"],
+        "latency": latency_view["overall"],
+        "saturation": saturation_view["aggregate"],
+    }
+
+
+def _recommendations_for_failure(diagnostics: Dict[str, Any]) -> List[str]:
+    root = diagnostics.get("root_failure") or {}
+    error_type = root.get("error_type")
+    recommendations: List[str] = []
+    if error_type == "tool_execution_error":
+        recommendations.append("Inspect failing tool inputs and upstream payload quality for the root failure step.")
+        recommendations.append("Adjust RetryPolicy.retryable_error_types if the failure is transient and currently non-retryable.")
+    elif error_type == "dependency_error":
+        recommendations.append("Trace upstream failing step and repair its tool contract before retrying downstream steps.")
+    elif error_type == "approval_rejected":
+        recommendations.append("Check approval workflow policy and rejection reason for the blocked step.")
+    else:
+        recommendations.append("Review root failure event payload and correlated step trace to isolate first error.")
+    if diagnostics.get("dependency_cascade_count", 0) > 0:
+        recommendations.append("Dependency cascade detected; prioritize fixing the first non-dependency failure event.")
+    return recommendations
+
+
+def _render_markdown_report(
+    overview: Dict[str, Any],
+    retries_view: Dict[str, Any],
+    fail_reasons_view: Dict[str, Any],
+    failed_run_diagnostics: Dict[str, Any],
+) -> str:
+    lines = [
+        "# Operator Telemetry Pack",
+        "",
+        f"- Generated: `{_now_utc_iso()}`",
+        f"- Runs analyzed: `{overview['run_count']}`",
+        f"- Failed runs: `{overview['failed_run_count']}` (`{overview['failed_run_rate']:.2%}`)",
+        f"- Retry events: `{overview['retry_event_total']}`",
+        "",
+        "## High-Level Signals",
+        "",
+        f"- Top failure types: `{fail_reasons_view.get('error_type_counts', {})}`",
+        f"- Top retry tools: `{retries_view.get('by_tool', [])[:5]}`",
+        f"- Step latency p95 (ms): `{overview['latency'].get('p95', 0.0):.3f}`",
+        f"- Global rate-wait p95 (s): "
+        f"`{overview['saturation'].get('global_rate_wait_seconds', {}).get('p95', 0.0):.6f}`",
+        "",
+        "## Failed Run Diagnosis",
+        "",
+    ]
+
+    failed_run_id = failed_run_diagnostics.get("failed_run_id")
+    if not failed_run_id:
+        lines.append("- No failed runs were found in the selected window.")
+        return "\n".join(lines) + "\n"
+
+    root = failed_run_diagnostics.get("root_failure") or {}
+    lines.append(f"- Failed run: `{failed_run_id}`")
+    lines.append(
+        f"- Root failure: `{root.get('error_type', 'unknown')}` in `{root.get('tool_name', 'unknown')}`/"
+        f"`{root.get('step_id', 'unknown')}`"
+    )
+    if root.get("message"):
+        lines.append(f"- Root message: `{root['message']}`")
+    lines.append(
+        f"- Dependency cascade events: `{failed_run_diagnostics.get('dependency_cascade_count', 0)}`"
+    )
+    lines.append("")
+    lines.append("## Recommended Actions")
+    lines.append("")
+    for action in _recommendations_for_failure(failed_run_diagnostics):
+        lines.append(f"- {action}")
+    lines.append("")
+    lines.append("## Timeline Snapshot")
+    lines.append("")
+    timeline = failed_run_diagnostics.get("timeline", [])[:12]
+    if not timeline:
+        lines.append("- No timeline events captured.")
+    else:
+        for event in timeline:
+            lines.append(
+                f"- `{event.get('timestamp_utc')}` `{event.get('event_type')}` "
+                f"`{event.get('tool_name')}/{event.get('step_id')}` "
+                f"(attempt {event.get('attempt')})"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export dashboard-ready telemetry artifacts for EAP operations.")
+    parser.add_argument("--db-path", default="agent_state.db", help="Path to SQLite state database.")
+    parser.add_argument(
+        "--output-dir",
+        default="artifacts/telemetry",
+        help="Directory where telemetry artifacts are written.",
+    )
+    parser.add_argument(
+        "--limit-runs",
+        type=int,
+        default=500,
+        help="Maximum number of recent runs to include.",
+    )
+    parser.add_argument(
+        "--failed-run-id",
+        default=None,
+        help="Optional specific failed run ID for diagnosis drilldown.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with sqlite3.connect(args.db_path) as conn:
+        runs = _load_runs(conn, limit=args.limit_runs)
+        run_ids = [run["run_id"] for run in runs]
+        trace_rows = _load_trace_rows(conn, run_ids=run_ids)
+        diagnostics_by_run = _load_diagnostics(conn, run_ids=run_ids)
+
+    retries_view = _build_retries_view(trace_rows)
+    fail_reasons_view = _build_fail_reasons_view(trace_rows)
+    latency_view = _build_latency_view(trace_rows)
+    saturation_view = _build_saturation_view(runs, diagnostics_by_run=diagnostics_by_run)
+    failed_run_id = _select_failed_run(runs, requested_run_id=args.failed_run_id)
+    failed_run_diagnostics = _build_failed_run_diagnostics(
+        runs=runs,
+        trace_rows=trace_rows,
+        diagnostics_by_run=diagnostics_by_run,
+        failed_run_id=failed_run_id,
+    )
+    overview = _build_overview(
+        runs=runs,
+        retries_view=retries_view,
+        fail_reasons_view=fail_reasons_view,
+        latency_view=latency_view,
+        saturation_view=saturation_view,
+    )
+
+    outputs = {
+        "overview.json": overview,
+        "retries.json": retries_view,
+        "fail_reasons.json": fail_reasons_view,
+        "latency_percentiles.json": latency_view,
+        "saturation.json": saturation_view,
+        "failed_run_diagnostics.json": failed_run_diagnostics,
+    }
+    for filename, payload in outputs.items():
+        (output_dir / filename).write_text(
+            json.dumps(payload, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+    report = _render_markdown_report(
+        overview=overview,
+        retries_view=retries_view,
+        fail_reasons_view=fail_reasons_view,
+        failed_run_diagnostics=failed_run_diagnostics,
+    )
+    (output_dir / "operator_report.md").write_text(report, encoding="utf-8")
+
+    manifest = {
+        "generated_at_utc": _now_utc_iso(),
+        "db_path": str(Path(args.db_path).resolve()),
+        "output_dir": str(output_dir.resolve()),
+        "files": sorted(
+            [path.name for path in output_dir.iterdir() if path.is_file()] + ["manifest.json"]
+        ),
+        "failed_run_id": failed_run_id,
+    }
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_telemetry_pack.py
+++ b/tests/integration/test_telemetry_pack.py
@@ -1,0 +1,169 @@
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from eap.environment import AsyncLocalExecutor, ToolRegistry
+from eap.protocol import (
+    BatchedMacroRequest,
+    ExecutionLimits,
+    RetryPolicy,
+    StateManager,
+    ToolCall,
+    ToolExecutionLimit,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _FlakyTool:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, value: str) -> str:
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("transient upstream failure")
+        return value
+
+
+def _slow_tool(value: str) -> str:
+    time.sleep(0.02)
+    return value
+
+
+def _always_fail(value: str) -> str:
+    raise RuntimeError(f"forced failure:{value}")
+
+
+def _echo_tool(value: str) -> str:
+    return value
+
+
+TOOL_SCHEMA = {
+    "name": "tool_name_placeholder",
+    "parameters": {
+        "type": "object",
+        "properties": {"value": {"type": "string"}},
+        "required": ["value"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _schema_for(name: str) -> dict:
+    schema = dict(TOOL_SCHEMA)
+    schema["name"] = name
+    return schema
+
+
+class TelemetryPackIntegrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        fd, self.db_path = tempfile.mkstemp(prefix="eap-telemetry-pack-", suffix=".db")
+        os.close(fd)
+
+        self.state_manager = StateManager(db_path=self.db_path)
+        registry = ToolRegistry()
+        registry.register("flaky_tool", _FlakyTool(), _schema_for("flaky_tool"))
+        registry.register("slow_tool", _slow_tool, _schema_for("slow_tool"))
+        registry.register("always_fail_tool", _always_fail, _schema_for("always_fail_tool"))
+        registry.register("echo_tool", _echo_tool, _schema_for("echo_tool"))
+        self.executor = AsyncLocalExecutor(self.state_manager, registry)
+
+    def tearDown(self) -> None:
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_export_telemetry_pack_can_diagnose_failed_run(self) -> None:
+        retry_and_saturation_macro = BatchedMacroRequest(
+            steps=[
+                ToolCall(step_id="step_flaky", tool_name="flaky_tool", arguments={"value": "ok"}),
+                ToolCall(step_id="step_slow_1", tool_name="slow_tool", arguments={"value": "a"}),
+                ToolCall(step_id="step_slow_2", tool_name="slow_tool", arguments={"value": "b"}),
+                ToolCall(step_id="step_slow_3", tool_name="slow_tool", arguments={"value": "c"}),
+            ],
+            retry_policy=RetryPolicy(
+                max_attempts=2,
+                initial_delay_seconds=0.0,
+                backoff_multiplier=1.0,
+                retryable_error_types=["RuntimeError"],
+            ),
+            execution_limits=ExecutionLimits(
+                max_global_concurrency=4,
+                global_requests_per_second=1.0,
+                global_burst_capacity=1,
+                per_tool={"slow_tool": ToolExecutionLimit(max_concurrency=2)},
+            ),
+        )
+        first_result = asyncio.run(self.executor.execute_macro(retry_and_saturation_macro))
+        self.assertIn("pointer_id", first_result)
+
+        failure_macro = BatchedMacroRequest(
+            steps=[
+                ToolCall(step_id="step_fail", tool_name="always_fail_tool", arguments={"value": "x"}),
+                ToolCall(step_id="step_dep", tool_name="echo_tool", arguments={"value": "$step:step_fail"}),
+            ],
+            retry_policy=RetryPolicy(max_attempts=1, initial_delay_seconds=0.0, backoff_multiplier=1.0),
+        )
+        failure_result = asyncio.run(self.executor.execute_macro(failure_macro))
+        failed_run_id = failure_result["metadata"]["execution_run_id"]
+        self.assertEqual(failure_result["metadata"]["status"], "error")
+
+        with tempfile.TemporaryDirectory(prefix="eap-telemetry-output-") as temp_dir:
+            command = [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "export_telemetry_pack.py"),
+                "--db-path",
+                self.db_path,
+                "--output-dir",
+                temp_dir,
+            ]
+            completed = subprocess.run(
+                command,
+                cwd=str(REPO_ROOT),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 0, msg=completed.stdout + completed.stderr)
+
+            expected_files = [
+                "overview.json",
+                "retries.json",
+                "fail_reasons.json",
+                "latency_percentiles.json",
+                "saturation.json",
+                "failed_run_diagnostics.json",
+                "operator_report.md",
+                "manifest.json",
+            ]
+            for filename in expected_files:
+                self.assertTrue((Path(temp_dir) / filename).exists(), msg=f"missing {filename}")
+
+            overview = json.loads((Path(temp_dir) / "overview.json").read_text(encoding="utf-8"))
+            retries = json.loads((Path(temp_dir) / "retries.json").read_text(encoding="utf-8"))
+            fail_reasons = json.loads((Path(temp_dir) / "fail_reasons.json").read_text(encoding="utf-8"))
+            saturation = json.loads((Path(temp_dir) / "saturation.json").read_text(encoding="utf-8"))
+            failed_diag = json.loads(
+                (Path(temp_dir) / "failed_run_diagnostics.json").read_text(encoding="utf-8")
+            )
+            report = (Path(temp_dir) / "operator_report.md").read_text(encoding="utf-8")
+
+            self.assertGreaterEqual(overview["run_count"], 2)
+            self.assertGreaterEqual(retries["retry_event_total"], 1)
+            self.assertGreaterEqual(fail_reasons["failed_event_total"], 1)
+            self.assertIn("tool_execution_error", fail_reasons["error_type_counts"])
+            self.assertIn("global_rate_wait_seconds", saturation["aggregate"])
+            self.assertEqual(failed_diag["failed_run_id"], failed_run_id)
+            self.assertEqual(failed_diag["root_failure"]["error_type"], "tool_execution_error")
+            self.assertIn(failed_run_id, report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -58,7 +58,7 @@ class SqliteMigrationTest(unittest.TestCase):
         self.assertEqual([step.version for step in pending], list(range(1, LATEST_SCHEMA_VERSION + 1)))
 
         result = apply_sqlite_migrations(self.db_path, dry_run=True)
-        self.assertEqual(result["planned_versions"], [1, 2, 3])
+        self.assertEqual(result["planned_versions"], [1, 2, 3, 4])
         self.assertEqual(result["applied_versions"], [])
 
         with sqlite3.connect(self.db_path) as conn:
@@ -69,7 +69,7 @@ class SqliteMigrationTest(unittest.TestCase):
 
     def test_apply_migrations_is_idempotent(self) -> None:
         first = apply_sqlite_migrations(self.db_path)
-        self.assertEqual(first["applied_versions"], [1, 2, 3])
+        self.assertEqual(first["applied_versions"], [1, 2, 3, 4])
         self.assertEqual(first["final_version"], LATEST_SCHEMA_VERSION)
 
         with sqlite3.connect(self.db_path) as conn:
@@ -80,7 +80,8 @@ class SqliteMigrationTest(unittest.TestCase):
                 WHERE type='index'
                 AND name IN (
                     'idx_execution_trace_events_step_id',
-                    'idx_execution_run_summaries_completed_at'
+                    'idx_execution_run_summaries_completed_at',
+                    'idx_execution_run_diagnostics_updated'
                 )
                 ORDER BY name
                 """
@@ -88,10 +89,16 @@ class SqliteMigrationTest(unittest.TestCase):
             self.assertEqual(
                 [row[0] for row in idx_rows],
                 [
+                    "idx_execution_run_diagnostics_updated",
                     "idx_execution_run_summaries_completed_at",
                     "idx_execution_trace_events_step_id",
                 ],
             )
+
+            diagnostics_row = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='execution_run_diagnostics'"
+            ).fetchone()
+            self.assertIsNotNone(diagnostics_row)
 
         second = apply_sqlite_migrations(self.db_path)
         self.assertEqual(second["applied_versions"], [])

--- a/tests/unit/test_operational_metrics.py
+++ b/tests/unit/test_operational_metrics.py
@@ -47,6 +47,21 @@ class OperationalMetricsTest(unittest.TestCase):
                 attempt=1,
             )
         )
+        self.manager.store_execution_diagnostics(
+            run_id=run_id,
+            payload={
+                "saturation_metrics": {
+                    "global_concurrency_wait_seconds": 0.5,
+                    "global_rate_wait_seconds": 0.2,
+                },
+                "approval_metrics": {
+                    "required_steps": 0,
+                    "approved_steps": 0,
+                    "rejected_steps": 0,
+                    "paused_steps": 0,
+                },
+            },
+        )
 
         future_now = "2099-01-01T00:00:00+00:00"
         metrics = self.manager.collect_operational_metrics(now_utc=future_now)
@@ -57,6 +72,7 @@ class OperationalMetricsTest(unittest.TestCase):
         self.assertEqual(metrics["conversation"]["turn_count"], 1)
         self.assertEqual(metrics["execution"]["run_count"], 1)
         self.assertEqual(metrics["execution"]["failed_run_count"], 1)
+        self.assertEqual(metrics["execution"]["diagnostics_run_count"], 1)
         self.assertEqual(metrics["execution"]["trace_events_by_type"]["queued"], 1)
 
         with tempfile.TemporaryDirectory(prefix="eap-metrics-out-") as tmpdir:
@@ -68,6 +84,13 @@ class OperationalMetricsTest(unittest.TestCase):
             payload = json.loads(open(output_path, "r", encoding="utf-8").read())
             self.assertEqual(payload["execution"]["run_count"], 1)
             self.assertEqual(payload["conversation"]["turn_count"], 1)
+
+        diagnostics = self.manager.get_execution_diagnostics(run_id)
+        self.assertEqual(diagnostics["run_id"], run_id)
+        self.assertEqual(
+            diagnostics["payload"]["saturation_metrics"]["global_concurrency_wait_seconds"],
+            0.5,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- persist per-run executor diagnostics (including saturation/approval metadata) in `execution_run_diagnostics`
- add telemetry exporter `scripts/export_telemetry_pack.py` that emits dashboard-ready artifacts:
  - retries, saturation, fail reasons, latency percentiles, failed-run diagnostics, operator report
- add integration test `tests/integration/test_telemetry_pack.py` proving failed-run diagnosis from telemetry artifacts
- add docs for telemetry export and triage workflow (`docs/operator_telemetry_pack.md`, `docs/observability.md`)
- update Phase 7 status docs to mark EAP-081 complete and advance next item to EAP-082

## Validation
- /Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python -m pytest -q tests/integration/test_telemetry_pack.py
- /Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python -m pytest -q tests/unit/test_migrations.py tests/unit/test_operational_metrics.py
- /Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python -m pytest -q tests/perf/test_concurrency_limits.py tests/integration/test_reliability_failures.py
- /Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python -m pytest -q tests/integration/test_resume_replay.py tests/integration/test_runtime_http_api.py
- python3 scripts/export_telemetry_pack.py --db-path agent_state.db --output-dir artifacts/telemetry-local --limit-runs 10