### PR TITLE
EAP-086: configurable OpenClaw routing headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ EAP_MODEL=nemotron-orchestrator-8b
 EAP_API_KEY=not-needed
 EAP_TIMEOUT_SECONDS=60
 EAP_TEMPERATURE=0.0
+# Optional JSON headers for OpenAI-compatible requests
+# Example: {"x-openclaw-agent-id":"my-openclaw-agent"}
+EAP_EXTRA_HEADERS_JSON={}
 
 # Architect override values
 EAP_ARCHITECT_BASE_URL=http://localhost:1234
@@ -11,6 +14,7 @@ EAP_ARCHITECT_MODEL=nemotron-orchestrator-8b
 EAP_ARCHITECT_API_KEY=not-needed
 EAP_ARCHITECT_TIMEOUT_SECONDS=60
 EAP_ARCHITECT_TEMPERATURE=0.0
+EAP_ARCHITECT_EXTRA_HEADERS_JSON={}
 
 # Auditor override values
 EAP_AUDITOR_BASE_URL=http://localhost:1234
@@ -18,6 +22,7 @@ EAP_AUDITOR_MODEL=nemotron-orchestrator-8b
 EAP_AUDITOR_API_KEY=not-needed
 EAP_AUDITOR_TIMEOUT_SECONDS=60
 EAP_AUDITOR_TEMPERATURE=0.0
+EAP_AUDITOR_EXTRA_HEADERS_JSON={}
 
 # Logging
 EAP_LOG_LEVEL=INFO

--- a/agent/agent_client.py
+++ b/agent/agent_client.py
@@ -18,6 +18,7 @@ class AgentClient:
         provider_name: str = "local",
         fallback_provider_name: Optional[str] = None,
         provider: Optional[LLMProvider] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
     ):
         self.endpoint = f"{base_url.rstrip('/')}/v1/chat/completions"
         self.base_url = base_url.rstrip("/")
@@ -27,12 +28,14 @@ class AgentClient:
         self.temperature = temperature
         self.timeout_seconds = timeout_seconds
         self.provider_name = provider_name
+        self.extra_headers = dict(extra_headers or {})
         self.fallback_provider_name = fallback_provider_name
         self.provider = provider or create_provider(
             provider_name=provider_name,
             base_url=self.base_url,
             api_key=api_key,
             timeout_seconds=timeout_seconds,
+            extra_headers=self.extra_headers,
             fallback_provider_name=fallback_provider_name,
         )
         self.compiler = MacroCompiler()
@@ -40,9 +43,10 @@ class AgentClient:
     def _headers(self) -> Dict[str, str]:
         if hasattr(self.provider, "_headers"):
             return self.provider._headers()  # type: ignore[attr-defined]
+        headers = dict(self.extra_headers)
         if self.api_key and self.api_key != "not-needed":
-            return {"Authorization": f"Bearer {self.api_key}"}
-        return {}
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
 
     def chat(self, user_input: str) -> str:
         """Simple text-to-text chat for non-macro tasks like auditing."""

--- a/agent/providers/factory.py
+++ b/agent/providers/factory.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from .anthropic_provider import AnthropicProvider
 from .base import LLMProvider
