### PR TITLE
EAP-088: add OpenAI Responses API adapter path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ EAP_MODEL=nemotron-orchestrator-8b
 EAP_API_KEY=not-needed
 EAP_TIMEOUT_SECONDS=60
 EAP_TEMPERATURE=0.0
+# OpenAI-compatible transport mode: chat_completions | responses
+EAP_OPENAI_API_MODE=chat_completions
 # Optional JSON headers for OpenAI-compatible requests
 # Example: {"x-openclaw-agent-id":"my-openclaw-agent"}
 EAP_EXTRA_HEADERS_JSON={}
@@ -14,6 +16,7 @@ EAP_ARCHITECT_MODEL=nemotron-orchestrator-8b
 EAP_ARCHITECT_API_KEY=not-needed
 EAP_ARCHITECT_TIMEOUT_SECONDS=60
 EAP_ARCHITECT_TEMPERATURE=0.0
+EAP_ARCHITECT_OPENAI_API_MODE=chat_completions
 EAP_ARCHITECT_EXTRA_HEADERS_JSON={}
 
 # Auditor override values
@@ -22,6 +25,7 @@ EAP_AUDITOR_MODEL=nemotron-orchestrator-8b
 EAP_AUDITOR_API_KEY=not-needed
 EAP_AUDITOR_TIMEOUT_SECONDS=60
 EAP_AUDITOR_TEMPERATURE=0.0
+EAP_AUDITOR_OPENAI_API_MODE=chat_completions
 EAP_AUDITOR_EXTRA_HEADERS_JSON={}
 
 # Logging

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,3 +78,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-084` execution governance protocol added with Linear-first ordered queue (`docs/execution_protocol.md`).
 - Phase 7 `EAP-085` tranche-4 scope defined with ordered dependency chain (`EAP-086` -> `EAP-087` -> `EAP-088`).
 - Phase 7 `EAP-086` OpenClaw routing header support merged (`PR #36`).
+- Phase 7 `EAP-087` OpenClaw `/tools/invoke` bridge merged (`PR #37`).

--- a/agent/agent_client.py
+++ b/agent/agent_client.py
@@ -16,6 +16,7 @@ class AgentClient:
         temperature: float = 0.0,
         timeout_seconds: int = 60,
         provider_name: str = "local",
+        openai_api_mode: str = "chat_completions",
         fallback_provider_name: Optional[str] = None,
         provider: Optional[LLMProvider] = None,
         extra_headers: Optional[Dict[str, str]] = None,
@@ -28,6 +29,7 @@ class AgentClient:
         self.temperature = temperature
         self.timeout_seconds = timeout_seconds
         self.provider_name = provider_name
+        self.openai_api_mode = openai_api_mode
         self.extra_headers = dict(extra_headers or {})
         self.fallback_provider_name = fallback_provider_name
         self.provider = provider or create_provider(
@@ -36,6 +38,7 @@ class AgentClient:
             api_key=api_key,
             timeout_seconds=timeout_seconds,
             extra_headers=self.extra_headers,
+            openai_api_mode=openai_api_mode,
             fallback_provider_name=fallback_provider_name,
         )
         self.compiler = MacroCompiler()

--- a/agent/providers/factory.py
+++ b/agent/providers/factory.py
@@ -14,21 +14,34 @@ def _normalize_provider_name(provider_name: str) -> str:
     return (provider_name or "local").strip().lower()
 
 
+def _normalize_openai_api_mode(openai_api_mode: str) -> str:
+    normalized = (openai_api_mode or "chat_completions").strip().lower()
+    if normalized in {"chat_completions", "responses"}:
+        return normalized
+    raise ValueError(f"Unsupported OpenAI API mode: {openai_api_mode}")
+
+
 def _build_provider(
     provider_name: str,
     base_url: str,
     api_key: str,
     timeout_seconds: int,
     extra_headers: Optional[Dict[str, str]] = None,
+    openai_api_mode: str = "chat_completions",
 ) -> LLMProvider:
     normalized = _normalize_provider_name(provider_name)
     if normalized in {"local", "openai"}:
-        endpoint = f"{base_url.rstrip('/')}/v1/chat/completions"
+        normalized_api_mode = _normalize_openai_api_mode(openai_api_mode)
+        if normalized_api_mode == "responses":
+            endpoint = f"{base_url.rstrip('/')}/v1/responses"
+        else:
+            endpoint = f"{base_url.rstrip('/')}/v1/chat/completions"
         return OpenAIProvider(
             endpoint=endpoint,
             api_key=api_key,
             timeout_seconds=timeout_seconds,
             extra_headers=extra_headers,
+            api_mode=normalized_api_mode,
         )
 
     if normalized == "anthropic":
@@ -54,6 +67,7 @@ def create_provider(
     timeout_seconds: int,
     fallback_provider_name: Optional[str] = None,
     extra_headers: Optional[Dict[str, str]] = None,
+    openai_api_mode: str = "chat_completions",
 ) -> LLMProvider:
     try:
         return _build_provider(
@@ -62,6 +76,7 @@ def create_provider(
             api_key=api_key,
             timeout_seconds=timeout_seconds,
             extra_headers=extra_headers,
+            openai_api_mode=openai_api_mode,
         )
     except ValueError:
         if not fallback_provider_name:
@@ -72,4 +87,5 @@ def create_provider(
             api_key=api_key,
             timeout_seconds=timeout_seconds,
             extra_headers=extra_headers,
+            openai_api_mode=openai_api_mode,
         )

--- a/agent/providers/openai_provider.py
+++ b/agent/providers/openai_provider.py
@@ -7,7 +7,7 @@ from .base import CompletionRequest, CompletionResponse, LLMProvider
 
 
 class OpenAIProvider(LLMProvider):
-    """Adapter for OpenAI-compatible `/v1/chat/completions` APIs."""
+    """Adapter for OpenAI-compatible APIs (`/v1/chat/completions` and `/v1/responses`)."""
 
     def __init__(
         self,
@@ -15,11 +15,13 @@ class OpenAIProvider(LLMProvider):
         api_key: str,
         timeout_seconds: int,
         extra_headers: Optional[Dict[str, str]] = None,
+        api_mode: str = "chat_completions",
     ):
         self.endpoint = endpoint
         self.api_key = api_key
         self.timeout_seconds = timeout_seconds
         self.extra_headers = dict(extra_headers or {})
+        self.api_mode = api_mode
 
     def _headers(self) -> Dict[str, str]:
         headers = dict(self.extra_headers)
@@ -28,6 +30,40 @@ class OpenAIProvider(LLMProvider):
         return headers
 
     def _request(self, request: CompletionRequest) -> CompletionResponse:
+        if self.api_mode == "responses":
+            payload = {
+                "model": request.model,
+                "input": [
+                    {
+                        "role": msg.role,
+                        "content": [{"type": "text", "text": msg.content}],
+                    }
+                    for msg in request.messages
+                ],
+                "temperature": request.temperature,
+            }
+            if request.tools:
+                payload["tools"] = request.tools
+            response = requests.post(
+                self.endpoint,
+                json=payload,
+                headers=self._headers(),
+                timeout=self.timeout_seconds,
+            )
+            try:
+                response.raise_for_status()
+            except requests.HTTPError as exc:
+                if response.status_code in {404, 405, 410, 501}:
+                    raise RuntimeError(
+                        "OpenAI Responses API path is unavailable on this endpoint."
+                    ) from exc
+                raise
+            raw_json = response.json()
+            return CompletionResponse(
+                text=self._extract_responses_text(raw_json),
+                raw_response=raw_json,
+            )
+
         payload = {
             "model": request.model,
             "messages": [{"role": msg.role, "content": msg.content} for msg in request.messages],
@@ -49,6 +85,31 @@ class OpenAIProvider(LLMProvider):
             raw_response=raw_json,
         )
 
+    @staticmethod
+    def _extract_responses_text(raw_json: Dict[str, object]) -> str:
+        output_text = raw_json.get("output_text")
+        if isinstance(output_text, str) and output_text:
+            return output_text
+
+        fragments = []
+        output = raw_json.get("output")
+        if isinstance(output, list):
+            for item in output:
+                if not isinstance(item, dict):
+                    continue
+                content = item.get("content")
+                if not isinstance(content, list):
+                    continue
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    text = block.get("text")
+                    if isinstance(text, str) and text:
+                        fragments.append(text)
+        if fragments:
+            return "".join(fragments)
+        raise KeyError("Responses payload did not include output_text content.")
+
     def complete(self, request: CompletionRequest) -> CompletionResponse:
         return self._request(request)
 
@@ -56,6 +117,9 @@ class OpenAIProvider(LLMProvider):
         return self._request(request)
 
     def stream(self, request: CompletionRequest) -> Iterable[str]:
+        if self.api_mode == "responses":
+            raise NotImplementedError("Streaming is not implemented for responses API mode.")
+
         payload = {
             "model": request.model,
             "messages": [{"role": msg.role, "content": msg.content} for msg in request.messages],

--- a/app.py
+++ b/app.py
@@ -311,6 +311,7 @@ with tab1:
                         api_key=settings.architect.api_key,
                         temperature=settings.architect.temperature,
                         timeout_seconds=settings.architect.timeout_seconds,
+                        openai_api_mode=settings.architect.openai_api_mode,
                         extra_headers=settings.architect.extra_headers,
                         system_prompt="You are the ARCHITECT. Create efficient tool-calling macros."
                     )
@@ -335,6 +336,7 @@ with tab1:
                         api_key=settings.auditor.api_key,
                         temperature=settings.auditor.temperature,
                         timeout_seconds=settings.auditor.timeout_seconds,
+                        openai_api_mode=settings.auditor.openai_api_mode,
                         extra_headers=settings.auditor.extra_headers,
                         system_prompt="Review for safety. Respond APPROVED or DENIED."
                     )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ Global defaults:
 - `EAP_API_KEY`
 - `EAP_TIMEOUT_SECONDS`
 - `EAP_TEMPERATURE`
