### PR TITLE
Docs: sync Phase 8 queue after EAP-089 merge

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,3 +88,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-086` OpenClaw routing header support merged (`PR #36`).
 - Phase 7 `EAP-087` OpenClaw `/tools/invoke` bridge merged (`PR #37`).
 - Phase 7 `EAP-088` OpenAI Responses API adapter path completed (`GEN-47`).
+- Phase 8 `EAP-089` Responses streaming parity completed (`GEN-49`, PR #42).

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -33,8 +33,8 @@ Updated: 2026-02-24
 | 3 | `EAP-086` | `GEN-46` | `Done` | OpenClaw agent-routing header support |
 | 4 | `EAP-087` | `GEN-48` | `Done` | OpenClaw `/tools/invoke` bridge |
 | 5 | `EAP-088` | `GEN-47` | `Done` | OpenAI Responses API adapter path |
-| 6 | `EAP-089` | `GEN-49` | `Todo` | Responses streaming parity |
-| 7 | `EAP-090` | `GEN-50` | `Todo (Blocked)` | Blocked by `GEN-49` |
+| 6 | `EAP-089` | `GEN-49` | `Done` | Responses streaming parity |
+| 7 | `EAP-090` | `GEN-50` | `Todo` | v1 compatibility enforcement |
 | 8 | `EAP-091` | `GEN-51` | `Todo (Blocked)` | Blocked by `GEN-50` |
 | 9 | `EAP-092` | `GEN-52` | `Todo (Blocked)` | Blocked by `GEN-51` |
 | 10 | `EAP-093` | `GEN-53` | `Todo (Blocked)` | Blocked by `GEN-52` |

--- a/docs/phase8_adoption_limits_closure_roadmap.md
+++ b/docs/phase8_adoption_limits_closure_roadmap.md
@@ -3,6 +3,14 @@
 Status: In progress (started 2026-02-24)  
 Source of truth: Linear project `Efficient Agent Protocol Roadmap`
 
+Current status:
+- [x] `EAP-089` Responses streaming parity (`GEN-49`)
+- [ ] `EAP-090` v1 compatibility enforcement (`GEN-50`)
+- [ ] `EAP-091` one-command bootstrap (`GEN-51`)
+- [ ] `EAP-092` guided onboarding + doctor (`GEN-52`)
+- [ ] `EAP-093` self-hosted control-plane reference (`GEN-53`)
+- [ ] `EAP-094` remote operations governance baseline (`GEN-54`)
+
 ## Objective
 
 Turn README caveats (`Not ideal yet` and `Current limits`) into concrete deliverables that improve adoption without weakening reliability guarantees.
@@ -37,4 +45,4 @@ Turn README caveats (`Not ideal yet` and `Current limits`) into concrete deliver
 
 ## Execution Constraint
 
-Only the first non-blocked `Todo` item may be started (currently `EAP-089`).
+Only the first non-blocked `Todo` item may be started (currently `EAP-090`).


### PR DESCRIPTION
## Summary
- mark `EAP-089 / GEN-49` as done in the in-repo execution queue
- advance Phase 8 execution constraint to `EAP-090`
- add roadmap done entry for `EAP-089` completion

## Why
Keep `ROADMAP.md` + Phase 8 roadmap + execution protocol in sync with Linear and merged implementation state.