@@ -19,11 +19,17 @@ def _build_provider(
     base_url: str,
     api_key: str,
     timeout_seconds: int,
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> LLMProvider:
     normalized = _normalize_provider_name(provider_name)
     if normalized in {"local", "openai"}:
         endpoint = f"{base_url.rstrip('/')}/v1/chat/completions"
-        return OpenAIProvider(endpoint=endpoint, api_key=api_key, timeout_seconds=timeout_seconds)
+        return OpenAIProvider(
+            endpoint=endpoint,
+            api_key=api_key,
+            timeout_seconds=timeout_seconds,
+            extra_headers=extra_headers,
+        )
 
     if normalized == "anthropic":
         if not api_key or api_key == "not-needed":
@@ -47,6 +53,7 @@ def create_provider(
     api_key: str,
     timeout_seconds: int,
     fallback_provider_name: Optional[str] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> LLMProvider:
     try:
         return _build_provider(
@@ -54,6 +61,7 @@ def create_provider(
             base_url=base_url,
             api_key=api_key,
             timeout_seconds=timeout_seconds,
+            extra_headers=extra_headers,
         )
     except ValueError:
         if not fallback_provider_name:
@@ -63,4 +71,5 @@ def create_provider(
             base_url=base_url,
             api_key=api_key,
             timeout_seconds=timeout_seconds,
+            extra_headers=extra_headers,
         )

--- a/agent/providers/openai_provider.py
+++ b/agent/providers/openai_provider.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Optional
 
 import requests
 
@@ -9,15 +9,23 @@ from .base import CompletionRequest, CompletionResponse, LLMProvider
 class OpenAIProvider(LLMProvider):
     """Adapter for OpenAI-compatible `/v1/chat/completions` APIs."""
 
-    def __init__(self, endpoint: str, api_key: str, timeout_seconds: int):
+    def __init__(
+        self,
+        endpoint: str,
+        api_key: str,
+        timeout_seconds: int,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ):
         self.endpoint = endpoint
         self.api_key = api_key
         self.timeout_seconds = timeout_seconds
+        self.extra_headers = dict(extra_headers or {})
 
     def _headers(self) -> Dict[str, str]:
+        headers = dict(self.extra_headers)
         if self.api_key and self.api_key != "not-needed":
-            return {"Authorization": f"Bearer {self.api_key}"}
-        return {}
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
 
     def _request(self, request: CompletionRequest) -> CompletionResponse:
         payload = {

--- a/app.py
+++ b/app.py
@@ -311,6 +311,7 @@ with tab1:
                         api_key=settings.architect.api_key,
                         temperature=settings.architect.temperature,
                         timeout_seconds=settings.architect.timeout_seconds,
+                        extra_headers=settings.architect.extra_headers,
                         system_prompt="You are the ARCHITECT. Create efficient tool-calling macros."
                     )
                     hashed_names = registry.get_hashed_manifest()
@@ -334,6 +335,7 @@ with tab1:
                         api_key=settings.auditor.api_key,
                         temperature=settings.auditor.temperature,
                         timeout_seconds=settings.auditor.timeout_seconds,
+                        extra_headers=settings.auditor.extra_headers,
                         system_prompt="Review for safety. Respond APPROVED or DENIED."
                     )
                     review_prompt = f"Review: {macro.model_dump_json()}"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ Global defaults:
 - `EAP_API_KEY`
 - `EAP_TIMEOUT_SECONDS`
 - `EAP_TEMPERATURE`
+- `EAP_EXTRA_HEADERS_JSON` (optional JSON object of HTTP headers)
 
 Role-specific overrides:
 - `EAP_ARCHITECT_BASE_URL`
@@ -24,11 +25,13 @@ Role-specific overrides:
 - `EAP_ARCHITECT_API_KEY`
 - `EAP_ARCHITECT_TIMEOUT_SECONDS`
 - `EAP_ARCHITECT_TEMPERATURE`
+- `EAP_ARCHITECT_EXTRA_HEADERS_JSON` (optional JSON object of HTTP headers)
 - `EAP_AUDITOR_BASE_URL`
 - `EAP_AUDITOR_MODEL`
 - `EAP_AUDITOR_API_KEY`
 - `EAP_AUDITOR_TIMEOUT_SECONDS`
 - `EAP_AUDITOR_TEMPERATURE`
+- `EAP_AUDITOR_EXTRA_HEADERS_JSON` (optional JSON object of HTTP headers)
 
 Logging:
 - `EAP_LOG_LEVEL` (`DEBUG`, `INFO`, `WARNING`, `ERROR`)
@@ -48,12 +51,17 @@ Pointer janitor (dashboard):
 - `EAP_POINTER_JANITOR_INTERVAL_SECONDS` (default: `300`)
 - `EAP_POINTER_JANITOR_MAX_DELETE` (default: `200`)
 
+OpenClaw routing header example:
+- Global: `EAP_EXTRA_HEADERS_JSON='{"x-openclaw-agent-id":"my-agent"}'`
+- Architect-only override: `EAP_ARCHITECT_EXTRA_HEADERS_JSON='{"x-openclaw-agent-id":"architect-agent"}'`
+
 ## Validation Rules
 
 - Base URLs must start with `http://` or `https://`.
 - Models and API keys cannot be empty strings.
 - Timeout values must be integers greater than zero.
 - Temperature must be a float greater than or equal to zero.
+- Extra header JSON values must be objects with non-empty string keys and values.
 - Executor global concurrency must be a positive integer.
 - Global burst capacity requires global RPS to be set.
 - Per-tool limits JSON must be an object keyed by non-empty tool names.

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -30,7 +30,7 @@ Updated: 2026-02-24
 | --- | --- | --- | --- | --- |
 | 1 | `EAP-084` | `GEN-45` | `Done` | Establish execution protocol + queue mirror |
 | 2 | `EAP-085` | `GEN-44` | `Done` | Tranche 4 scope and acceptance criteria defined |
-| 3 | `EAP-086` | `GEN-46` | `Todo` | OpenClaw agent-routing header support |
+| 3 | `EAP-086` | `GEN-46` | `In Progress` | OpenClaw agent-routing header support |
 | 4 | `EAP-087` | `GEN-48` | `Backlog` | Blocked by `EAP-086` |
 | 5 | `EAP-088` | `GEN-47` | `Backlog` | Blocked by `EAP-087` |
 

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,8 +1,8 @@
 # OpenClaw Interop Spike (EAP-071)
 
-Status: Updated through EAP-085 (2026-02-24)  
+Status: Updated for EAP-086 in-progress implementation (2026-02-24)  
 Owner: EAP maintainers  
-Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081, EAP-082, EAP-083, EAP-084, EAP-085)
+Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081, EAP-082, EAP-083, EAP-084, EAP-085, EAP-086)
 
 ## 1) Version Snapshot
 