+- `EAP_OPENAI_API_MODE` (`chat_completions` or `responses`, default: `chat_completions`)
 - `EAP_EXTRA_HEADERS_JSON` (optional JSON object of HTTP headers)
 
 Role-specific overrides:
@@ -25,12 +26,14 @@ Role-specific overrides:
 - `EAP_ARCHITECT_API_KEY`
 - `EAP_ARCHITECT_TIMEOUT_SECONDS`
 - `EAP_ARCHITECT_TEMPERATURE`
+- `EAP_ARCHITECT_OPENAI_API_MODE` (`chat_completions` or `responses`)
 - `EAP_ARCHITECT_EXTRA_HEADERS_JSON` (optional JSON object of HTTP headers)
 - `EAP_AUDITOR_BASE_URL`
 - `EAP_AUDITOR_MODEL`
 - `EAP_AUDITOR_API_KEY`
 - `EAP_AUDITOR_TIMEOUT_SECONDS`
 - `EAP_AUDITOR_TEMPERATURE`
+- `EAP_AUDITOR_OPENAI_API_MODE` (`chat_completions` or `responses`)
 - `EAP_AUDITOR_EXTRA_HEADERS_JSON` (optional JSON object of HTTP headers)
 
 Logging:
@@ -55,12 +58,24 @@ OpenClaw routing header example:
 - Global: `EAP_EXTRA_HEADERS_JSON='{"x-openclaw-agent-id":"my-agent"}'`
 - Architect-only override: `EAP_ARCHITECT_EXTRA_HEADERS_JSON='{"x-openclaw-agent-id":"architect-agent"}'`
 
+OpenAI Responses API mode example:
+- Global responses path: `EAP_OPENAI_API_MODE=responses`
+- Architect responses + auditor chat-completions split:
+  - `EAP_ARCHITECT_OPENAI_API_MODE=responses`
+  - `EAP_AUDITOR_OPENAI_API_MODE=chat_completions`
+
+Mode guidance:
+- Use `chat_completions` when you need streaming token output (`stream=true` path).
+- Use `responses` when your gateway exposes `POST /v1/responses` and you want explicit Responses API compatibility.
+- If `responses` endpoint is disabled/unsupported, EAP surfaces an explicit runtime error and you should switch mode back to `chat_completions`.
+
 ## Validation Rules
 
 - Base URLs must start with `http://` or `https://`.
 - Models and API keys cannot be empty strings.
 - Timeout values must be integers greater than zero.
 - Temperature must be a float greater than or equal to zero.
