### PR TITLE
Roadmap: add Phase 8 adoption queue and sync execution state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,12 +45,20 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Add post-release install smoke validation against published package artifacts.
 - Finalize `v1.0` stabilization checklist and upgrade notes for external adopters.
 
-## Phase 7: Competitive Positioning + OpenClaw Interop (Next)
+## Phase 7: Competitive Positioning + OpenClaw Interop (Completed)
 
 - Execute OpenClaw integration track (plugin + skills + CI interop lane).
 - Close remaining high-impact competitive gaps after HITL checkpoints, crash-safe resume, and MCP interop.
 - Publish updated competitive proof artifacts with reproducible evidence.
 - Checklist: `docs/phase7_competitive_openclaw_roadmap.md`
+
+## Phase 8: Adoption + Limits Closure (Now)
+
+- Close remaining `responses`-mode parity gaps.
+- Convert pre-`1.0` uncertainty into explicit `v1` compatibility gates.
+- Reduce onboarding friction with one-command bootstrap and doctor tooling.
+- Publish a self-hosted control-plane reference path plus remote-ops governance baseline.
+- Checklist: `docs/phase8_adoption_limits_closure_roadmap.md`
 
 ## Done
 
@@ -79,3 +87,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-085` tranche-4 scope defined with ordered dependency chain (`EAP-086` -> `EAP-087` -> `EAP-088`).
 - Phase 7 `EAP-086` OpenClaw routing header support merged (`PR #36`).
 - Phase 7 `EAP-087` OpenClaw `/tools/invoke` bridge merged (`PR #37`).
+- Phase 7 `EAP-088` OpenAI Responses API adapter path completed (`GEN-47`).

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -6,7 +6,7 @@ This protocol prevents ad-hoc execution and keeps all work in a visible ordered 
 
 1. Linear issue state is the execution authority.
 2. This file mirrors the active order (`Now`, `Next`, `Blocked`).
-3. `docs/phase7_competitive_openclaw_roadmap.md` is the narrative roadmap, not the live queue.
+3. `docs/phase7_competitive_openclaw_roadmap.md` and `docs/phase8_adoption_limits_closure_roadmap.md` are narrative roadmaps, not the live queue.
 
 ## Start Gate (Must Be True Before Coding)
 
@@ -32,7 +32,13 @@ Updated: 2026-02-24
 | 2 | `EAP-085` | `GEN-44` | `Done` | Tranche 4 scope and acceptance criteria defined |
 | 3 | `EAP-086` | `GEN-46` | `Done` | OpenClaw agent-routing header support |
 | 4 | `EAP-087` | `GEN-48` | `Done` | OpenClaw `/tools/invoke` bridge |
-| 5 | `EAP-088` | `GEN-47` | `In Progress` | OpenAI Responses API adapter path |
+| 5 | `EAP-088` | `GEN-47` | `Done` | OpenAI Responses API adapter path |
+| 6 | `EAP-089` | `GEN-49` | `Todo` | Responses streaming parity |
+| 7 | `EAP-090` | `GEN-50` | `Todo (Blocked)` | Blocked by `GEN-49` |
+| 8 | `EAP-091` | `GEN-51` | `Todo (Blocked)` | Blocked by `GEN-50` |
+| 9 | `EAP-092` | `GEN-52` | `Todo (Blocked)` | Blocked by `GEN-51` |
+| 10 | `EAP-093` | `GEN-53` | `Todo (Blocked)` | Blocked by `GEN-52` |
+| 11 | `EAP-094` | `GEN-54` | `Todo (Blocked)` | Blocked by `GEN-53` |
 
 ## Execution Rule
 

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -1,6 +1,6 @@
 # OpenClaw Interop Spike (EAP-071)
 
-Status: Updated for EAP-088 in-progress implementation (2026-02-24)  
+Status: Updated for completed EAP-088 implementation (2026-02-24)  
 Owner: EAP maintainers  
 Scope: interoperability analysis plus implemented interop foundation (EAP-072, EAP-073, EAP-074, EAP-075, EAP-076, EAP-077, EAP-078, EAP-079, EAP-080, EAP-081, EAP-082, EAP-083, EAP-084, EAP-085, EAP-086, EAP-087, EAP-088)
 
@@ -28,7 +28,7 @@ OpenClaw-side surfaces:
 
 EAP-side surfaces:
 - OpenAI-compatible provider adapter using `base_url + /v1/chat/completions`.
-- Explicit OpenAI Responses mode path using `base_url + /v1/responses` (EAP-088 in progress).
+- Explicit OpenAI Responses mode path using `base_url + /v1/responses` (EAP-088 complete).
 - Bearer auth header support.
 - Python plugin system via `importlib.metadata` entry points (`eap.tool_plugins`).
 - EAP runtime HTTP endpoints for `/v1/eap/*` execution/status/pointer summary.