@@ -38,7 +38,7 @@ EAP-side surfaces:
 | --- | --- | --- | --- | --- |
 | LLM chat transport | `POST /v1/chat/completions` (OpenAI shape) | `OpenAIProvider` posts to `/v1/chat/completions` | **Compatible now** | Configure `EAP_BASE_URL` to OpenClaw gateway URL; endpoint must be enabled in OpenClaw config. |
 | Gateway auth model | Bearer token, gateway auth mode token/password | EAP OpenAI provider sends `Authorization: Bearer <api_key>` | **Compatible now** | Set `EAP_API_KEY` to gateway token/password value used by OpenClaw auth mode. |
-| OpenClaw agent selection | Preferred: `model: "openclaw:<agentId>"`; optional header `x-openclaw-agent-id` | EAP controls `model`, but does not set custom gateway headers | **Partial** | Use `EAP_MODEL=openclaw:<agentId>`; header-based routing would require EAP provider header extension. |
+| OpenClaw agent selection | Preferred: `model: "openclaw:<agentId>"`; optional header `x-openclaw-agent-id` | EAP controls `model` and now supports configurable custom headers in OpenAI-compatible provider path | **Compatible now** | Use `EAP_MODEL=openclaw:<agentId>` and/or `EAP_EXTRA_HEADERS_JSON='{"x-openclaw-agent-id":"<agentId>"}'` (role-specific overrides supported). |
 | Streaming chat | SSE for OpenAI endpoint when `stream=true` | EAP provider has SSE stream parsing for `data:` + `[DONE]` | **Compatible now** | Verify with real gateway in EAP-075 CI smoke. |
 | OpenResponses API | `POST /v1/responses` (disabled by default) | No EAP provider for Responses API | **Gap** | Optional future adapter (not required for MVP interop). |
 | Tool invocation API | `POST /tools/invoke`, policy + denylist enforced | No EAP client for this endpoint | **Gap** | Add dedicated client only if we need direct OpenClaw tool calls outside agent-turn flow. |
