### PR TITLE
EAP-087: add OpenClaw /tools/invoke bridge

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,3 +77,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-083` proof sheet contract checks added and enforced in CI to prevent evidence/command drift.
 - Phase 7 `EAP-084` execution governance protocol added with Linear-first ordered queue (`docs/execution_protocol.md`).
 - Phase 7 `EAP-085` tranche-4 scope defined with ordered dependency chain (`EAP-086` -> `EAP-087` -> `EAP-088`).
+- Phase 7 `EAP-086` OpenClaw routing header support merged (`PR #36`).

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -30,8 +30,8 @@ Updated: 2026-02-24
 | --- | --- | --- | --- | --- |
 | 1 | `EAP-084` | `GEN-45` | `Done` | Establish execution protocol + queue mirror |
 | 2 | `EAP-085` | `GEN-44` | `Done` | Tranche 4 scope and acceptance criteria defined |
-| 3 | `EAP-086` | `GEN-46` | `In Progress` | OpenClaw agent-routing header support |
-| 4 | `EAP-087` | `GEN-48` | `Backlog` | Blocked by `EAP-086` |
+| 3 | `EAP-086` | `GEN-46` | `Done` | OpenClaw agent-routing header support |
+| 4 | `EAP-087` | `GEN-48` | `In Progress` | OpenClaw `/tools/invoke` bridge |
 | 5 | `EAP-088` | `GEN-47` | `Backlog` | Blocked by `EAP-087` |
 
 ## Execution Rule

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,8 +1,8 @@
 # OpenClaw Interop Spike (EAP-071)
 
-Status: Updated for EAP-086 in-progress implementation (2026-02-24)  
+Status: Updated for EAP-087 in-progress implementation (2026-02-24)  
 Owner: EAP maintainers  
-Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081, EAP-082, EAP-083, EAP-084, EAP-085, EAP-086)
+Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081, EAP-082, EAP-083, EAP-084, EAP-085, EAP-086, EAP-087)
 
 ## 1) Version Snapshot
 
@@ -41,7 +41,7 @@ EAP-side surfaces:
 | OpenClaw agent selection | Preferred: `model: "openclaw:<agentId>"`; optional header `x-openclaw-agent-id` | EAP controls `model` and now supports configurable custom headers in OpenAI-compatible provider path | **Compatible now** | Use `EAP_MODEL=openclaw:<agentId>` and/or `EAP_EXTRA_HEADERS_JSON='{"x-openclaw-agent-id":"<agentId>"}'` (role-specific overrides supported). |
 | Streaming chat | SSE for OpenAI endpoint when `stream=true` | EAP provider has SSE stream parsing for `data:` + `[DONE]` | **Compatible now** | Verify with real gateway in EAP-075 CI smoke. |
 | OpenResponses API | `POST /v1/responses` (disabled by default) | No EAP provider for Responses API | **Gap** | Optional future adapter (not required for MVP interop). |
-| Tool invocation API | `POST /tools/invoke`, policy + denylist enforced | No EAP client for this endpoint | **Gap** | Add dedicated client only if we need direct OpenClaw tool calls outside agent-turn flow. |
+| Tool invocation API | `POST /tools/invoke`, policy + denylist enforced | EAP now has typed OpenClaw tools-invoke client + runtime bridge tool (`invoke_openclaw_tool`) | **Compatible now** | Use bridge tool for direct gateway tool calls with bearer auth and policy-denial mapping. |
 | Plugin runtime model | TypeScript/JavaScript in-process plugin modules, required `openclaw.plugin.json` | Adapter package added at `integrations/openclaw/eap-runtime-plugin` | **Compatible now (MVP)** | Plugin exports required tools and maps directly to EAP runtime endpoints. |
 | Skills model | AgentSkills-style `SKILL.md`; plugin can ship skills via manifest `skills` field | Skill pack added at `integrations/openclaw/eap-runtime-plugin/skills` | **Compatible now (MVP)** | Includes `run`, `inspect`, `retry failed step`, and `export trace` skill workflows with quickstart docs. |
 | External EAP control plane | OpenClaw plugins/tools can call external HTTP services | EAP runtime service now serves execute/run/pointer summary endpoints | **Compatible now (MVP)** | Bearer auth and JSON error envelopes are implemented and covered by integration tests. |
@@ -239,7 +239,8 @@ Recommended sequence:
 - explicit `Now/Next/Blocked` queue mapped to Linear IDs:
   - `GEN-45` (`EAP-084`)
   - `GEN-44` (`EAP-085`)
-  - `GEN-46` (`EAP-086`, in progress)
+  - `GEN-46` (`EAP-086`, done)
+  - `GEN-48` (`EAP-087`, in progress)
 - roadmap sync:
   - `docs/phase7_competitive_openclaw_roadmap.md`
 