+- OpenAI API mode must be `chat_completions` or `responses`.
 - Extra header JSON values must be objects with non-empty string keys and values.
 - Executor global concurrency must be a positive integer.
 - Global burst capacity requires global RPS to be set.

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -31,8 +31,8 @@ Updated: 2026-02-24
 | 1 | `EAP-084` | `GEN-45` | `Done` | Establish execution protocol + queue mirror |
 | 2 | `EAP-085` | `GEN-44` | `Done` | Tranche 4 scope and acceptance criteria defined |
 | 3 | `EAP-086` | `GEN-46` | `Done` | OpenClaw agent-routing header support |
-| 4 | `EAP-087` | `GEN-48` | `In Progress` | OpenClaw `/tools/invoke` bridge |
-| 5 | `EAP-088` | `GEN-47` | `Backlog` | Blocked by `EAP-087` |
+| 4 | `EAP-087` | `GEN-48` | `Done` | OpenClaw `/tools/invoke` bridge |
+| 5 | `EAP-088` | `GEN-47` | `In Progress` | OpenAI Responses API adapter path |
 
 ## Execution Rule
 

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,8 +1,8 @@
 # OpenClaw Interop Spike (EAP-071)
 
-Status: Updated for EAP-087 in-progress implementation (2026-02-24)  
+Status: Updated for EAP-088 in-progress implementation (2026-02-24)  
 Owner: EAP maintainers  
-Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081, EAP-082, EAP-083, EAP-084, EAP-085, EAP-086, EAP-087)
+Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081, EAP-082, EAP-083, EAP-084, EAP-085, EAP-086, EAP-087, EAP-088)
 
 ## 1) Version Snapshot
 
@@ -28,6 +28,7 @@ OpenClaw-side surfaces:
 
 EAP-side surfaces:
 - OpenAI-compatible provider adapter using `base_url + /v1/chat/completions`.
+- Explicit OpenAI Responses mode path using `base_url + /v1/responses` (EAP-088 in progress).
 - Bearer auth header support.
 - Python plugin system via `importlib.metadata` entry points (`eap.tool_plugins`).
 - EAP runtime HTTP endpoints for `/v1/eap/*` execution/status/pointer summary.
@@ -40,7 +41,7 @@ EAP-side surfaces:
 | Gateway auth model | Bearer token, gateway auth mode token/password | EAP OpenAI provider sends `Authorization: Bearer <api_key>` | **Compatible now** | Set `EAP_API_KEY` to gateway token/password value used by OpenClaw auth mode. |
 | OpenClaw agent selection | Preferred: `model: "openclaw:<agentId>"`; optional header `x-openclaw-agent-id` | EAP controls `model` and now supports configurable custom headers in OpenAI-compatible provider path | **Compatible now** | Use `EAP_MODEL=openclaw:<agentId>` and/or `EAP_EXTRA_HEADERS_JSON='{"x-openclaw-agent-id":"<agentId>"}'` (role-specific overrides supported). |
 | Streaming chat | SSE for OpenAI endpoint when `stream=true` | EAP provider has SSE stream parsing for `data:` + `[DONE]` | **Compatible now** | Verify with real gateway in EAP-075 CI smoke. |
