### PR TITLE
EAP-083: enforce proof-sheet contract checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,12 @@ jobs:
         run: |
           pre-commit run --all-files
 
+      - name: Proof sheet contract checks
+        if: matrix.python-version == '3.11'
+        run: |
+          python scripts/verify_proof_sheet.py
+          python -m pytest -q tests/contract/test_eap_proof_sheet_contract.py
+
       - name: Dependency vulnerability audit
         if: matrix.python-version == '3.11'
         run: |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,3 +74,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-080` vertical starter packs added with runnable walkthroughs and smoke tests.
 - Phase 7 `EAP-081` operator telemetry pack added with dashboard-ready diagnostics and failed-run triage artifacts.
 - Phase 7 `EAP-082` competitive proof sheet refreshed with side-by-side capability matrix and reproducible validation commands.
+- Phase 7 `EAP-083` proof sheet contract checks added and enforced in CI to prevent evidence/command drift.

--- a/docs/eap_proof_sheet.md
+++ b/docs/eap_proof_sheet.md
@@ -57,6 +57,13 @@ Expected output:
 - `artifacts/telemetry/failed_run_diagnostics.json`
 - `artifacts/telemetry/operator_report.md`
 
+### 4) Proof sheet contract verification
+
+```bash
+python scripts/verify_proof_sheet.py
+python -m pytest -q tests/contract/test_eap_proof_sheet_contract.py
+```
+
 ## Evidence Snapshot
 
 Source: `docs/benchmarks.md` and `docs/eval_thresholds.json`

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,8 +1,8 @@
 # OpenClaw Interop Spike (EAP-071)
 
-Status: Updated through EAP-082 (2026-02-24)  
+Status: Updated through EAP-083 (2026-02-24)  
 Owner: EAP maintainers  
-Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081, EAP-082)
+Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081, EAP-082, EAP-083)
 
 ## 1) Version Snapshot
 
@@ -212,7 +212,24 @@ Recommended sequence:
   - scorecard/eval gate generation
   - telemetry pack export
 
-Proceed to **EAP-083**.
+`EAP-083` target:
+- add proof sheet contract checks to prevent evidence drift.
+
+`EAP-083` follow-up is now complete (see section 13 below).
+
+## 13) Implemented Proof Sheet Contract Checks (EAP-083)
+
+`EAP-083` is now implemented in-repo with:
+- proof-sheet verifier script:
+  - `scripts/verify_proof_sheet.py`
+- contract test coverage:
+  - `tests/contract/test_eap_proof_sheet_contract.py`
+- CI enforcement in py3.11 lane:
+  - `.github/workflows/ci.yml` (`Proof sheet contract checks`)
+- proof sheet command references now include verifier execution:
+  - `docs/eap_proof_sheet.md`
+
+Proceed to **EAP-084**.
 
 ## References (Primary Sources)
 

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -1,6 +1,6 @@
 # Phase 7 Competitive Roadmap (OpenClaw + Market Positioning)
 
-Status: In progress (through EAP-082, 2026-02-24)
+Status: In progress (through EAP-083, 2026-02-24)
 
 Current status:
 - [x] `EAP-071` interop spike + compatibility matrix published (`docs/openclaw_interop.md`)
@@ -15,7 +15,8 @@ Current status:
 - [x] `EAP-080` vertical starter packs (research assistant, doc ops, local ETL)
 - [x] `EAP-081` operator telemetry pack (dashboard-ready triage artifacts)
 - [x] `EAP-082` "Why EAP now" competitive proof sheet refresh
-- [ ] `EAP-083` onward
+- [x] `EAP-083` proof sheet contract checks in CI
+- [ ] `EAP-084` onward
 
 ## Objective
 
@@ -124,6 +125,11 @@ Optional validation track:
     - Deliverable: refresh `docs/eap_proof_sheet.md` with new interop and eval evidence
     - Done when: proof sheet includes side-by-side capability table + reproducible commands
     - Status: complete (`docs/eap_proof_sheet.md`)
+
+13. `EAP-083` Proof sheet contract checks
+    - Deliverable: add automated checks that fail when proof sheet evidence/commands drift from repo reality
+    - Done when: CI validates referenced evidence paths and command paths in `docs/eap_proof_sheet.md`
+    - Status: complete (`scripts/verify_proof_sheet.py`, `tests/contract/test_eap_proof_sheet_contract.py`, `.github/workflows/ci.yml`)
 
 ## Guardrails
 

--- a/scripts/verify_proof_sheet.py
+++ b/scripts/verify_proof_sheet.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_ALLOWED_COMMAND_PATH_PREFIXES = (
+    "tests/",
+    "scripts/",
+    "integrations/",
+    "docs/",
+    "environment/",
+    ".github/",
+)
+
+_ALLOWED_EVIDENCE_PATH_PREFIXES = (
+    "tests/",
+    "scripts/",
+    "integrations/",
+    "docs/",
+    "environment/",
+    "protocol/",
+    "agent/",
+    "eap/",
+    "sdk/",
+    "starter_packs/",
+    ".github/",
+)
+
+
+@dataclass
+class VerificationResult:
+    checked_evidence_paths: list[str]
+    checked_command_paths: list[str]
+    missing_evidence_paths: list[str]
+    missing_command_paths: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.missing_evidence_paths and not self.missing_command_paths
+
+
+def _extract_section(markdown: str, heading: str) -> str:
+    lines = markdown.splitlines()
+    start_index: int | None = None
+    for index, line in enumerate(lines):
+        if line.strip() == heading:
+            start_index = index + 1
+            break
+    if start_index is None:
+        return ""
+
+    section_lines: list[str] = []
+    for line in lines[start_index:]:
+        if line.startswith("## "):
+            break
+        section_lines.append(line)
+    return "\n".join(section_lines)
+
+
+def _extract_backticked_tokens(text: str) -> list[str]:
+    return re.findall(r"`([^`\n]+)`", text)
+
+
+def _looks_like_repo_path(token: str) -> bool:
+    if not token or " " in token:
+        return False
+    if token.startswith("http://") or token.startswith("https://"):
+        return False
+    if token.startswith("/"):
+        return False
+    if token.startswith("POST "):
+        return False
+
+    if token == "app.py":
+        return True
+
+    if token.startswith(_ALLOWED_EVIDENCE_PATH_PREFIXES):
+        return True
+
+    return False
+
+
+def _extract_bash_blocks(markdown: str) -> list[str]:
+    return re.findall(r"```bash\n(.*?)```", markdown, flags=re.DOTALL)
+
+
+def _extract_command_paths(markdown: str) -> list[str]:
+    blocks = _extract_bash_blocks(markdown)
+    candidates: set[str] = set()
+    path_pattern = re.compile(r"([A-Za-z0-9_.\-/]+)")
+
+    for block in blocks:
+        for token in path_pattern.findall(block):
+            if token == "app.py":
+                candidates.add(token)
+                continue
+
+            normalized = token.rstrip("\\")
+            if normalized.startswith(_ALLOWED_COMMAND_PATH_PREFIXES):
+                candidates.add(normalized)
+
+    return sorted(candidates)
+
+
+def verify_proof_sheet(proof_sheet_path: Path, repo_root: Path) -> VerificationResult:
+    markdown = proof_sheet_path.read_text(encoding="utf-8")
+    capability_table = _extract_section(markdown, "## Side-by-Side Capability Table")
+
+    evidence_tokens = _extract_backticked_tokens(capability_table)
+    evidence_paths = sorted({token for token in evidence_tokens if _looks_like_repo_path(token)})
+
+    command_paths = _extract_command_paths(markdown)
+
+    missing_evidence_paths = [
+        path for path in evidence_paths if not (repo_root / path).exists()
+    ]
+    missing_command_paths = [
+        path for path in command_paths if not (repo_root / path).exists()
+    ]
+
+    if not evidence_paths:
+        missing_evidence_paths.append("<no-evidence-paths-found>")
+    if not command_paths:
+        missing_command_paths.append("<no-command-paths-found>")
+
+    return VerificationResult(
+        checked_evidence_paths=evidence_paths,
+        checked_command_paths=command_paths,
+        missing_evidence_paths=missing_evidence_paths,
+        missing_command_paths=missing_command_paths,
+    )
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate docs/eap_proof_sheet.md evidence and command references."
+    )
+    parser.add_argument(
+        "--proof-sheet",
+        default=str(REPO_ROOT / "docs" / "eap_proof_sheet.md"),
+        help="Path to the proof sheet markdown file.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(REPO_ROOT),
+        help="Repository root used to resolve relative paths.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    proof_sheet_path = Path(args.proof_sheet).resolve()
+    repo_root = Path(args.repo_root).resolve()
+
+    result = verify_proof_sheet(proof_sheet_path=proof_sheet_path, repo_root=repo_root)
+
+    print(f"Proof sheet: {proof_sheet_path}")
+    print(f"Checked evidence paths: {len(result.checked_evidence_paths)}")
+    print(f"Checked command paths: {len(result.checked_command_paths)}")
+
+    if result.missing_evidence_paths:
+        print("Missing evidence paths:")
+        for path in result.missing_evidence_paths:
+            print(f"- {path}")
+
+    if result.missing_command_paths:
+        print("Missing command paths:")
+        for path in result.missing_command_paths:
+            print(f"- {path}")
+
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/contract/test_eap_proof_sheet_contract.py
+++ b/tests/contract/test_eap_proof_sheet_contract.py
@@ -1,0 +1,66 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERIFY_SCRIPT = REPO_ROOT / "scripts" / "verify_proof_sheet.py"
+
+
+class EAPProofSheetContractTest(unittest.TestCase):
+    def test_verify_script_passes_for_repository_proof_sheet(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(VERIFY_SCRIPT)],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, msg=completed.stdout + completed.stderr)
+
+    def test_verify_script_fails_when_referenced_paths_are_missing(self) -> None:
+        proof_markdown = """# EAP Proof Sheet: Why EAP Now
+
+## Side-by-Side Capability Table
+
+| Capability | EAP runtime status | OpenClaw interop status | Evidence |
+| --- | --- | --- | --- |
+| Broken row | test | test | `scripts/missing_file.py`, `docs/missing_doc.md` |
+
+## Reproducible Commands
+
+```bash
+python scripts/missing_file.py
+```
+"""
+
+        with tempfile.TemporaryDirectory(prefix="eap-proof-sheet-contract-") as temp_dir:
+            temp_root = Path(temp_dir)
+            proof_path = temp_root / "proof.md"
+            proof_path.write_text(proof_markdown, encoding="utf-8")
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(VERIFY_SCRIPT),
+                    "--proof-sheet",
+                    str(proof_path),
+                    "--repo-root",
+                    str(temp_root),
+                ],
+                cwd=str(REPO_ROOT),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 1)
+            combined_output = completed.stdout + completed.stderr
+            self.assertIn("scripts/missing_file.py", combined_output)
+            self.assertIn("docs/missing_doc.md", combined_output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/verify_proof_sheet.py` to validate evidence and command references in `docs/eap_proof_sheet.md`
- add contract test coverage in `tests/contract/test_eap_proof_sheet_contract.py`
- wire the proof-sheet contract check into the CI py3.11 lane
- update phase tracking docs and roadmap done log to mark EAP-083 complete and advance to EAP-084

## Validation
- `/Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python scripts/verify_proof_sheet.py`
- `/Users/ct/Desktop/efficient-agent-protocol/.venv-eap072b/bin/python -m pytest -q tests/contract/test_eap_proof_sheet_contract.py`