@@ -255,16 +256,16 @@ Recommended sequence:
   - `docs/phase7_tranche4_scope.md`
 - ordered implementation backlog and dependencies:
   - `EAP-086` / `GEN-46` (OpenClaw agent-routing header support)
-  - `EAP-087` / `GEN-48` (OpenClaw `/tools/invoke` bridge), blocked by `EAP-086`
+  - `EAP-087` / `GEN-48` (OpenClaw `/tools/invoke` bridge)
   - `EAP-088` / `GEN-47` (Responses API adapter path), blocked by `EAP-087`
 - queue sync:
   - `docs/execution_protocol.md`
 
-`EAP-086` implementation is in progress (see section 16 below).
+`EAP-086` follow-up is now complete (see section 16 below).
 
-## 16) In-Progress OpenClaw Agent-Routing Header Support (EAP-086)
+## 16) Implemented OpenClaw Agent-Routing Header Support (EAP-086)
 
-`EAP-086` implementation branch currently includes:
+`EAP-086` is now implemented in-repo with:
 - configurable extra headers in runtime settings:
   - `EAP_EXTRA_HEADERS_JSON`
   - `EAP_ARCHITECT_EXTRA_HEADERS_JSON`
@@ -279,7 +280,42 @@ Recommended sequence:
   - `docs/configuration.md`
   - `.env.example`
 
-After merge, proceed to **EAP-087**.
+`EAP-087` implementation is now in progress (see section 17 below).
+
+## 17) In-Progress OpenClaw `/tools/invoke` Bridge (EAP-087)
+
+`EAP-087` implementation branch currently includes:
+- typed OpenClaw tools-invoke client:
+  - `environment/openclaw_client.py`
+- runtime bridge tool:
+  - `environment/tools/openclaw_tools.py`
+  - schema export in `environment.tools` and `eap.environment.tools`
+- coverage for success, auth failure, and policy-denial mapping:
+  - `tests/unit/test_openclaw_client.py`
+  - `tests/unit/test_openclaw_tools.py`
+  - `tests/integration/test_openclaw_tools_invoke_bridge.py`
+
+Minimal invocation example (macro step arguments):
+```json
+{
+  "step_id": "step_openclaw_tool",
+  "tool_name": "invoke_openclaw_tool",
+  "arguments": {
+    "base_url": "https://openclaw-gateway.example.com",
+    "api_key": "gateway-token",
+    "tool_name": "fetch_issue",
+    "tool_arguments": {"id": "GEN-48"},
+    "timeout_seconds": 30
+  }
+}
+```
+
+Guardrails:
+- keep `tool_arguments` scoped to tool-specific inputs only (do not pass unrelated secrets);
+- treat `api_key` as credential material and source it from runtime secret management;
+- handle policy denials as expected control-path outcomes (`TOOL_INVOKE_POLICY_DENIED`).
+
+After merge, proceed to **EAP-088**.
 
 ## References (Primary Sources)
 

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -1,6 +1,6 @@
 # Phase 7 Competitive Roadmap (OpenClaw + Market Positioning)
 
-Status: In progress (through EAP-086 implementation in progress, 2026-02-24)
+Status: In progress (through EAP-087 implementation in progress, 2026-02-24)
 
 Current status:
 - [x] `EAP-071` interop spike + compatibility matrix published (`docs/openclaw_interop.md`)
@@ -18,8 +18,9 @@ Current status:
 - [x] `EAP-083` proof sheet contract checks in CI
 - [x] `EAP-084` execution governance protocol + Linear-first queue
 - [x] `EAP-085` tranche 4 scope + acceptance criteria
-- [ ] `EAP-086` OpenClaw agent-routing header support (in progress)
-- [ ] `EAP-087` onward
+- [x] `EAP-086` OpenClaw agent-routing header support
+- [ ] `EAP-087` OpenClaw `/tools/invoke` bridge (in progress)
+- [ ] `EAP-088` onward
 
 ## Objective
 
@@ -148,9 +149,10 @@ Optional validation track:
 
 16. `EAP-086` OpenClaw agent-routing header support (`x-openclaw-agent-id`)
     - Linear: `GEN-46`