-| OpenResponses API | `POST /v1/responses` (disabled by default) | No EAP provider for Responses API | **Gap** | Optional future adapter (not required for MVP interop). |
+| OpenResponses API | `POST /v1/responses` (disabled by default) | EAP provider path now supports explicit Responses mode selection (in progress) | **In progress** | Configure `EAP_OPENAI_API_MODE=responses`; unsupported/disabled endpoints are surfaced as explicit runtime errors. |
 | Tool invocation API | `POST /tools/invoke`, policy + denylist enforced | EAP now has typed OpenClaw tools-invoke client + runtime bridge tool (`invoke_openclaw_tool`) | **Compatible now** | Use bridge tool for direct gateway tool calls with bearer auth and policy-denial mapping. |
 | Plugin runtime model | TypeScript/JavaScript in-process plugin modules, required `openclaw.plugin.json` | Adapter package added at `integrations/openclaw/eap-runtime-plugin` | **Compatible now (MVP)** | Plugin exports required tools and maps directly to EAP runtime endpoints. |
 | Skills model | AgentSkills-style `SKILL.md`; plugin can ship skills via manifest `skills` field | Skill pack added at `integrations/openclaw/eap-runtime-plugin/skills` | **Compatible now (MVP)** | Includes `run`, `inspect`, `retry failed step`, and `export trace` skill workflows with quickstart docs. |
@@ -240,7 +241,8 @@ Recommended sequence:
   - `GEN-45` (`EAP-084`)
   - `GEN-44` (`EAP-085`)
   - `GEN-46` (`EAP-086`, done)
-  - `GEN-48` (`EAP-087`, in progress)
+  - `GEN-48` (`EAP-087`, done)
+  - `GEN-47` (`EAP-088`, in progress)
 - roadmap sync:
   - `docs/phase7_competitive_openclaw_roadmap.md`
 
@@ -257,7 +259,7 @@ Recommended sequence:
 - ordered implementation backlog and dependencies:
   - `EAP-086` / `GEN-46` (OpenClaw agent-routing header support)
   - `EAP-087` / `GEN-48` (OpenClaw `/tools/invoke` bridge)
-  - `EAP-088` / `GEN-47` (Responses API adapter path), blocked by `EAP-087`
+  - `EAP-088` / `GEN-47` (Responses API adapter path)
 - queue sync:
   - `docs/execution_protocol.md`
 
@@ -280,11 +282,11 @@ Recommended sequence:
   - `docs/configuration.md`
   - `.env.example`
 
-`EAP-087` implementation is now in progress (see section 17 below).
+`EAP-087` follow-up is now complete (see section 17 below).
 
-## 17) In-Progress OpenClaw `/tools/invoke` Bridge (EAP-087)
+## 17) Implemented OpenClaw `/tools/invoke` Bridge (EAP-087)
 
-`EAP-087` implementation branch currently includes:
+`EAP-087` is now implemented in-repo with:
 - typed OpenClaw tools-invoke client:
   - `environment/openclaw_client.py`
 - runtime bridge tool:
@@ -315,7 +317,25 @@ Guardrails:
 - treat `api_key` as credential material and source it from runtime secret management;
 - handle policy denials as expected control-path outcomes (`TOOL_INVOKE_POLICY_DENIED`).
 
-After merge, proceed to **EAP-088**.
+`EAP-088` implementation is now in progress (see section 18 below).
+
+## 18) In-Progress OpenAI Responses API Adapter Path (EAP-088)
+
+`EAP-088` implementation branch currently includes:
+- explicit OpenAI API mode selection controls:
+  - `EAP_OPENAI_API_MODE`
+  - `EAP_ARCHITECT_OPENAI_API_MODE`
+  - `EAP_AUDITOR_OPENAI_API_MODE`
+- provider adapter path for `POST /v1/responses`:
+  - OpenAI provider `responses` mode payload normalization
+  - explicit unsupported endpoint handling when Responses path is disabled/unavailable
+- regression and compatibility coverage:
+  - `tests/unit/test_provider_adapters.py`
+  - `tests/integration/test_provider_selection.py`
+  - `tests/unit/test_settings.py`
+  - `tests/unit/test_agent_client.py`
+
+After merge, tranche-4 gap-closure execution is complete.
 
 ## References (Primary Sources)
 

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -1,6 +1,6 @@
 # Phase 7 Competitive Roadmap (OpenClaw + Market Positioning)
 
-Status: In progress (through EAP-087 implementation in progress, 2026-02-24)
+Status: In progress (through EAP-088 implementation in progress, 2026-02-24)
 
 Current status:
 - [x] `EAP-071` interop spike + compatibility matrix published (`docs/openclaw_interop.md`)
