### PR TITLE
EAP-084: establish Linear-first execution protocol

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,3 +75,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-081` operator telemetry pack added with dashboard-ready diagnostics and failed-run triage artifacts.
 - Phase 7 `EAP-082` competitive proof sheet refreshed with side-by-side capability matrix and reproducible validation commands.
 - Phase 7 `EAP-083` proof sheet contract checks added and enforced in CI to prevent evidence/command drift.
+- Phase 7 `EAP-084` execution governance protocol added with Linear-first ordered queue (`docs/execution_protocol.md`).

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -1,0 +1,37 @@
+# Execution Protocol (Linear-First)
+
+This protocol prevents ad-hoc execution and keeps all work in a visible ordered queue.
+
+## Source Of Truth
+
+1. Linear issue state is the execution authority.
+2. This file mirrors the active order (`Now`, `Next`, `Blocked`).
+3. `docs/phase7_competitive_openclaw_roadmap.md` is the narrative roadmap, not the live queue.
+
+## Start Gate (Must Be True Before Coding)
+
+1. Issue exists in Linear with an EAP ID.
+2. Issue has explicit deliverable + measurable done criteria.
+3. Issue state is `Todo` and it is the top `Next` item.
+4. Dependencies are either `Done` or explicitly marked as blockers.
+
+## Finish Gate (Must Be True Before Marking Done)
+
+1. Code/docs/tests merged to `main`.
+2. Required CI checks pass.
+3. Roadmap/docs updated for status and next item.
+4. Linear issue moved to `Done` with merged PR link.
+
+## Current Ordered Queue
+
+Updated: 2026-02-24
+
+| Order | EAP ID | Linear | Status | Notes |
+| --- | --- | --- | --- | --- |
+| 1 | `EAP-084` | `GEN-45` | `Done` | Establish execution protocol + queue mirror |
+| 2 | `EAP-085` | `GEN-44` | `Todo` | Define tranche 4 scope + acceptance criteria |
+| 3 | `EAP-086` | `GEN-46` | `Backlog` | Blocked by `EAP-085` |
+
+## Execution Rule
+
+Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,8 +1,8 @@
 # OpenClaw Interop Spike (EAP-071)
 
-Status: Updated through EAP-083 (2026-02-24)  
+Status: Updated through EAP-084 (2026-02-24)  
 Owner: EAP maintainers  
-Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081, EAP-082, EAP-083)
+Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081, EAP-082, EAP-083, EAP-084)
 
 ## 1) Version Snapshot
 
@@ -229,7 +229,21 @@ Recommended sequence:
 - proof sheet command references now include verifier execution:
   - `docs/eap_proof_sheet.md`
 
-Proceed to **EAP-084**.
+`EAP-084` follow-up is now complete (see section 14 below).
+
+## 14) Implemented Execution Governance Protocol (EAP-084)
+
+`EAP-084` is now implemented in-repo with:
+- Linear-first execution protocol:
+  - `docs/execution_protocol.md`
+- explicit `Now/Next/Blocked` queue mapped to Linear IDs:
+  - `GEN-45` (`EAP-084`)
+  - `GEN-44` (`EAP-085`)
+  - `GEN-46` (`EAP-086`, blocked)
+- roadmap sync:
+  - `docs/phase7_competitive_openclaw_roadmap.md`
+
+Proceed to **EAP-085**.
 
 ## References (Primary Sources)
 

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -1,6 +1,6 @@
 # Phase 7 Competitive Roadmap (OpenClaw + Market Positioning)
 
-Status: In progress (through EAP-083, 2026-02-24)
+Status: In progress (through EAP-084, 2026-02-24)
 
 Current status:
 - [x] `EAP-071` interop spike + compatibility matrix published (`docs/openclaw_interop.md`)
@@ -16,7 +16,8 @@ Current status:
 - [x] `EAP-081` operator telemetry pack (dashboard-ready triage artifacts)
 - [x] `EAP-082` "Why EAP now" competitive proof sheet refresh
 - [x] `EAP-083` proof sheet contract checks in CI
-- [ ] `EAP-084` onward
+- [x] `EAP-084` execution governance protocol + Linear-first queue
+- [ ] `EAP-085` onward
 
 ## Objective
 
@@ -130,6 +131,11 @@ Optional validation track:
     - Deliverable: add automated checks that fail when proof sheet evidence/commands drift from repo reality
     - Done when: CI validates referenced evidence paths and command paths in `docs/eap_proof_sheet.md`
     - Status: complete (`scripts/verify_proof_sheet.py`, `tests/contract/test_eap_proof_sheet_contract.py`, `.github/workflows/ci.yml`)
+
+14. `EAP-084` Execution governance protocol and queue discipline
+    - Deliverable: publish a Linear-first execution protocol and explicit ordered queue to stop ad-hoc starts
+    - Done when: queue is visible in-repo and mapped to active Linear issues (`Now`/`Next`/`Blocked`)
+    - Status: complete (`docs/execution_protocol.md`, Linear `GEN-45/GEN-44/GEN-46`)
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary
- add `docs/execution_protocol.md` as the Linear-first execution operating protocol
- define explicit start/finish gates to prevent ad-hoc item starts
- publish visible ordered queue (`Now`, `Next`, `Blocked`) mapped to Linear IDs (`GEN-45`, `GEN-44`, `GEN-46`)
- sync Phase 7 status docs and roadmap to mark EAP-084 complete and move next item to EAP-085

## Validation
- docs/process-only update
- verified queue/order references in updated roadmap docs