-    - Status: in progress (implementation branch has settings/provider/tests/docs updates pending merge)
+    - Status: complete (PR #36 merged to `main`)
 17. `EAP-087` OpenClaw `/tools/invoke` client bridge
-    - Linear: `GEN-48` (blocked by `EAP-086`)
+    - Linear: `GEN-48`
+    - Status: in progress (typed tools-invoke client + runtime bridge + integration tests in branch)
 18. `EAP-088` OpenAI Responses API adapter path
     - Linear: `GEN-47` (blocked by `EAP-087`)
 

--- a/docs/phase7_tranche4_scope.md
+++ b/docs/phase7_tranche4_scope.md
@@ -1,6 +1,6 @@
 # Phase 7 Tranche 4 Scope (EAP-085)
 
-Updated: 2026-02-24 (execution through EAP-086)  
+Updated: 2026-02-24 (execution through EAP-087 in progress)  
 Source of truth: Linear project `Efficient Agent Protocol Roadmap`
 
 ## Objective
@@ -22,4 +22,4 @@ Close the remaining high-impact OpenClaw interoperability gaps identified in `do
 
 ## Execution Constraint
 
-Only the first non-blocked `Todo` item may be started (currently `EAP-086`).
+Only the first non-blocked `Todo` item may be started (currently `EAP-087`).

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -91,6 +91,25 @@ This document describes the built-in tools shipped in `environment.tools`.
   - Returns JSON text payload from MCP result so downstream steps can parse it.
   - Schema uses `additionalProperties: false`.
 
+### `invoke_openclaw_tool`
+- Purpose: Call OpenClaw gateway `POST /tools/invoke` and return the JSON response payload.
+- Parameters:
+  - `base_url` (`string`, required, `minLength=1`)
+  - `api_key` (`string`, required, `minLength=1`)
+  - `tool_name` (`string`, required, `minLength=1`)
+  - `tool_arguments` (`object`, optional)
+  - `timeout_seconds` (`integer`, optional, `1..120`)
+  - `account_id` (`string`, optional, `minLength=1`)
+  - `channel_id` (`string`, optional, `minLength=1`)
+- Notes:
+  - Sends bearer auth via `Authorization: Bearer <api_key>`.
+  - Supports OpenClaw multi-tenant routing headers:
+    - `x-openclaw-account-id`
+    - `x-openclaw-channel-id`
+  - Maps gateway policy denials (`TOOL_INVOKE_POLICY_DENIED`) to normalized tool errors.
+  - Returns JSON text payload so downstream steps can parse tool output.
+  - Schema uses `additionalProperties: false`.
+
 ## Validation contract
 
 Tool inputs are validated by `ToolRegistry.validate_arguments` before execution.

--- a/eap/environment/openclaw_client.py
+++ b/eap/environment/openclaw_client.py
@@ -1,0 +1,13 @@
+from environment.openclaw_client import (
+    OpenClawToolInvokeError,
+    OpenClawToolInvokeRequest,
+    OpenClawToolInvokeResponse,
+    invoke_openclaw_tools_api,
+)
+
+__all__ = [
+    "OpenClawToolInvokeError",
+    "OpenClawToolInvokeRequest",
+    "OpenClawToolInvokeResponse",
+    "invoke_openclaw_tools_api",
+]

--- a/eap/environment/tools/__init__.py
+++ b/eap/environment/tools/__init__.py
@@ -2,6 +2,7 @@ from environment.tools import (
     ANALYZE_SCHEMA,
     FETCH_SCHEMA,
     INVOKE_MCP_TOOL_SCHEMA,
+    INVOKE_OPENCLAW_TOOL_SCHEMA,
     LIST_DIRECTORY_SCHEMA,
     READ_FILE_SCHEMA,
     EXTRACT_LINKS_SCHEMA,
@@ -13,6 +14,7 @@ from environment.tools import (
     fetch_json_url,
     fetch_user_data,
     invoke_mcp_tool,
+    invoke_openclaw_tool,
     list_local_directory,
     read_local_file,
     scrape_url,
@@ -38,4 +40,6 @@ __all__ = [
     "EXTRACT_LINKS_SCHEMA",
     "invoke_mcp_tool",
     "INVOKE_MCP_TOOL_SCHEMA",
+    "invoke_openclaw_tool",
+    "INVOKE_OPENCLAW_TOOL_SCHEMA",
 ]

--- a/eap/environment/tools/openclaw_tools.py
+++ b/eap/environment/tools/openclaw_tools.py
@@ -1,0 +1,3 @@
+from environment.tools.openclaw_tools import INVOKE_OPENCLAW_TOOL_SCHEMA, invoke_openclaw_tool
+
+__all__ = ["invoke_openclaw_tool", "INVOKE_OPENCLAW_TOOL_SCHEMA"]

--- a/environment/openclaw_client.py
+++ b/environment/openclaw_client.py
@@ -1,0 +1,167 @@
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+
+@dataclass(frozen=True)
+class OpenClawToolInvokeRequest:
+    name: str
+    arguments: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class OpenClawToolInvokeResponse:
+    status_code: int
+    payload: Dict[str, Any]
+
+
+class OpenClawToolInvokeError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        status_code: int,
+        error_type: str,
+        details: Optional[Dict[str, Any]] = None,
+        retry_after_seconds: Optional[int] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_type = error_type
+        self.details = details
+        self.retry_after_seconds = retry_after_seconds
+
+
+def _parse_retry_after_seconds(value: Optional[str]) -> Optional[int]:
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    try:
+        return int(normalized)
+    except ValueError:
+        return None
+
+
+def _read_json_payload(response: requests.Response) -> Dict[str, Any]:
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {"message": response.text.strip() or "OpenClaw response was not valid JSON."}
+    if not isinstance(payload, dict):
+        return {"message": json.dumps(payload)}
+    return payload
+
+
+def _extract_error_code(payload: Dict[str, Any]) -> Optional[str]:
+    error = payload.get("error")
+    if isinstance(error, dict):
+        code = error.get("code")
+        if isinstance(code, str) and code.strip():
+            return code.strip()
+    code = payload.get("code")
+    if isinstance(code, str) and code.strip():
+        return code.strip()
+    return None
+
+
+def _extract_error_message(payload: Dict[str, Any], default: str) -> str:
+    error = payload.get("error")
+    if isinstance(error, dict):
+        message = error.get("message")
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+    message = payload.get("message")
+    if isinstance(message, str) and message.strip():
+        return message.strip()
+    return default
+
+
+def _extract_error_details(payload: Dict[str, Any], fallback_code: Optional[str]) -> Optional[Dict[str, Any]]:
+    details: Dict[str, Any] = {}
+    error = payload.get("error")
+    if isinstance(error, dict):
+        nested_details = error.get("details")
+        if isinstance(nested_details, dict):
+            details.update(nested_details)
+        elif nested_details is not None:
+            details["details"] = nested_details
+    top_details = payload.get("details")
+    if isinstance(top_details, dict):
+        details.update(top_details)
+    elif top_details is not None:
+        details["details"] = top_details
+    if fallback_code and "code" not in details:
+        details["code"] = fallback_code
+    return details or None
+
+
+def _map_error_type(status_code: int, error_code: Optional[str]) -> str:
+    normalized_code = (error_code or "").upper()
+    if "POLICY_DENIED" in normalized_code:
+        return "policy_denied"
+    if status_code in (401, 403):
+        return "unauthorized"
+    if status_code == 429:
+        return "rate_limited"
+    if status_code == 400:
+        return "validation_error"
+    return "tool_execution_error"
+
+
+def invoke_openclaw_tools_api(
+    base_url: str,
+    api_key: str,
+    request: OpenClawToolInvokeRequest,
+    timeout_seconds: int = 30,
+    account_id: Optional[str] = None,
+    channel_id: Optional[str] = None,
+) -> OpenClawToolInvokeResponse:
+    normalized_base = (base_url or "").strip().rstrip("/")
+    if not normalized_base.startswith(("http://", "https://")):
+        raise ValueError("base_url must start with http:// or https://")
+
+    normalized_key = (api_key or "").strip()
+    if not normalized_key:
+        raise ValueError("api_key cannot be empty")
+
+    if not request.name.strip():
+        raise ValueError("request.name cannot be empty")
+
+    endpoint = f"{normalized_base}/tools/invoke"
+    headers = {
+        "Authorization": f"Bearer {normalized_key}",
+        "Content-Type": "application/json",
+    }
+    if account_id and account_id.strip():
+        headers["x-openclaw-account-id"] = account_id.strip()
+    if channel_id and channel_id.strip():
+        headers["x-openclaw-channel-id"] = channel_id.strip()
+
+    response = requests.post(
+        endpoint,
+        json={"name": request.name, "arguments": request.arguments},
+        headers=headers,
+        timeout=timeout_seconds,
+    )
+    payload = _read_json_payload(response)
+    if 200 <= response.status_code < 300:
+        return OpenClawToolInvokeResponse(status_code=response.status_code, payload=payload)
+
+    error_code = _extract_error_code(payload)
+    error_type = _map_error_type(response.status_code, error_code)
+    message = _extract_error_message(
+        payload,
+        default=f"OpenClaw /tools/invoke failed with HTTP {response.status_code}.",
+    )
+    details = _extract_error_details(payload, fallback_code=error_code)
+    retry_after_seconds = _parse_retry_after_seconds(response.headers.get("Retry-After"))
+    raise OpenClawToolInvokeError(
+        message=message,
+        status_code=response.status_code,
+        error_type=error_type,
+        details=details,
+        retry_after_seconds=retry_after_seconds,
+    )

--- a/environment/tools/__init__.py
+++ b/environment/tools/__init__.py
@@ -20,6 +20,10 @@ from .mcp_tools import (
     INVOKE_MCP_TOOL_SCHEMA,
     invoke_mcp_tool,
 )
+from .openclaw_tools import (
+    INVOKE_OPENCLAW_TOOL_SCHEMA,
+    invoke_openclaw_tool,
+)
 
 __all__ = [
     "fetch_user_data", "analyze_data", "FETCH_SCHEMA", "ANALYZE_SCHEMA",
@@ -28,4 +32,5 @@ __all__ = [
     "scrape_url", "fetch_json_url", "extract_links_from_url",
     "SCRAPE_SCHEMA", "FETCH_JSON_SCHEMA", "EXTRACT_LINKS_SCHEMA",
     "invoke_mcp_tool", "INVOKE_MCP_TOOL_SCHEMA",
+    "invoke_openclaw_tool", "INVOKE_OPENCLAW_TOOL_SCHEMA",
 ]

--- a/environment/tools/openclaw_tools.py
+++ b/environment/tools/openclaw_tools.py
@@ -1,0 +1,63 @@
+import json
+from typing import Any, Dict, Optional
+
+from environment.openclaw_client import (
+    OpenClawToolInvokeError,
+    OpenClawToolInvokeRequest,
+    invoke_openclaw_tools_api,
+)
+
+
+def invoke_openclaw_tool(
+    base_url: str,
+    api_key: str,
+    tool_name: str,
+    tool_arguments: Optional[Dict[str, Any]] = None,
+    timeout_seconds: int = 30,
+    account_id: Optional[str] = None,
+    channel_id: Optional[str] = None,
+) -> str:
+    """
+    Invoke an OpenClaw gateway tool via HTTP `/tools/invoke`.
+
+    Returns JSON-encoded payload from OpenClaw so downstream steps can parse it.
+    """
+    try:
+        response = invoke_openclaw_tools_api(
+            base_url=base_url,
+            api_key=api_key,
+            request=OpenClawToolInvokeRequest(
+                name=tool_name,
+                arguments=tool_arguments or {},
+            ),
+            timeout_seconds=timeout_seconds,
+            account_id=account_id,
+            channel_id=channel_id,
+        )
+    except OpenClawToolInvokeError as exc:
+        message = (
+            f"OpenClaw /tools/invoke failed ({exc.error_type}, status={exc.status_code}): {str(exc)}"
+        )
+        raise RuntimeError(message) from exc
+
+    return json.dumps(response.payload, sort_keys=True)
+
+
+INVOKE_OPENCLAW_TOOL_SCHEMA = {
+    "name": "invoke_openclaw_tool",
+    "description": "Invoke an OpenClaw gateway tool through HTTP /tools/invoke and return JSON response payload.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "base_url": {"type": "string", "minLength": 1},
+            "api_key": {"type": "string", "minLength": 1},
+            "tool_name": {"type": "string", "minLength": 1},
+            "tool_arguments": {"type": "object"},
+            "timeout_seconds": {"type": "integer", "minimum": 1, "maximum": 120},
+            "account_id": {"type": "string", "minLength": 1},
+            "channel_id": {"type": "string", "minLength": 1},
+        },
+        "required": ["base_url", "api_key", "tool_name"],
+        "additionalProperties": False,
+    },
+}

--- a/tests/integration/test_openclaw_tools_invoke_bridge.py
+++ b/tests/integration/test_openclaw_tools_invoke_bridge.py
@@ -1,0 +1,211 @@
+import json
+import os
+import tempfile
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from typing import Any, Dict
+
+import requests
+
+from eap.environment import AsyncLocalExecutor, ToolRegistry
+from eap.environment.tools import INVOKE_OPENCLAW_TOOL_SCHEMA, invoke_openclaw_tool
+from eap.protocol import StateManager
+from eap.runtime import EAPRuntimeHTTPServer
+
+
+def _json_response(handler: BaseHTTPRequestHandler, status_code: int, payload: Dict[str, Any]) -> None:
+    encoded = json.dumps(payload, sort_keys=True).encode("utf-8")
+    handler.send_response(status_code)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(encoded)))
+    handler.end_headers()
+    handler.wfile.write(encoded)
+
+
+class _MockOpenClawToolsInvokeHandler(BaseHTTPRequestHandler):
+    server: "_MockOpenClawHTTPServer"
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/tools/invoke":
+            _json_response(self, 404, {"error": {"code": "NOT_FOUND", "message": "Route not found."}})
+            return
+
+        auth_header = (self.headers.get("Authorization") or "").strip()
+        if auth_header != f"Bearer {self.server.required_token}":
+            _json_response(
+                self,
+                401,
+                {"error": {"code": "UNAUTHORIZED", "message": "Missing or invalid bearer token."}},
+            )
+            return
+
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            _json_response(
+                self,
+                400,
+                {"error": {"code": "BAD_REQUEST", "message": "Invalid Content-Length header."}},
+            )
+            return
+
+        raw_body = self.rfile.read(content_length)
+        try:
+            payload = json.loads(raw_body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            _json_response(
+                self,
+                400,
+                {"error": {"code": "BAD_REQUEST", "message": "Request body must be valid JSON."}},
+            )
+            return
+
+        tool_name = payload.get("name")
+        arguments = payload.get("arguments", {})
+        if tool_name == "blocked_tool":
+            _json_response(
+                self,
+                403,
+                {
+                    "error": {
+                        "code": "TOOL_INVOKE_POLICY_DENIED",
+                        "message": "Tool denied by policy.",
+                        "details": {"policy": "denylist"},
+                    }
+                },
+            )
+            return
+
+        _json_response(
+            self,
+            200,
+            {"ok": True, "tool": tool_name, "arguments": arguments},
+        )
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+        return
+
+
+class _MockOpenClawHTTPServer(ThreadingHTTPServer):
+    def __init__(self, required_token: str):
+        super().__init__(("127.0.0.1", 0), _MockOpenClawToolsInvokeHandler)
+        self.required_token = required_token
+        self._thread = Thread(target=self.serve_forever, daemon=True)
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.server_address[1]}"
+
+    def start(self) -> "_MockOpenClawHTTPServer":
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self.shutdown()
+        self.server_close()
+        if self._thread.is_alive():
+            self._thread.join(timeout=5)
+
+
+class OpenClawToolsInvokeBridgeIntegrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        fd, self.db_path = tempfile.mkstemp(prefix="eap-openclaw-tools-", suffix=".db")
+        os.close(fd)
+
+        self.state_manager = StateManager(db_path=self.db_path)
+        registry = ToolRegistry()
+        registry.register("invoke_openclaw_tool", invoke_openclaw_tool, INVOKE_OPENCLAW_TOOL_SCHEMA)
+        executor = AsyncLocalExecutor(self.state_manager, registry)
+
+        self.runtime_server = EAPRuntimeHTTPServer(
+            executor=executor,
+            state_manager=self.state_manager,
+            required_bearer_token="runtime-token",
+        ).start()
+        self.openclaw_server = _MockOpenClawHTTPServer(required_token="gateway-token").start()
+        time.sleep(0.05)
+
+    def tearDown(self) -> None:
+        self.runtime_server.stop()
+        self.openclaw_server.stop()
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def _execute_bridge_step(self, api_key: str, tool_name: str) -> Dict[str, Any]:
+        response = requests.post(
+            f"{self.runtime_server.base_url}/v1/eap/macro/execute",
+            headers={"Authorization": "Bearer runtime-token"},
+            json={
+                "macro": {
+                    "steps": [
+                        {
+                            "step_id": "step_openclaw",
+                            "tool_name": "invoke_openclaw_tool",
+                            "arguments": {
+                                "base_url": self.openclaw_server.base_url,
+                                "api_key": api_key,
+                                "tool_name": tool_name,
+                                "tool_arguments": {"text": "hello"},
+                                "timeout_seconds": 10,
+                            },
+                        }
+                    ]
+                }
+            },
+            timeout=10,
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.json()
+
+    def test_runtime_bridge_executes_openclaw_tool_successfully(self) -> None:
+        body = self._execute_bridge_step(api_key="gateway-token", tool_name="echo_tool")
+        payload = json.loads(self.state_manager.retrieve(body["pointer_id"]))
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["tool"], "echo_tool")
+        self.assertEqual(payload["arguments"]["text"], "hello")
+
+    def test_runtime_bridge_surfaces_auth_failure(self) -> None:
+        body = self._execute_bridge_step(api_key="wrong-token", tool_name="echo_tool")
+        self.assertEqual(body["metadata"]["status"], "error")
+        self.assertEqual(body["metadata"]["error_type"], "tool_execution_error")
+
+        run_id = body["metadata"]["execution_run_id"]
+        run_response = requests.get(
+            f"{self.runtime_server.base_url}/v1/eap/runs/{run_id}",
+            headers={"Authorization": "Bearer runtime-token"},
+            timeout=5,
+        )
+        self.assertEqual(run_response.status_code, 200)
+        failed_events = [
+            event
+            for event in run_response.json()["trace_events"]
+            if event.get("event_type") == "failed"
+        ]
+        self.assertEqual(len(failed_events), 1)
+        self.assertIn("unauthorized", failed_events[0]["error"]["message"].lower())
+
+    def test_runtime_bridge_surfaces_policy_denial(self) -> None:
+        body = self._execute_bridge_step(api_key="gateway-token", tool_name="blocked_tool")
+        self.assertEqual(body["metadata"]["status"], "error")
+        self.assertEqual(body["metadata"]["error_type"], "tool_execution_error")
+
+        run_id = body["metadata"]["execution_run_id"]
+        run_response = requests.get(
+            f"{self.runtime_server.base_url}/v1/eap/runs/{run_id}",
+            headers={"Authorization": "Bearer runtime-token"},
+            timeout=5,
+        )
+        self.assertEqual(run_response.status_code, 200)
+        failed_events = [
+            event
+            for event in run_response.json()["trace_events"]
+            if event.get("event_type") == "failed"
+        ]
+        self.assertEqual(len(failed_events), 1)
+        self.assertIn("policy_denied", failed_events[0]["error"]["message"].lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_openclaw_client.py
+++ b/tests/unit/test_openclaw_client.py
@@ -1,0 +1,111 @@
+import unittest
+from unittest.mock import patch
+
+from eap.environment.openclaw_client import (
+    OpenClawToolInvokeError,
+    OpenClawToolInvokeRequest,
+    invoke_openclaw_tools_api,
+)
+
+
+class _MockResponse:
+    def __init__(self, status_code, payload, headers=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.headers = headers or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class OpenClawClientUnitTest(unittest.TestCase):
+    def test_invoke_openclaw_tools_api_success(self) -> None:
+        mock_response = _MockResponse(
+            status_code=200,
+            payload={"ok": True, "tool": "echo_tool", "result": {"text": "hello"}},
+        )
+        with patch("environment.openclaw_client.requests.post", return_value=mock_response) as post:
+            result = invoke_openclaw_tools_api(
+                base_url="https://gateway.openclaw.local",
+                api_key="secret-token",
+                request=OpenClawToolInvokeRequest(name="echo_tool", arguments={"text": "hello"}),
+                timeout_seconds=12,
+                account_id="acct-123",
+                channel_id="chan-456",
+            )
+
+        self.assertEqual(result.status_code, 200)
+        self.assertTrue(result.payload["ok"])
+        kwargs = post.call_args.kwargs
+        self.assertEqual(kwargs["timeout"], 12)
+        self.assertEqual(kwargs["json"]["name"], "echo_tool")
+        self.assertEqual(kwargs["json"]["arguments"]["text"], "hello")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer secret-token")
+        self.assertEqual(kwargs["headers"]["x-openclaw-account-id"], "acct-123")
+        self.assertEqual(kwargs["headers"]["x-openclaw-channel-id"], "chan-456")
+
+    def test_invoke_openclaw_tools_api_maps_unauthorized(self) -> None:
+        mock_response = _MockResponse(
+            status_code=401,
+            payload={"error": {"code": "UNAUTHORIZED", "message": "Missing or invalid bearer token."}},
+        )
+        with patch("environment.openclaw_client.requests.post", return_value=mock_response):
+            with self.assertRaises(OpenClawToolInvokeError) as context:
+                invoke_openclaw_tools_api(
+                    base_url="https://gateway.openclaw.local",
+                    api_key="wrong-token",
+                    request=OpenClawToolInvokeRequest(name="echo_tool", arguments={}),
+                )
+
+        error = context.exception
+        self.assertEqual(error.error_type, "unauthorized")
+        self.assertEqual(error.status_code, 401)
+        self.assertIn("invalid bearer token", str(error).lower())
+
+    def test_invoke_openclaw_tools_api_maps_policy_denied(self) -> None:
+        mock_response = _MockResponse(
+            status_code=403,
+            payload={
+                "error": {
+                    "code": "TOOL_INVOKE_POLICY_DENIED",
+                    "message": "Tool denied by policy.",
+                    "details": {"policy": "denylist"},
+                }
+            },
+        )
+        with patch("environment.openclaw_client.requests.post", return_value=mock_response):
+            with self.assertRaises(OpenClawToolInvokeError) as context:
+                invoke_openclaw_tools_api(
+                    base_url="https://gateway.openclaw.local",
+                    api_key="secret-token",
+                    request=OpenClawToolInvokeRequest(name="blocked_tool", arguments={}),
+                )
+
+        error = context.exception
+        self.assertEqual(error.error_type, "policy_denied")
+        self.assertEqual(error.status_code, 403)
+        self.assertEqual(error.details["policy"], "denylist")
+        self.assertEqual(error.details["code"], "TOOL_INVOKE_POLICY_DENIED")
+
+    def test_invoke_openclaw_tools_api_reads_retry_after(self) -> None:
+        mock_response = _MockResponse(
+            status_code=429,
+            payload={"error": {"code": "RATE_LIMITED", "message": "Too many requests."}},
+            headers={"Retry-After": "17"},
+        )
+        with patch("environment.openclaw_client.requests.post", return_value=mock_response):
+            with self.assertRaises(OpenClawToolInvokeError) as context:
+                invoke_openclaw_tools_api(
+                    base_url="https://gateway.openclaw.local",
+                    api_key="secret-token",
+                    request=OpenClawToolInvokeRequest(name="echo_tool", arguments={}),
+                )
+
+        error = context.exception
+        self.assertEqual(error.error_type, "rate_limited")
+        self.assertEqual(error.retry_after_seconds, 17)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_openclaw_tools.py
+++ b/tests/unit/test_openclaw_tools.py
@@ -1,0 +1,50 @@
+import json
+import unittest
+from unittest.mock import patch
+
+from eap.environment.openclaw_client import (
+    OpenClawToolInvokeError,
+    OpenClawToolInvokeResponse,
+)
+from eap.environment.tools.openclaw_tools import invoke_openclaw_tool
+
+
+class OpenClawToolsUnitTest(unittest.TestCase):
+    def test_invoke_openclaw_tool_returns_json_payload(self) -> None:
+        response = OpenClawToolInvokeResponse(
+            status_code=200,
+            payload={"ok": True, "result": {"answer": 42}},
+        )
+        with patch("environment.tools.openclaw_tools.invoke_openclaw_tools_api", return_value=response):
+            raw = invoke_openclaw_tool(
+                base_url="https://gateway.openclaw.local",
+                api_key="secret-token",
+                tool_name="echo_tool",
+                tool_arguments={"x": 1},
+            )
+        parsed = json.loads(raw)
+        self.assertTrue(parsed["ok"])
+        self.assertEqual(parsed["result"]["answer"], 42)
+
+    def test_invoke_openclaw_tool_translates_client_error(self) -> None:
+        with patch(
+            "environment.tools.openclaw_tools.invoke_openclaw_tools_api",
+            side_effect=OpenClawToolInvokeError(
+                message="Tool denied by policy.",
+                status_code=403,
+                error_type="policy_denied",
+            ),
+        ):
+            with self.assertRaises(RuntimeError) as context:
+                invoke_openclaw_tool(
+                    base_url="https://gateway.openclaw.local",
+                    api_key="secret-token",
+                    tool_name="blocked_tool",
+                )
+
+        self.assertIn("policy_denied", str(context.exception))
+        self.assertIn("status=403", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_tool_schemas.py
+++ b/tests/unit/test_tool_schemas.py
@@ -7,6 +7,7 @@ from eap.environment.tools import (
     EXTRACT_LINKS_SCHEMA,
     FETCH_JSON_SCHEMA,
     INVOKE_MCP_TOOL_SCHEMA,
+    INVOKE_OPENCLAW_TOOL_SCHEMA,
     LIST_DIRECTORY_SCHEMA,
     READ_FILE_SCHEMA,
     SCRAPE_SCHEMA,
@@ -15,6 +16,7 @@ from eap.environment.tools import (
     extract_links_from_url,
     fetch_json_url,
     invoke_mcp_tool,
+    invoke_openclaw_tool,
     list_local_directory,
     read_local_file,
     scrape_url,
@@ -33,6 +35,7 @@ class ToolSchemaValidationTest(unittest.TestCase):
         self.registry.register("fetch_json_url", fetch_json_url, FETCH_JSON_SCHEMA)
         self.registry.register("extract_links_from_url", extract_links_from_url, EXTRACT_LINKS_SCHEMA)
         self.registry.register("invoke_mcp_tool", invoke_mcp_tool, INVOKE_MCP_TOOL_SCHEMA)
+        self.registry.register("invoke_openclaw_tool", invoke_openclaw_tool, INVOKE_OPENCLAW_TOOL_SCHEMA)
 
     def test_valid_payload_passes_validation(self) -> None:
         self.registry.validate_arguments("analyze_data", {"raw_data": "payload", "focus": "summary"})
@@ -97,6 +100,28 @@ class ToolSchemaValidationTest(unittest.TestCase):
                     "server_command": "python -u /tmp/server.py",
                     "tool_name": "echo",
                     "tool_arguments": "not-an-object",
+                },
+            )
+
+    def test_openclaw_schema_requires_base_url(self) -> None:
+        with self.assertRaises(InputValidationError):
+            self.registry.validate_arguments(
+                "invoke_openclaw_tool",
+                {
+                    "api_key": "secret-token",
+                    "tool_name": "echo_tool",
+                },
+            )
+
+    def test_openclaw_schema_rejects_unknown_fields(self) -> None:
+        with self.assertRaises(InputValidationError):
+            self.registry.validate_arguments(
+                "invoke_openclaw_tool",
+                {
+                    "base_url": "https://gateway.openclaw.local",
+                    "api_key": "secret-token",
+                    "tool_name": "echo_tool",
+                    "extra": "not-allowed",
                 },
             )
 


### PR DESCRIPTION
## Summary
- add typed OpenClaw `/tools/invoke` client in `environment/openclaw_client.py`
- add runtime bridge tool `invoke_openclaw_tool` with strict schema in `environment/tools/openclaw_tools.py`
- export bridge tool through `environment.tools` and `eap.environment.tools`
- add unit and integration coverage for success, auth failure, and policy-denial paths
- update OpenClaw interop, queue, roadmap, and tools docs for EAP-087 progress

## Verification
- `.venv/bin/python -m unittest tests.unit.test_openclaw_client tests.unit.test_openclaw_tools tests.unit.test_tool_schemas tests.integration.test_openclaw_tools_invoke_bridge`
- `.venv/bin/python -m unittest tests.unit.test_settings tests.unit.test_provider_adapters tests.integration.test_provider_selection tests.unit.test_agent_client tests.unit.test_tool_schemas tests.unit.test_openclaw_client tests.unit.test_openclaw_tools tests.integration.test_openclaw_tools_invoke_bridge tests.integration.test_mcp_interop tests.integration.test_runtime_http_api`