@@ -41,7 +41,7 @@ EAP-side surfaces:
 | Gateway auth model | Bearer token, gateway auth mode token/password | EAP OpenAI provider sends `Authorization: Bearer <api_key>` | **Compatible now** | Set `EAP_API_KEY` to gateway token/password value used by OpenClaw auth mode. |
 | OpenClaw agent selection | Preferred: `model: "openclaw:<agentId>"`; optional header `x-openclaw-agent-id` | EAP controls `model` and now supports configurable custom headers in OpenAI-compatible provider path | **Compatible now** | Use `EAP_MODEL=openclaw:<agentId>` and/or `EAP_EXTRA_HEADERS_JSON='{"x-openclaw-agent-id":"<agentId>"}'` (role-specific overrides supported). |
 | Streaming chat | SSE for OpenAI endpoint when `stream=true` | EAP provider has SSE stream parsing for `data:` + `[DONE]` | **Compatible now** | Verify with real gateway in EAP-075 CI smoke. |
-| OpenResponses API | `POST /v1/responses` (disabled by default) | EAP provider path now supports explicit Responses mode selection (in progress) | **In progress** | Configure `EAP_OPENAI_API_MODE=responses`; unsupported/disabled endpoints are surfaced as explicit runtime errors. |
+| OpenResponses API | `POST /v1/responses` (disabled by default) | EAP provider path supports explicit Responses mode selection | **Compatible now** | Configure `EAP_OPENAI_API_MODE=responses`; unsupported/disabled endpoints are surfaced as explicit runtime errors. |
 | Tool invocation API | `POST /tools/invoke`, policy + denylist enforced | EAP now has typed OpenClaw tools-invoke client + runtime bridge tool (`invoke_openclaw_tool`) | **Compatible now** | Use bridge tool for direct gateway tool calls with bearer auth and policy-denial mapping. |
 | Plugin runtime model | TypeScript/JavaScript in-process plugin modules, required `openclaw.plugin.json` | Adapter package added at `integrations/openclaw/eap-runtime-plugin` | **Compatible now (MVP)** | Plugin exports required tools and maps directly to EAP runtime endpoints. |
 | Skills model | AgentSkills-style `SKILL.md`; plugin can ship skills via manifest `skills` field | Skill pack added at `integrations/openclaw/eap-runtime-plugin/skills` | **Compatible now (MVP)** | Includes `run`, `inspect`, `retry failed step`, and `export trace` skill workflows with quickstart docs. |
@@ -242,7 +242,7 @@ Recommended sequence:
   - `GEN-44` (`EAP-085`)
   - `GEN-46` (`EAP-086`, done)
   - `GEN-48` (`EAP-087`, done)
-  - `GEN-47` (`EAP-088`, in progress)
+  - `GEN-47` (`EAP-088`, done)
 - roadmap sync:
   - `docs/phase7_competitive_openclaw_roadmap.md`
 
@@ -317,11 +317,11 @@ Guardrails:
 - treat `api_key` as credential material and source it from runtime secret management;
 - handle policy denials as expected control-path outcomes (`TOOL_INVOKE_POLICY_DENIED`).
 
-`EAP-088` implementation is now in progress (see section 18 below).
+`EAP-088` implementation is complete (see section 18 below).
 
-## 18) In-Progress OpenAI Responses API Adapter Path (EAP-088)
+## 18) Implemented OpenAI Responses API Adapter Path (EAP-088)
 
-`EAP-088` implementation branch currently includes:
+`EAP-088` implementation now includes:
 - explicit OpenAI API mode selection controls:
   - `EAP_OPENAI_API_MODE`
   - `EAP_ARCHITECT_OPENAI_API_MODE`
@@ -335,7 +335,7 @@ Guardrails:
   - `tests/unit/test_settings.py`
   - `tests/unit/test_agent_client.py`
 
-After merge, tranche-4 gap-closure execution is complete.
+Tranche-4 gap-closure execution is complete.
 
 ## References (Primary Sources)
 

--- a/docs/phase7_competitive_openclaw_roadmap.md
+++ b/docs/phase7_competitive_openclaw_roadmap.md
@@ -1,6 +1,6 @@
 # Phase 7 Competitive Roadmap (OpenClaw + Market Positioning)
 
-Status: In progress (through EAP-088 implementation in progress, 2026-02-24)
+Status: Completed (through EAP-088, 2026-02-24)
 
 Current status:
 - [x] `EAP-071` interop spike + compatibility matrix published (`docs/openclaw_interop.md`)
@@ -20,7 +20,7 @@ Current status:
 - [x] `EAP-085` tranche 4 scope + acceptance criteria
 - [x] `EAP-086` OpenClaw agent-routing header support
 - [x] `EAP-087` OpenClaw `/tools/invoke` bridge