@@ -90,8 +90,8 @@ Recommended sequence:
 
 ## 6) Known Limits / Risks Identified
 
-1. **Agent routing header not configurable in EAP provider**
-   - OpenClaw supports `x-openclaw-agent-id`; EAP currently cannot set custom headers in `OpenAIProvider`.
+1. **Agent routing header configuration added in EAP-086**
+   - `OpenAIProvider` now supports configurable headers via `EAP_EXTRA_HEADERS_JSON` and role-specific overrides.
 2. **OpenClaw endpoint toggles**
    - `/v1/chat/completions` is disabled by default; operators must enable it.
 3. **Plugin model mismatch**
@@ -239,7 +239,7 @@ Recommended sequence:
 - explicit `Now/Next/Blocked` queue mapped to Linear IDs:
   - `GEN-45` (`EAP-084`)
   - `GEN-44` (`EAP-085`)
-  - `GEN-46` (`EAP-086`, blocked)
+  - `GEN-46` (`EAP-086`, in progress)
 - roadmap sync:
   - `docs/phase7_competitive_openclaw_roadmap.md`
 
@@ -260,7 +260,26 @@ Recommended sequence:
 - queue sync:
   - `docs/execution_protocol.md`
 
-Proceed to **EAP-086**.
+`EAP-086` implementation is in progress (see section 16 below).
+
+## 16) In-Progress OpenClaw Agent-Routing Header Support (EAP-086)
+
+`EAP-086` implementation branch currently includes:
+- configurable extra headers in runtime settings:
+  - `EAP_EXTRA_HEADERS_JSON`
+  - `EAP_ARCHITECT_EXTRA_HEADERS_JSON`
+  - `EAP_AUDITOR_EXTRA_HEADERS_JSON`
+- provider plumbing and request emission:
+  - `OpenAIProvider` accepts and sends configured headers
+  - `AgentClient` and provider factory pass configured headers
+- test and docs coverage:
+  - `tests/unit/test_provider_adapters.py`
+  - `tests/unit/test_settings.py`
+  - `tests/integration/test_provider_selection.py`
+  - `docs/configuration.md`
+  - `.env.example`
+
+After merge, proceed to **EAP-087**.
 
 ## References (Primary Sources)
 

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -1,6 +1,6 @@
 # Phase 7 Competitive Roadmap (OpenClaw + Market Positioning)
 
-Status: In progress (through EAP-085, 2026-02-24)
+Status: In progress (through EAP-086 implementation in progress, 2026-02-24)
 
 Current status:
 - [x] `EAP-071` interop spike + compatibility matrix published (`docs/openclaw_interop.md`)
@@ -18,7 +18,8 @@ Current status:
 - [x] `EAP-083` proof sheet contract checks in CI
 - [x] `EAP-084` execution governance protocol + Linear-first queue
 - [x] `EAP-085` tranche 4 scope + acceptance criteria
-- [ ] `EAP-086` onward
+- [ ] `EAP-086` OpenClaw agent-routing header support (in progress)
+- [ ] `EAP-087` onward
 
 ## Objective
 
@@ -147,6 +148,7 @@ Optional validation track:
 
 16. `EAP-086` OpenClaw agent-routing header support (`x-openclaw-agent-id`)
     - Linear: `GEN-46`
+    - Status: in progress (implementation branch has settings/provider/tests/docs updates pending merge)
 17. `EAP-087` OpenClaw `/tools/invoke` client bridge
     - Linear: `GEN-48` (blocked by `EAP-086`)
 18. `EAP-088` OpenAI Responses API adapter path

--- a/docs/phase7_tranche4_scope.md
+++ b/docs/phase7_tranche4_scope.md
@@ -1,6 +1,6 @@
 # Phase 7 Tranche 4 Scope (EAP-085)
 
