### PR TITLE
EAP-082: refresh proof sheet with side-by-side interop evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,3 +73,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-079` evaluation harness shipped with CI scorecard artifacts and regression threshold gate.
 - Phase 7 `EAP-080` vertical starter packs added with runnable walkthroughs and smoke tests.
 - Phase 7 `EAP-081` operator telemetry pack added with dashboard-ready diagnostics and failed-run triage artifacts.
+- Phase 7 `EAP-082` competitive proof sheet refreshed with side-by-side capability matrix and reproducible validation commands.

--- a/docs/eap_proof_sheet.md
+++ b/docs/eap_proof_sheet.md
@@ -1,47 +1,73 @@
-# EAP Proof Sheet: Why Choose EAP
+# EAP Proof Sheet: Why EAP Now
 
-This is a one-page decision brief for teams evaluating EAP against general-purpose agent orchestration stacks.
+Updated: 2026-02-24  
+Scope: EAP `0.1.7` with OpenClaw interop, eval gating, and operator telemetry (EAP-071 to EAP-082 complete).
 
-## Where EAP Is Strong
+## Side-by-Side Capability Table
 
-- Pointer-backed state keeps large intermediate payloads out of LLM context (`ptr_*` references instead of raw payload replay).
-- Dependency-aware DAG execution runs independent steps in parallel with typed retry + failure contracts.
-- Built-in execution traces and run summaries make retries/failures auditable by default.
-- Local-first operation with optional Redis/PostgreSQL backends for pointer storage.
+| Capability | EAP runtime status | OpenClaw interop status | Evidence |
+| --- | --- | --- | --- |
+| OpenAI-compatible execution API | Native (`POST /v1/eap/execute` and related run/pointer endpoints) | Plugin tools call EAP runtime over HTTP | `app.py`, `tests/integration/test_runtime_http_api.py`, `integrations/openclaw/eap-runtime-plugin` |
+| Plugin and skills integration | EAP side exposes stable runtime contract | OpenClaw plugin + skill pack MVP shipped | `integrations/openclaw/eap-runtime-plugin/openclaw.plugin.json`, `integrations/openclaw/eap-runtime-plugin/skills/README.md`, `tests/contract/test_openclaw_skill_pack.py` |
+| Human-in-the-loop approvals | Step-level `approval_required/approved/rejected` transitions persisted in traces | Available through runtime endpoints and resume flow | `tests/integration/test_human_approval.py`, `tests/integration/test_runtime_http_api.py` |
+| Crash-safe resume/replay | Checkpointed runs can resume deterministically after interruption | Runtime resume endpoint available to plugin clients | `tests/integration/test_resume_replay.py`, `tests/integration/test_runtime_http_api.py` |
+| MCP tool interoperability | Built-in `invoke_mcp_tool` bridge in runtime tool registry | Can be invoked in EAP workflows used by interop flows | `environment/tools/mcp_tools.py`, `tests/integration/test_mcp_interop.py` |
+| CI-gated quality scorecard | Correctness/reliability/latency harness with hard thresholds | Runs as required CI lane on PR/push | `scripts/eval_scorecard.py`, `.github/workflows/ci.yml`, `docs/eval_thresholds.json` |
+| Operator diagnostics | Dashboard-ready retry/failure/latency/saturation telemetry export | Maintainers can triage failed runs from artifacts only | `scripts/export_telemetry_pack.py`, `docs/operator_telemetry_pack.md`, `tests/integration/test_telemetry_pack.py` |
+
+## Reproducible Commands
+
+### 1) Interop evidence (plugin + skills + runtime contract)
+
+```bash
+npm --prefix integrations/openclaw/eap-runtime-plugin ci
+npm --prefix integrations/openclaw/eap-runtime-plugin test
+./scripts/interop_openclaw_smoke.sh v2026.2.22
+python -m pytest -q \
+  tests/contract/test_openclaw_skill_pack.py \
+  tests/integration/test_runtime_http_api.py \
+  tests/integration/test_mcp_interop.py
+```
+
+### 2) Eval scorecard evidence (regression-gated)
+
+```bash
+python scripts/eval_scorecard.py \
+  --output-dir artifacts/eval \
+  --threshold-config docs/eval_thresholds.json \
+  --baseline docs/eval_baseline.json
+```
+
+Expected output:
+- `artifacts/eval/scorecard.json`
+- `artifacts/eval/scorecard.md`
+- `artifacts/eval/trend.json`
+- `artifacts/eval/history.ndjson`
+
+### 3) Telemetry evidence (failed-run diagnosis)
+
+```bash
+python -m pytest -q tests/integration/test_telemetry_pack.py
+python scripts/export_telemetry_pack.py \
+  --db-path agent_state.db \
+  --output-dir artifacts/telemetry
+```
+
+Expected output:
+- `artifacts/telemetry/failed_run_diagnostics.json`
+- `artifacts/telemetry/operator_report.md`
 
 ## Evidence Snapshot
 
-Source: `docs/benchmarks.md` (baseline date: 2026-02-23)
+Source: `docs/benchmarks.md` and `docs/eval_thresholds.json`
 
-- Concurrency-limit perf path: `0.28s` (`test_global_concurrency_limit_caps_parallel_work`)
-- Rate-limit saturation path: `1.70s` (`test_rate_limit_generates_saturation_metrics`)
-- Distributed lease recovery paths: `0.01s` each (`test_expired_lease_is_reassigned`, `test_stale_completion_report_is_rejected_after_reassignment`)
-- CI perf regression guards:
-  - global-concurrency path must stay `< 2.0s`
-  - rate-limit path must stay `< 4.0s`
-
-## Failure-Mode Evidence
-
-| Scenario | Expected behavior | Evidence |
-| --- | --- | --- |
-| Transient tool failure | Retry and then succeed when policy allows | `tests/integration/test_executor_retries.py` |
-| Non-retryable timeout | Fail fast with typed `tool_execution_error` | `tests/integration/test_reliability_failures.py` |
-| Upstream step fails | Downstream dependency marked `dependency_error` | `tests/integration/test_reliability_failures.py` |
-| Retry/fail/approval/replay trace visibility | `replayed/queued/approval_required/approved/rejected/started/retried/failed/completed` persisted with run summary | `tests/integration/test_execution_traces.py`, `tests/integration/test_human_approval.py`, `tests/integration/test_resume_replay.py` |
-| Pointer lifecycle cleanup | Expired pointers filtered and cleaned idempotently | `tests/integration/test_pointer_ttl.py` |
-| Distributed worker lease expiry | Expired lease is reassigned; stale completion rejected | `tests/perf/test_distributed_resilience.py` |
-
-## Quick Verification Commands
-
-```bash
-python3 -m pytest -q tests/integration/test_executor_retries.py
-python3 -m pytest -q tests/integration/test_reliability_failures.py
-python3 -m pytest -q tests/integration/test_execution_traces.py
-python3 -m pytest -q tests/perf --durations=10
-```
+- Perf baseline (2026-02-23): concurrency path `0.28s`, rate-limit saturation path `1.70s`.
+- Eval gate thresholds:
+  - correctness pass rate `>= 1.0`
+  - reliability pass rate `>= 1.0`
+  - latency `p95 <= 300ms`, `max <= 500ms`
+- CI enforces these gates on every PR via `Eval scorecard (py3.11)`.
 
 ## Decision Rule
 
-Choose EAP when you need predictable tool orchestration with strong failure semantics, pointer-based state management, and observable execution behavior.
-
-Choose a broader framework if your priority is large ecosystem integrations over execution-contract rigor.
+Choose EAP now if you need strong failure semantics, resumable execution, OpenClaw/MCP interop, and operator-grade diagnostics with reproducible CI evidence.

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,8 +1,8 @@
 # OpenClaw Interop Spike (EAP-071)
 
-Status: Updated through EAP-081 (2026-02-23)  
+Status: Updated through EAP-082 (2026-02-24)  
 Owner: EAP maintainers  
-Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081)
+Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081, EAP-082)
 
 ## 1) Version Snapshot
 
@@ -189,8 +189,30 @@ Recommended sequence:
 - integration validation:
   - `tests/integration/test_telemetry_pack.py`
 
-Proceed to **EAP-082**:
+`EAP-082` target:
 - refresh competitive proof sheet with interop + eval + telemetry evidence.
+
+`EAP-082` follow-up is now complete (see section 12 below).
+
+## 12) Implemented Competitive Proof Sheet Refresh (EAP-082)
+
+`EAP-082` is now implemented in-repo with:
+- refreshed decision brief:
+  - `docs/eap_proof_sheet.md`
+- side-by-side capability table covering:
+  - runtime API
+  - OpenClaw plugin/skills interop
+  - approval checkpoints
+  - resume/replay
+  - MCP bridge
+  - eval gating
+  - telemetry diagnostics
+- reproducible command set for:
+  - OpenClaw interop validation
+  - scorecard/eval gate generation
+  - telemetry pack export
+
+Proceed to **EAP-083**.
 
 ## References (Primary Sources)
 

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -1,6 +1,6 @@
 # Phase 7 Competitive Roadmap (OpenClaw + Market Positioning)
 
-Status: In progress (through EAP-081, 2026-02-23)
+Status: In progress (through EAP-082, 2026-02-24)
 
 Current status:
 - [x] `EAP-071` interop spike + compatibility matrix published (`docs/openclaw_interop.md`)
@@ -14,7 +14,8 @@ Current status:
 - [x] `EAP-079` evaluation harness + scorecard (CI artifact + regression gate)
 - [x] `EAP-080` vertical starter packs (research assistant, doc ops, local ETL)
 - [x] `EAP-081` operator telemetry pack (dashboard-ready triage artifacts)
-- [ ] `EAP-082` onward
+- [x] `EAP-082` "Why EAP now" competitive proof sheet refresh
+- [ ] `EAP-083` onward
 
 ## Objective
 
@@ -122,6 +123,7 @@ Optional validation track:
 12. `EAP-082` "Why EAP now" competitive page refresh
     - Deliverable: refresh `docs/eap_proof_sheet.md` with new interop and eval evidence
     - Done when: proof sheet includes side-by-side capability table + reproducible commands
+    - Status: complete (`docs/eap_proof_sheet.md`)
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary
- refresh `docs/eap_proof_sheet.md` into a current "Why EAP now" decision brief
- add side-by-side capability table covering runtime, OpenClaw interop, MCP bridge, eval gating, and telemetry diagnostics
- add reproducible commands for interop validation, eval scorecard generation, and telemetry export
- mark EAP-082 complete in Phase 7 tracking docs and roadmap done log

## Validation
- docs-only change; no runtime code changes
- checked for stale EAP-082 pending references in roadmap/interop docs