-- [ ] `EAP-088` OpenAI Responses adapter path (in progress)
+- [x] `EAP-088` OpenAI Responses adapter path
 
 ## Objective
 
@@ -155,7 +155,7 @@ Optional validation track:
     - Status: complete (PR #37 merged to `main`)
 18. `EAP-088` OpenAI Responses API adapter path
     - Linear: `GEN-47`
-    - Status: in progress (explicit API-mode selection + provider `/v1/responses` path under implementation)
+    - Status: complete (explicit API-mode selection + provider `/v1/responses` path with tests/docs merged to `main`)
 
 ## Guardrails
 

--- a/docs/phase7_tranche4_scope.md
+++ b/docs/phase7_tranche4_scope.md
@@ -1,6 +1,6 @@
 # Phase 7 Tranche 4 Scope (EAP-085)
 
-Updated: 2026-02-24 (execution through EAP-088 in progress)  
+Updated: 2026-02-24 (execution through EAP-088 complete)  
 Source of truth: Linear project `Efficient Agent Protocol Roadmap`
 
 ## Objective
@@ -22,4 +22,4 @@ Close the remaining high-impact OpenClaw interoperability gaps identified in `do
 
 ## Execution Constraint
 
-Only the first non-blocked `Todo` item may be started (currently `EAP-088`).
+Tranche complete: no remaining open items in this scoped sequence.

--- a/docs/phase8_adoption_limits_closure_roadmap.md
+++ b/docs/phase8_adoption_limits_closure_roadmap.md
@@ -1,0 +1,40 @@
+# Phase 8 Adoption + Limits Closure Roadmap
+
+Status: In progress (started 2026-02-24)  
+Source of truth: Linear project `Efficient Agent Protocol Roadmap`
+
+## Objective
+
+Turn README caveats (`Not ideal yet` and `Current limits`) into concrete deliverables that improve adoption without weakening reliability guarantees.
+
+## Gap-to-Workstream Mapping
+
+| README Gap | Phase 8 Workstream |
+| --- | --- |
+| `responses` mode lacks streaming parity | `EAP-089` |
+| Pre-`1.0` contract uncertainty | `EAP-090` |
+| High setup friction for first-time users | `EAP-091`, `EAP-092` |
+| Teams wanting more than local-only runtime operation | `EAP-093`, `EAP-094` |
+
+## Ordered Implementation Items
+
+| Order | EAP ID | Linear | Scope | Deliverable | Done Criteria |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `EAP-089` | `GEN-49` | Responses streaming parity | Stream support in `responses` mode | Integration coverage for responses streaming; no chat-completions regressions; docs updated |
+| 2 | `EAP-090` | `GEN-50` | v1 compatibility enforcement | Frozen v1 surfaces + CI compatibility gate | Contract docs finalized; compatibility tests required in CI; breaking-change simulation test included |
+| 3 | `EAP-091` | `GEN-51` | One-command bootstrap | Bootstrap script for first successful run | Idempotent bootstrap path for macOS/Linux; actionable failure output; README quickstart updated |
+| 4 | `EAP-092` | `GEN-52` | Guided onboarding + doctor | Config wizard + `doctor` validation command | Non-zero categorized failures; runnable `.env` generation; troubleshooting mapping documented |
+| 5 | `EAP-093` | `GEN-53` | Self-hosted control-plane reference | Docker Compose reference deployment + ops docs | One-command stack startup; remote `/v1/eap/*` smoke check; auth/TLS guidance published |
+| 6 | `EAP-094` | `GEN-54` | Remote operations governance baseline | Scoped auth + run actor metadata + governance docs | Unauthorized operations blocked by scope tests; traces include actor metadata; governance/migration docs published |
+
+## Dependency Order
+
+1. `EAP-089` unblocks `EAP-090`.
+2. `EAP-090` unblocks `EAP-091`.
+3. `EAP-091` unblocks `EAP-092`.
+4. `EAP-092` unblocks `EAP-093`.
+5. `EAP-093` unblocks `EAP-094`.
+
+## Execution Constraint
+
+Only the first non-blocked `Todo` item may be started (currently `EAP-089`).


### PR DESCRIPTION
## Summary
- add a new Phase 8 roadmap focused on README caveat closure (`docs/phase8_adoption_limits_closure_roadmap.md`)
- sync execution protocol queue with Linear issues `GEN-49` to `GEN-54`
- mark `EAP-088` as completed across roadmap docs to remove status drift
- update top-level `ROADMAP.md` with a new Phase 8 section and checklist link

## Why
We needed a single ordered queue for the remaining "Not ideal yet" and "Current limits" items so implementation can proceed without ad-hoc starts or status confusion.