@@ -19,8 +19,8 @@ Current status:
 - [x] `EAP-084` execution governance protocol + Linear-first queue
 - [x] `EAP-085` tranche 4 scope + acceptance criteria
 - [x] `EAP-086` OpenClaw agent-routing header support
-- [ ] `EAP-087` OpenClaw `/tools/invoke` bridge (in progress)
-- [ ] `EAP-088` onward
+- [x] `EAP-087` OpenClaw `/tools/invoke` bridge
+- [ ] `EAP-088` OpenAI Responses adapter path (in progress)
 
 ## Objective
 
@@ -152,9 +152,10 @@ Optional validation track:
     - Status: complete (PR #36 merged to `main`)
 17. `EAP-087` OpenClaw `/tools/invoke` client bridge
     - Linear: `GEN-48`
-    - Status: in progress (typed tools-invoke client + runtime bridge + integration tests in branch)
+    - Status: complete (PR #37 merged to `main`)
 18. `EAP-088` OpenAI Responses API adapter path
-    - Linear: `GEN-47` (blocked by `EAP-087`)
+    - Linear: `GEN-47`
+    - Status: in progress (explicit API-mode selection + provider `/v1/responses` path under implementation)
 
 ## Guardrails
 

--- a/docs/phase7_tranche4_scope.md
+++ b/docs/phase7_tranche4_scope.md
@@ -1,6 +1,6 @@
 # Phase 7 Tranche 4 Scope (EAP-085)
 
-Updated: 2026-02-24 (execution through EAP-087 in progress)  
+Updated: 2026-02-24 (execution through EAP-088 in progress)  
 Source of truth: Linear project `Efficient Agent Protocol Roadmap`
 
 ## Objective
@@ -22,4 +22,4 @@ Close the remaining high-impact OpenClaw interoperability gaps identified in `do
 
 ## Execution Constraint
 
-Only the first non-blocked `Todo` item may be started (currently `EAP-087`).
+Only the first non-blocked `Todo` item may be started (currently `EAP-088`).

--- a/protocol/settings.py
+++ b/protocol/settings.py
@@ -8,6 +8,7 @@ DEFAULT_BASE_URL = "http://localhost:1234"
 DEFAULT_MODEL = "nemotron-orchestrator-8b"
 DEFAULT_TIMEOUT_SECONDS = 60
 DEFAULT_TEMPERATURE = 0.0
+DEFAULT_OPENAI_API_MODE = "chat_completions"
 DEFAULT_EXECUTOR_MAX_CONCURRENCY = 8
 
 
@@ -18,6 +19,7 @@ class LLMClientSettings:
     api_key: str
     timeout_seconds: int
     temperature: float
+    openai_api_mode: str
     extra_headers: Dict[str, str]
 
 
@@ -100,6 +102,15 @@ def _parse_extra_headers(value: str, field_name: str) -> Dict[str, str]:
     return headers
 
 
+def _parse_openai_api_mode(value: str, field_name: str) -> str:
+    normalized = value.strip().lower()
+    if normalized in {"chat_completions", "responses"}:
+        return normalized
+    raise ValueError(
+        f"{field_name} must be one of: chat_completions, responses"
+    )
+
+
 def _build_client_settings(role_prefix: str) -> LLMClientSettings:
     base_url = _validate_base_url(
         os.getenv(f"{role_prefix}_BASE_URL", os.getenv("EAP_BASE_URL", DEFAULT_BASE_URL)),
@@ -124,6 +135,14 @@ def _build_client_settings(role_prefix: str) -> LLMClientSettings:
     if temperature < 0:
         raise ValueError(f"{role_prefix}_TEMPERATURE must be >= 0")
 
+    openai_api_mode = _parse_openai_api_mode(
+        os.getenv(
+            f"{role_prefix}_OPENAI_API_MODE",
+            os.getenv("EAP_OPENAI_API_MODE", DEFAULT_OPENAI_API_MODE),
+        ),
+        f"{role_prefix}_OPENAI_API_MODE",
+    )
+
     global_extra_headers = _parse_extra_headers(
         os.getenv("EAP_EXTRA_HEADERS_JSON", "{}"),
         "EAP_EXTRA_HEADERS_JSON",
@@ -141,6 +160,7 @@ def _build_client_settings(role_prefix: str) -> LLMClientSettings:
         api_key=api_key,
         timeout_seconds=timeout_seconds,
         temperature=temperature,
+        openai_api_mode=openai_api_mode,
         extra_headers=extra_headers,
     )
 

--- a/tests/integration/test_provider_selection.py
+++ b/tests/integration/test_provider_selection.py
@@ -21,6 +21,16 @@ class ProviderSelectionIntegrationTest(unittest.TestCase):
         self.assertIsInstance(client.provider, OpenAIProvider)
         self.assertEqual(client._headers()["x-openclaw-agent-id"], "router-abc")
 
+    def test_local_provider_can_select_responses_api_mode(self) -> None:
+        client = AgentClient(
+            base_url="http://localhost:1234",
+            model_name="model-a",
+            openai_api_mode="responses",
+        )
+        self.assertIsInstance(client.provider, OpenAIProvider)
+        self.assertEqual(client.provider.api_mode, "responses")
+        self.assertTrue(client.provider.endpoint.endswith("/v1/responses"))
+
     def test_anthropic_provider_selected_when_configured(self) -> None:
         client = AgentClient(
             base_url="https://api.anthropic.com",
@@ -63,6 +73,14 @@ class ProviderSelectionIntegrationTest(unittest.TestCase):
                 model_name="claude-3-5-sonnet-latest",
                 api_key="not-needed",
                 provider_name="anthropic",
+            )
+
+    def test_invalid_openai_api_mode_fails_fast(self) -> None:
+        with self.assertRaises(ValueError):
+            AgentClient(
+                base_url="http://localhost:1234",
+                model_name="model-a",
+                openai_api_mode="legacy",
             )
 
 

--- a/tests/unit/test_agent_client.py
+++ b/tests/unit/test_agent_client.py
@@ -60,6 +60,25 @@ class AgentClientTest(unittest.TestCase):
         self.assertIn("### MEMORY CONTEXT ###", user_message)
         self.assertIn("prior question", user_message)
 
+    def test_chat_can_use_responses_api_mode(self) -> None:
+        client = AgentClient(
+            base_url="http://localhost:1234",
+            model_name="model-a",
+            openai_api_mode="responses",
+        )
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"output_text": "ok"}
+        mock_response.raise_for_status.return_value = None
+
+        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+            result = client.chat("hello")
+
+        self.assertEqual(result, "ok")
+        kwargs = post.call_args.kwargs
+        self.assertTrue(client.provider.endpoint.endswith("/v1/responses"))
+        self.assertIn("input", kwargs["json"])
+        self.assertEqual(kwargs["json"]["input"][1]["content"][0]["text"], "hello")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_provider_adapters.py
+++ b/tests/unit/test_provider_adapters.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import requests
+
 from eap.agent import (
     AnthropicProvider,
     CompletionRequest,
@@ -108,6 +110,50 @@ class ProviderAdaptersTest(unittest.TestCase):
         kwargs = post.call_args.kwargs
         self.assertEqual(kwargs["headers"]["x-api-key"], "anthro-key")
         self.assertIn("system", kwargs["json"])
+
+    def test_openai_responses_mode_normalizes_output_text(self) -> None:
+        provider = OpenAIProvider(
+            endpoint="http://localhost:1234/v1/responses",
+            api_key="secret",
+            timeout_seconds=10,
+            api_mode="responses",
+        )
+        request = CompletionRequest(
+            model="gpt-4.1-mini",
+            messages=[ProviderMessage(role="user", content="hello")],
+            temperature=0.0,
+        )
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "resp_1", "output_text": "responses-ok"}
+        mock_response.raise_for_status.return_value = None
+        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+            response = provider.complete(request)
+
+        self.assertEqual(response.text, "responses-ok")
+        kwargs = post.call_args.kwargs
+        self.assertIn("input", kwargs["json"])
+        self.assertEqual(kwargs["json"]["input"][0]["content"][0]["text"], "hello")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer secret")
+
+    def test_openai_responses_mode_unavailable_endpoint_has_explicit_error(self) -> None:
+        provider = OpenAIProvider(
+            endpoint="http://localhost:1234/v1/responses",
+            api_key="secret",
+            timeout_seconds=10,
+            api_mode="responses",
+        )
+        request = CompletionRequest(
+            model="gpt-4.1-mini",
+            messages=[ProviderMessage(role="user", content="hello")],
+            temperature=0.0,
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
+        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response):
+            with self.assertRaises(RuntimeError) as context:
+                provider.complete(request)
+        self.assertIn("Responses API path is unavailable", str(context.exception))
 
     def test_google_provider_normalizes_response_and_tools(self) -> None:
         provider = GoogleProvider(

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -11,6 +11,8 @@ class SettingsTest(unittest.TestCase):
             settings = load_settings()
             self.assertEqual(settings.architect.base_url, "http://localhost:1234")
             self.assertEqual(settings.auditor.base_url, "http://localhost:1234")
+            self.assertEqual(settings.architect.openai_api_mode, "chat_completions")
+            self.assertEqual(settings.auditor.openai_api_mode, "chat_completions")
             self.assertEqual(settings.architect.extra_headers, {})
             self.assertEqual(settings.auditor.extra_headers, {})
             self.assertEqual(settings.executor.max_global_concurrency, 8)
@@ -24,12 +26,16 @@ class SettingsTest(unittest.TestCase):
                 "EAP_AUDITOR_MODEL": "audit-model",
                 "EAP_EXTRA_HEADERS_JSON": '{"x-shared":"one","x-role":"global"}',
                 "EAP_ARCHITECT_EXTRA_HEADERS_JSON": '{"x-role":"architect"}',
+                "EAP_OPENAI_API_MODE": "responses",
+                "EAP_AUDITOR_OPENAI_API_MODE": "chat_completions",
             },
             clear=True,
         ):
             settings = load_settings()
             self.assertEqual(settings.architect.model_name, "arch-model")
             self.assertEqual(settings.auditor.model_name, "audit-model")
+            self.assertEqual(settings.architect.openai_api_mode, "responses")
+            self.assertEqual(settings.auditor.openai_api_mode, "chat_completions")
             self.assertEqual(settings.architect.extra_headers["x-shared"], "one")
             self.assertEqual(settings.architect.extra_headers["x-role"], "architect")
             self.assertEqual(settings.auditor.extra_headers["x-role"], "global")
@@ -62,6 +68,11 @@ class SettingsTest(unittest.TestCase):
                 load_settings()
 
         with mock.patch.dict(os.environ, {"EAP_AUDITOR_EXTRA_HEADERS_JSON": '{"x-one": 1}'}, clear=True):
+            with self.assertRaises(ValueError):
+                load_settings()
+
+    def test_invalid_openai_api_mode_validation(self) -> None:
+        with mock.patch.dict(os.environ, {"EAP_OPENAI_API_MODE": "legacy"}, clear=True):
             with self.assertRaises(ValueError):
                 load_settings()
 


### PR DESCRIPTION
## Summary
- add explicit OpenAI API mode selection (`chat_completions` vs `responses`) in settings and runtime wiring
- add OpenAI provider adapter path for `POST /v1/responses` with output normalization
- add explicit unsupported/disabled responses endpoint handling
- preserve existing chat-completions path and streaming behavior
- update configuration/interop/queue docs for EAP-088 in-progress state

## Verification
- `.venv/bin/python -m unittest tests.unit.test_settings tests.unit.test_provider_adapters tests.integration.test_provider_selection tests.unit.test_agent_client`
- `.venv/bin/python -m unittest tests.unit.test_settings tests.unit.test_provider_adapters tests.integration.test_provider_selection tests.unit.test_agent_client tests.unit.test_openclaw_client tests.unit.test_openclaw_tools tests.unit.test_tool_schemas tests.integration.test_openclaw_tools_invoke_bridge tests.integration.test_mcp_interop tests.integration.test_runtime_http_api`