-Updated: 2026-02-24  
+Updated: 2026-02-24 (execution through EAP-086)  
 Source of truth: Linear project `Efficient Agent Protocol Roadmap`
 
 ## Objective
@@ -22,4 +22,4 @@ Close the remaining high-impact OpenClaw interoperability gaps identified in `do
 
 ## Execution Constraint
 
-Only the first non-blocked `Todo` item may be started (`EAP-086`).
+Only the first non-blocked `Todo` item may be started (currently `EAP-086`).

--- a/protocol/settings.py
+++ b/protocol/settings.py
@@ -18,6 +18,7 @@ class LLMClientSettings:
     api_key: str
     timeout_seconds: int
     temperature: float
+    extra_headers: Dict[str, str]
 
 
 @dataclass(frozen=True)
@@ -79,6 +80,26 @@ def _parse_optional_int(value: str, field_name: str) -> Optional[int]:
     return parsed
 
 
+def _parse_extra_headers(value: str, field_name: str) -> Dict[str, str]:
+    normalized = value.strip() or "{}"
+    try:
+        parsed = json.loads(normalized)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{field_name} must be valid JSON.") from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{field_name} must be a JSON object.")
+
+    headers: Dict[str, str] = {}
+    for raw_key, raw_value in parsed.items():
+        if not isinstance(raw_key, str) or not raw_key.strip():
+            raise ValueError(f"{field_name} keys must be non-empty strings.")
+        if not isinstance(raw_value, str) or not raw_value.strip():
+            raise ValueError(f"{field_name} values must be non-empty strings.")
+        headers[raw_key.strip()] = raw_value.strip()
+    return headers
+
+
 def _build_client_settings(role_prefix: str) -> LLMClientSettings:
     base_url = _validate_base_url(
         os.getenv(f"{role_prefix}_BASE_URL", os.getenv("EAP_BASE_URL", DEFAULT_BASE_URL)),
@@ -103,12 +124,24 @@ def _build_client_settings(role_prefix: str) -> LLMClientSettings:
     if temperature < 0:
         raise ValueError(f"{role_prefix}_TEMPERATURE must be >= 0")
 
+    global_extra_headers = _parse_extra_headers(
+        os.getenv("EAP_EXTRA_HEADERS_JSON", "{}"),
+        "EAP_EXTRA_HEADERS_JSON",
+    )
+    role_extra_headers = _parse_extra_headers(
+        os.getenv(f"{role_prefix}_EXTRA_HEADERS_JSON", "{}"),
+        f"{role_prefix}_EXTRA_HEADERS_JSON",
+    )
+    extra_headers = dict(global_extra_headers)
+    extra_headers.update(role_extra_headers)
+
     return LLMClientSettings(
         base_url=base_url,
         model_name=model_name,
         api_key=api_key,
         timeout_seconds=timeout_seconds,
         temperature=temperature,
+        extra_headers=extra_headers,
     )
 
 

--- a/tests/integration/test_provider_selection.py
+++ b/tests/integration/test_provider_selection.py
@@ -12,6 +12,15 @@ class ProviderSelectionIntegrationTest(unittest.TestCase):
         )
         self.assertIsInstance(client.provider, OpenAIProvider)
 
+    def test_local_provider_applies_extra_headers(self) -> None:
+        client = AgentClient(
+            base_url="http://localhost:1234",
+            model_name="model-a",
+            extra_headers={"x-openclaw-agent-id": "router-abc"},
+        )
+        self.assertIsInstance(client.provider, OpenAIProvider)
+        self.assertEqual(client._headers()["x-openclaw-agent-id"], "router-abc")
+
     def test_anthropic_provider_selected_when_configured(self) -> None:
         client = AgentClient(
             base_url="https://api.anthropic.com",

--- a/tests/unit/test_provider_adapters.py
+++ b/tests/unit/test_provider_adapters.py
@@ -61,6 +61,29 @@ class ProviderAdaptersTest(unittest.TestCase):
         self.assertTrue(kwargs["stream"])
         self.assertTrue(kwargs["json"]["stream"])
 
+    def test_openai_provider_includes_configured_extra_headers(self) -> None:
+        provider = OpenAIProvider(
+            endpoint="http://localhost:1234/v1/chat/completions",
+            api_key="secret",
+            timeout_seconds=10,
+            extra_headers={"x-openclaw-agent-id": "router-123"},
+        )
+        request = CompletionRequest(
+            model="gpt-4o-mini",
+            messages=[ProviderMessage(role="user", content="hello")],
+            temperature=0.1,
+        )
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+        mock_response.raise_for_status.return_value = None
+
+        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+            provider.complete(request)
+
+        kwargs = post.call_args.kwargs
+        self.assertEqual(kwargs["headers"]["x-openclaw-agent-id"], "router-123")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer secret")
+
     def test_anthropic_provider_normalizes_response(self) -> None:
         provider = AnthropicProvider(
             endpoint="https://api.anthropic.com/v1/messages",

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -11,6 +11,8 @@ class SettingsTest(unittest.TestCase):
             settings = load_settings()
             self.assertEqual(settings.architect.base_url, "http://localhost:1234")
             self.assertEqual(settings.auditor.base_url, "http://localhost:1234")
+            self.assertEqual(settings.architect.extra_headers, {})
+            self.assertEqual(settings.auditor.extra_headers, {})
             self.assertEqual(settings.executor.max_global_concurrency, 8)
             self.assertEqual(settings.executor.per_tool_limits, {})
 
@@ -20,12 +22,17 @@ class SettingsTest(unittest.TestCase):
             {
                 "EAP_ARCHITECT_MODEL": "arch-model",
                 "EAP_AUDITOR_MODEL": "audit-model",
+                "EAP_EXTRA_HEADERS_JSON": '{"x-shared":"one","x-role":"global"}',
+                "EAP_ARCHITECT_EXTRA_HEADERS_JSON": '{"x-role":"architect"}',
             },
             clear=True,
         ):
             settings = load_settings()
             self.assertEqual(settings.architect.model_name, "arch-model")
             self.assertEqual(settings.auditor.model_name, "audit-model")
+            self.assertEqual(settings.architect.extra_headers["x-shared"], "one")
+            self.assertEqual(settings.architect.extra_headers["x-role"], "architect")
+            self.assertEqual(settings.auditor.extra_headers["x-role"], "global")
 
     def test_invalid_base_url_fails_fast(self) -> None:
         with mock.patch.dict(os.environ, {"EAP_BASE_URL": "localhost:1234"}, clear=True):
@@ -48,6 +55,15 @@ class SettingsTest(unittest.TestCase):
             settings = load_settings()
             self.assertEqual(settings.executor.per_tool_limits["tool_a"].max_concurrency, 2)
             self.assertEqual(settings.executor.per_tool_limits["tool_a"].requests_per_second, 5.0)
+
+    def test_invalid_extra_headers_validation(self) -> None:
+        with mock.patch.dict(os.environ, {"EAP_EXTRA_HEADERS_JSON": '["bad"]'}, clear=True):
+            with self.assertRaises(ValueError):
+                load_settings()
+
+        with mock.patch.dict(os.environ, {"EAP_AUDITOR_EXTRA_HEADERS_JSON": '{"x-one": 1}'}, clear=True):
+            with self.assertRaises(ValueError):
+                load_settings()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add configurable extra headers to LLM client settings via `EAP_EXTRA_HEADERS_JSON` and role-specific overrides
- plumb `extra_headers` through `AgentClient` and provider factory into `OpenAIProvider`
- emit configured headers (including `x-openclaw-agent-id`) while preserving existing default behavior
- add unit/integration test coverage and update configuration/interop/queue docs

## Verification
- `.venv/bin/python -m unittest tests.unit.test_settings tests.unit.test_provider_adapters tests.integration.test_provider_selection tests.unit.test_agent_client`
