### PR TITLE
EAP-090: enforce v1 compatibility contract gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -91,6 +93,14 @@ jobs:
         run: |
           python scripts/verify_proof_sheet.py
           python -m pytest -q tests/contract/test_eap_proof_sheet_contract.py
+
+      - name: V1 compatibility contract gate
+        if: matrix.python-version == '3.11'
+        run: |
+          python scripts/check_v1_contract.py
+          python -m pytest -q \
+            tests/contract/test_v1_contract_lock.py \
+            tests/unit/test_v1_contract_gate.py
 
       - name: Dependency vulnerability audit
         if: matrix.python-version == '3.11'

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,6 +22,11 @@ Version resolution is label-based:
 
 The draft release body is the source of truth for release notes/changelog content.
 
+Compatibility policy:
+
+- If `docs/v1_contract_lock.json` changes, release version must be bumped in the same PR.
+- CI enforces this via `scripts/check_v1_contract.py`.
+
 ## Release Steps
 
 1. Ensure PR labels (`major`/`minor`/`patch`) are correct for merged changes.
@@ -30,6 +35,9 @@ The draft release body is the source of truth for release notes/changelog conten
 4. Publish the release with tag `vX.Y.Z`.
 5. Confirm release workflow success (`.github/workflows/release.yml`).
 6. Verify published package(s) and attach release link in roadmap/issue tracking.
+7. For releases with contract-surface changes:
+   - confirm `docs/v1_contract_lock.json` was updated intentionally
+   - confirm `Breaking Changes` and `Upgrade Notes` sections are populated
 
 ## Publish Authentication
 

--- a/docs/release_notes_template.md
+++ b/docs/release_notes_template.md
@@ -16,16 +16,16 @@ Use this template for every tagged release.
 
 ## Deprecated
 
-- 
+- Example: "`EAP_ARCHITECT_OPENAI_API_MODE=legacy_mode` is deprecated; use `chat_completions` or `responses`."
 
 ## Removed
 
-- 
+- Example: "Removed deprecated `legacy_mode` support in provider selection."
 
 ## Breaking Changes
 
-- 
+- Example: "Contract lock changed (`docs/v1_contract_lock.json`) with version bump from `0.1.7` to `0.2.0`."
 
 ## Upgrade Notes
 
-- 
+- Example: "Update `EAP_OPENAI_API_MODE` env values and rerun `python -m examples.01_minimal` to validate runtime behavior."

--- a/docs/v1_contract.md
+++ b/docs/v1_contract.md
@@ -1,73 +1,84 @@
-# V1 Contract Draft
+# V1 Compatibility Contract
 
-This document defines the intended contract for `v1.0`.
-Until `v1.0` is released, this is a target contract and may still evolve in `0.x`.
+This document defines the enforced compatibility surface that must remain stable
+for `v1.0` consumers.
 
-## V1.0 Scope
+While the project is still `0.x`, this contract is validated by CI to prevent
+accidental drift.
 
-The `v1.0` goal is a stable local-first execution core with a stable public import surface for:
+## Scope
 
-- Macro planning/validation models
-- Dependency-aware local execution
-- Pointer-backed state persistence
-- Basic provider integration through `AgentClient`
+The `v1.0` contract covers:
 
-## V1.0 Non-Goals
+- Public Python entry-point exports in:
+  - `eap.protocol`
+  - `eap.environment`
+  - `eap.agent`
+- Workflow graph schema fields and enum values for:
+  - `PersistedWorkflowGraph`
+  - `WorkflowGraphNode`
+  - `WorkflowGraphEdge`
+  - `WorkflowEdgeKind`
+- Tool error payload envelope (`ToolErrorPayload`) including allowed `error_type`
+  values.
+- Frozen runtime settings key surface used by `load_settings()`.
+- SDK HTTP operation path set for TypeScript and Go clients.
 
-The following are explicitly out of scope for `v1.0` stability guarantees:
+The source-of-truth lock file is:
+
+- `docs/v1_contract_lock.json`
+
+## Non-Goals
+
+The following remain out of scope for `v1.0` stability guarantees:
 
 - Streamlit UI layout and UX details in `app.py`
 - Internal module organization under non-`eap.*` namespaces
 - Experimental plugin manifest fields not exported through `eap.environment`
 - Advanced distributed coordination semantics beyond documented behavior
 
-## Public API Freeze Candidates (for V1.0)
+## Enforcement
 
-The symbols exported by these module entry points are the stability candidates:
+CI enforces contract stability through:
 
-- `eap.protocol`
-- `eap.environment`
-- `eap.agent`
+- `scripts/check_v1_contract.py`
+- `tests/contract/test_v1_contract_lock.py`
+- `tests/unit/test_v1_contract_gate.py`
 
-The current candidate symbol list is the explicit `__all__` set in those files.
-Additions are allowed in minor releases; removals/behavioral breaks are only allowed in major releases after `v1.0`.
+What fails CI:
 
-## Workflow Schema Freeze Candidates (for V1.0)
+1. Runtime surface differs from `docs/v1_contract_lock.json`.
+2. Contract lock changes without an explicit package version bump.
 
-For `PersistedWorkflowGraph` and related types, these fields are intended to be stable:
+This provides a measurable gate for compatibility changes before `v1.0`.
 
-- `workflow_id`
-- `version`
-- `nodes`
-- `edges`
-- `created_at_utc`
-- `updated_at_utc`
-- `metadata`
+## Intentional Contract Changes
 
-For node and edge models, these fields are intended to be stable:
+If you intentionally change the frozen contract surface:
 
-- Node: `node_id`, `step`, `label`, `position_x`, `position_y`
-- Edge: `source_node_id`, `target_node_id`, `kind`
-
-The validation guarantees in `docs/workflow_schema.md` are also intended to be part of the `v1.0` contract.
+1. Bump package version in `pyproject.toml`.
+2. Regenerate lock:
+   - `PYTHONPATH=. python scripts/check_v1_contract.py --write-lock`
+3. Update this document and release notes.
+4. Ensure CI passes with the new lock.
 
 ## Supported User Profile
 
-This project is currently best for:
+Best fit:
 
-- Python developers building local tool-execution agents
-- Teams that want pointer-backed state and execution traces
-- Users comfortable with pre-1.0 iteration and explicit upgrade checks
+- Python developers building local tool-execution agents.
+- Teams that need deterministic execution traces and pointer-backed state.
+- Users comfortable with explicit compatibility gates during pre-`1.0`.
 
-This project is not yet ideal for:
+Not ideal yet:
 
-- Teams needing strict long-term API stability today
-- Non-technical users expecting no-code setup
-- Regulated production environments requiring formal support SLAs
+- Teams requiring long-term, SLA-backed support commitments.
+- Non-technical users expecting no-code setup.
+- Fully managed hosted-control-plane expectations.
 
-## Release Notes Contract (starting now)
+## Release Notes Requirements
 
-Each release notes entry should include, when applicable:
+Every release must include, when applicable:
 
 - `Added`
 - `Changed`

--- a/docs/v1_contract_lock.json
+++ b/docs/v1_contract_lock.json
@@ -1,0 +1,168 @@
+{
+  "generated_from_package_version": "0.1.7",
+  "lock_format_version": 1,
+  "snapshot": {
+    "public_api_exports": {
+      "eap.agent": [
+        "AgentClient",
+        "AnthropicProvider",
+        "CompletionRequest",
+        "CompletionResponse",
+        "GoogleProvider",
+        "LLMProvider",
+        "MacroCompiler",
+        "OpenAIProvider",
+        "ProviderMessage",
+        "WorkflowGraphCompiler",
+        "create_provider"
+      ],
+      "eap.environment": [
+        "AsyncLocalExecutor",
+        "DEFAULT_PLUGIN_ENTRYPOINT_GROUP",
+        "DistributedCoordinator",
+        "InputValidationError",
+        "PluginLoadError",
+        "PluginManifestError",
+        "ToolDefinition",
+        "ToolRegistry",
+        "discover_plugin_entry_points",
+        "load_plugins_into_registry"
+      ],
+      "eap.protocol": [
+        "BatchedMacroRequest",
+        "BranchingRule",
+        "ConversationSession",
+        "ConversationTurn",
+        "EAPSettings",
+        "ExecutionLimits",
+        "ExecutionTraceEvent",
+        "ExecutionTraceEventType",
+        "ExecutorLimitSettings",
+        "LLMClientSettings",
+        "MemoryStrategy",
+        "PersistedWorkflowGraph",
+        "PointerResponse",
+        "PointerStoreBackend",
+        "PostgresPointerStore",
+        "RedisPointerStore",
+        "RetryPolicy",
+        "SQLitePointerStore",
+        "StateManager",
+        "StepApprovalCheckpoint",
+        "StepApprovalDecision",
+        "StepApprovalDecisionType",
+        "ToolCall",
+        "ToolErrorPayload",
+        "ToolExecutionLimit",
+        "ToolLimitSettings",
+        "WorkflowEdgeKind",
+        "WorkflowGraphEdge",
+        "WorkflowGraphNode",
+        "configure_logging",
+        "load_settings"
+      ]
+    },
+    "sdk_http_paths": [
+      "/v1/eap/chat",
+      "/v1/eap/macro/execute",
+      "/v1/eap/macro/generate",
+      "/v1/eap/runs/"
+    ],
+    "settings_env_keys": [
+      "EAP_API_KEY",
+      "EAP_ARCHITECT_API_KEY",
+      "EAP_ARCHITECT_BASE_URL",
+      "EAP_ARCHITECT_EXTRA_HEADERS_JSON",
+      "EAP_ARCHITECT_MODEL",
+      "EAP_ARCHITECT_OPENAI_API_MODE",
+      "EAP_ARCHITECT_TEMPERATURE",
+      "EAP_ARCHITECT_TIMEOUT_SECONDS",
+      "EAP_AUDITOR_API_KEY",
+      "EAP_AUDITOR_BASE_URL",
+      "EAP_AUDITOR_EXTRA_HEADERS_JSON",
+      "EAP_AUDITOR_MODEL",
+      "EAP_AUDITOR_OPENAI_API_MODE",
+      "EAP_AUDITOR_TEMPERATURE",
+      "EAP_AUDITOR_TIMEOUT_SECONDS",
+      "EAP_BASE_URL",
+      "EAP_EXECUTOR_GLOBAL_BURST",
+      "EAP_EXECUTOR_GLOBAL_RPS",
+      "EAP_EXECUTOR_MAX_CONCURRENCY",
+      "EAP_EXECUTOR_PER_TOOL_LIMITS_JSON",
+      "EAP_EXTRA_HEADERS_JSON",
+      "EAP_MODEL",
+      "EAP_OPENAI_API_MODE",
+      "EAP_TEMPERATURE",
+      "EAP_TIMEOUT_SECONDS"
+    ],
+    "tool_error_payload_contract": {
+      "allowed_error_types": [
+        "validation_error",
+        "dependency_error",
+        "tool_execution_error",
+        "approval_rejected"
+      ],
+      "fields": [
+        "details",
+        "error_type",
+        "message",
+        "step_id",
+        "tool_name"
+      ],
+      "schema_required": [
+        "error_type",
+        "message",
+        "step_id",
+        "tool_name"
+      ]
+    },
+    "workflow_schema": {
+      "persisted_workflow_graph": {
+        "properties": [
+          "created_at_utc",
+          "edges",
+          "metadata",
+          "nodes",
+          "updated_at_utc",
+          "version",
+          "workflow_id"
+        ],
+        "required": [
+          "nodes",
+          "workflow_id"
+        ]
+      },
+      "workflow_edge_kind_values": [
+        "branch_fallback",
+        "branch_false",
+        "branch_true",
+        "dependency"
+      ],
+      "workflow_graph_edge": {
+        "properties": [
+          "kind",
+          "source_node_id",
+          "target_node_id"
+        ],
+        "required": [
+          "source_node_id",
+          "target_node_id"
+        ]
+      },
+      "workflow_graph_node": {
+        "properties": [
+          "label",
+          "node_id",
+          "position_x",
+          "position_y",
+          "step"
+        ],
+        "required": [
+          "node_id",
+          "step"
+        ]
+      }
+    }
+  },
+  "snapshot_version": "1.0.0"
+}

--- a/docs/v1_stabilization_checklist.md
+++ b/docs/v1_stabilization_checklist.md
@@ -16,19 +16,19 @@ Ship `v1.0` with a stable contract for core runtime APIs, workflow schema, and u
 
 ### API and Namespace Freeze
 
-- [ ] Freeze exported symbols in `eap.protocol`, `eap.environment`, and `eap.agent`.
-- [ ] Document all symbols considered `v1.0` contract surface.
+- [x] Freeze exported symbols in `eap.protocol`, `eap.environment`, and `eap.agent`.
+- [x] Document all symbols considered `v1.0` contract surface.
 - [ ] Identify and remove or deprecate unstable public entry points before tag cut.
 
 ### Workflow and Data Contract Freeze
 
-- [ ] Freeze `PersistedWorkflowGraph` required/optional fields and validation rules.
-- [ ] Freeze executor error payload contract (`validation_error`, `dependency_error`, `tool_execution_error`).
+- [x] Freeze `PersistedWorkflowGraph` required/optional fields and validation rules.
+- [x] Freeze executor error payload contract (`validation_error`, `dependency_error`, `tool_execution_error`).
 - [ ] Freeze pointer lifecycle semantics (TTL and cleanup behavior).
 
 ### Configuration and Operational Defaults
 
-- [ ] Freeze required environment variables and defaults.
+- [x] Freeze required environment variables and defaults.
 - [ ] Verify migration scripts and migration docs cover upgrade from latest `0.x`.
 - [ ] Verify observability defaults (structured logs + metrics export) remain compatible.
 
@@ -46,7 +46,7 @@ Ship `v1.0` with a stable contract for core runtime APIs, workflow schema, and u
 
 ### Documentation and Operator Readiness
 
-- [ ] Update `docs/v1_contract.md` from draft to final `v1.0` contract.
+- [x] Update `docs/v1_contract.md` from draft to final `v1.0` contract.
 - [ ] Ensure README quickstart and docs links are current.
 - [ ] Confirm release runbook and maintainer runbook reflect final `v1.0` process.
 

--- a/scripts/check_v1_contract.py
+++ b/scripts/check_v1_contract.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import eap.agent as eap_agent
+import eap.environment as eap_environment
+import eap.protocol as eap_protocol
+from eap.protocol import (
+    PersistedWorkflowGraph,
+    ToolErrorPayload,
+    WorkflowEdgeKind,
+    WorkflowGraphEdge,
+    WorkflowGraphNode,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LOCK_PATH = REPO_ROOT / "docs" / "v1_contract_lock.json"
+DEFAULT_PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+DEFAULT_SETTINGS_PATH = REPO_ROOT / "protocol" / "settings.py"
+DEFAULT_TS_CLIENT_PATH = REPO_ROOT / "sdk" / "typescript" / "src" / "client.ts"
+DEFAULT_GO_CLIENT_PATH = REPO_ROOT / "sdk" / "go" / "client.go"
+
+
+def _extract_project_version_from_text(pyproject_text: str) -> str:
+    match = re.search(r'(?m)^version\s*=\s*"([^"]+)"\s*$', pyproject_text)
+    if not match:
+        raise ValueError("Could not find [project].version in pyproject.toml")
+    return match.group(1)
+
+
+def _extract_project_version(pyproject_path: Path) -> str:
+    return _extract_project_version_from_text(pyproject_path.read_text(encoding="utf-8"))
+
+
+def _collect_sdk_http_paths(ts_client_path: Path, go_client_path: Path) -> list[str]:
+    ts_client = ts_client_path.read_text(encoding="utf-8")
+    go_client = go_client_path.read_text(encoding="utf-8")
+    pattern = re.compile(r'"/v1/eap/[^"]+"')
+    tokens = set(pattern.findall(ts_client)) | set(pattern.findall(go_client))
+    normalized = sorted(token.strip('"') for token in tokens)
+    return normalized
+
+
+def _collect_settings_env_keys(settings_path: Path) -> list[str]:
+    text = settings_path.read_text(encoding="utf-8")
+    tokens = re.findall(r'os\.getenv\(\s*"([^"]+)"', text)
+    keys = {token for token in tokens if token.startswith("EAP_")}
+    for prefix in ("EAP_ARCHITECT", "EAP_AUDITOR"):
+        for suffix in (
+            "BASE_URL",
+            "MODEL",
+            "API_KEY",
+            "TIMEOUT_SECONDS",
+            "TEMPERATURE",
+            "OPENAI_API_MODE",
+            "EXTRA_HEADERS_JSON",
+        ):
+            keys.add(f"{prefix}_{suffix}")
+    return sorted(keys)
+
+
+def _schema_contract(model: Any) -> Dict[str, list[str]]:
+    schema = model.model_json_schema()
+    return {
+        "required": sorted(schema.get("required", [])),
+        "properties": sorted(schema.get("properties", {}).keys()),
+    }
+
+
+def build_current_snapshot(repo_root: Path) -> Dict[str, Any]:
+    error_type_description = (
+        ToolErrorPayload.model_fields["error_type"].description
+        or ""
+    )
+    allowed_error_types = [
+        token.strip()
+        for token in error_type_description.split("|")
+        if token.strip()
+    ]
+
+    return {
+        "public_api_exports": {
+            "eap.protocol": sorted(eap_protocol.__all__),
+            "eap.environment": sorted(eap_environment.__all__),
+            "eap.agent": sorted(eap_agent.__all__),
+        },
+        "workflow_schema": {
+            "persisted_workflow_graph": _schema_contract(PersistedWorkflowGraph),
+            "workflow_graph_node": _schema_contract(WorkflowGraphNode),
+            "workflow_graph_edge": _schema_contract(WorkflowGraphEdge),
+            "workflow_edge_kind_values": sorted(kind.value for kind in WorkflowEdgeKind),
+        },
+        "tool_error_payload_contract": {
+            "fields": sorted(ToolErrorPayload.model_fields.keys()),
+            "schema_required": sorted(
+                ToolErrorPayload.model_json_schema().get("required", [])
+            ),
+            "allowed_error_types": allowed_error_types,
+        },
+        "settings_env_keys": _collect_settings_env_keys(DEFAULT_SETTINGS_PATH),
+        "sdk_http_paths": _collect_sdk_http_paths(
+            DEFAULT_TS_CLIENT_PATH,
+            DEFAULT_GO_CLIENT_PATH,
+        ),
+    }
+
+
+def evaluate_version_bump_policy(
+    previous_snapshot: Optional[Dict[str, Any]],
+    current_snapshot: Dict[str, Any],
+    previous_package_version: Optional[str],
+    current_package_version: str,
+) -> Tuple[bool, str]:
+    if previous_snapshot is None or previous_package_version is None:
+        return True, "No comparable base revision was available for version-bump policy checks."
+
+    if previous_snapshot == current_snapshot:
+        return True, "No contract lock change detected."
+
+    if previous_package_version == current_package_version:
+        return (
+            False,
+            (
+                "v1 contract lock changed without an explicit package version bump. "
+                f"Previous version={previous_package_version}, current version={current_package_version}."
+            ),
+        )
+
+    return True, "Contract lock changed with explicit package version bump."
+
+
+def _git_output(repo_root: Path, args: list[str]) -> Optional[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _resolve_base_revision(repo_root: Path) -> Optional[str]:
+    github_event = os.getenv("GITHUB_EVENT_NAME", "").strip().lower()
+    if github_event == "pull_request":
+        base_ref = os.getenv("GITHUB_BASE_REF", "").strip()
+        if base_ref:
+            remote_base = f"origin/{base_ref}"
+            if _git_output(repo_root, ["rev-parse", "--verify", remote_base]):
+                merge_base = _git_output(repo_root, ["merge-base", "HEAD", remote_base])
+                if merge_base:
+                    return merge_base
+
+    if _git_output(repo_root, ["rev-parse", "--verify", "HEAD~1"]):
+        return "HEAD~1"
+
+    if _git_output(repo_root, ["rev-parse", "--verify", "origin/main"]):
+        merge_base = _git_output(repo_root, ["merge-base", "HEAD", "origin/main"])
+        if merge_base:
+            return merge_base
+
+    return None
+
+
+def _read_file_at_revision(repo_root: Path, revision: str, relative_path: str) -> Optional[str]:
+    spec = f"{revision}:{relative_path}"
+    return _git_output(repo_root, ["show", spec])
+
+
+def _to_pretty_json(value: Dict[str, Any]) -> str:
+    return json.dumps(value, indent=2, sort_keys=True)
+
+
+def _diff_json(expected: Dict[str, Any], actual: Dict[str, Any]) -> str:
+    expected_lines = _to_pretty_json(expected).splitlines()
+    actual_lines = _to_pretty_json(actual).splitlines()
+    return "\n".join(
+        difflib.unified_diff(
+            expected_lines,
+            actual_lines,
+            fromfile="v1_contract_lock.snapshot",
+            tofile="current_runtime_snapshot",
+            lineterm="",
+        )
+    )
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate that the frozen v1 contract lock matches the repository runtime surface."
+        )
+    )
+    parser.add_argument(
+        "--lock-file",
+        default=str(DEFAULT_LOCK_PATH),
+        help="Path to the v1 contract lock JSON file.",
+    )
+    parser.add_argument(
+        "--write-lock",
+        action="store_true",
+        help="Write a fresh lock file using the current runtime snapshot.",
+    )
+    parser.add_argument(
+        "--base-revision",
+        default=None,
+        help="Optional git revision to compare against for version-bump policy checks.",
+    )
+    parser.add_argument(
+        "--skip-version-history-check",
+        action="store_true",
+        help="Skip git-history based version-bump policy validation.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    lock_path = Path(args.lock_file).resolve()
+    repo_root = REPO_ROOT
+    current_package_version = _extract_project_version(DEFAULT_PYPROJECT_PATH)
+    current_snapshot = build_current_snapshot(repo_root)
+
+    if args.write_lock:
+        payload = {
+            "lock_format_version": 1,
+            "snapshot_version": "1.0.0",
+            "generated_from_package_version": current_package_version,
+            "snapshot": current_snapshot,
+        }
+        lock_path.write_text(_to_pretty_json(payload) + "\n", encoding="utf-8")
+        print(f"Wrote v1 contract lock to {lock_path}")
+        return 0
+
+    if not lock_path.exists():
+        print(
+            f"Missing contract lock file: {lock_path}. "
+            "Run scripts/check_v1_contract.py --write-lock.",
+            file=sys.stderr,
+        )
+        return 1
+
+    lock_payload = json.loads(lock_path.read_text(encoding="utf-8"))
+    expected_snapshot = lock_payload.get("snapshot")
+    if not isinstance(expected_snapshot, dict):
+        print("Contract lock is missing a valid 'snapshot' object.", file=sys.stderr)
+        return 1
+
+    if current_snapshot != expected_snapshot:
+        print("v1 contract snapshot mismatch detected.", file=sys.stderr)
+        print(_diff_json(expected_snapshot, current_snapshot), file=sys.stderr)
+        print(
+            "If this is intentional, update lock + docs and bump package version explicitly.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not args.skip_version_history_check:
+        base_revision = args.base_revision or _resolve_base_revision(repo_root)
+        if base_revision:
+            previous_lock_text = _read_file_at_revision(
+                repo_root,
+                base_revision,
+                str(lock_path.relative_to(repo_root)),
+            )
+            previous_pyproject_text = _read_file_at_revision(
+                repo_root,
+                base_revision,
+                str(DEFAULT_PYPROJECT_PATH.relative_to(repo_root)),
+            )
+            previous_snapshot: Optional[Dict[str, Any]] = None
+            previous_version: Optional[str] = None
+
+            if previous_lock_text:
+                previous_snapshot = json.loads(previous_lock_text).get("snapshot")
+            if previous_pyproject_text:
+                previous_version = _extract_project_version_from_text(previous_pyproject_text)
+
+            ok, message = evaluate_version_bump_policy(
+                previous_snapshot=previous_snapshot,
+                current_snapshot=expected_snapshot,
+                previous_package_version=previous_version,
+                current_package_version=current_package_version,
+            )
+            if not ok:
+                print(message, file=sys.stderr)
+                return 1
+            print(message)
+        else:
+            print("No base revision available; skipped version-bump policy check.")
+
+    print(f"v1 contract lock is valid for package version {current_package_version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/contract/test_v1_contract_lock.py
+++ b/tests/contract/test_v1_contract_lock.py
@@ -1,0 +1,29 @@
+import json
+import unittest
+from pathlib import Path
+
+from scripts.check_v1_contract import build_current_snapshot
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOCK_PATH = REPO_ROOT / "docs" / "v1_contract_lock.json"
+
+
+class V1ContractLockTest(unittest.TestCase):
+    def test_lock_file_exists_and_has_required_metadata(self) -> None:
+        self.assertTrue(LOCK_PATH.exists(), "docs/v1_contract_lock.json must exist")
+        payload = json.loads(LOCK_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(payload.get("lock_format_version"), 1)
+        self.assertEqual(payload.get("snapshot_version"), "1.0.0")
+        self.assertIn("generated_from_package_version", payload)
+        self.assertIsInstance(payload.get("snapshot"), dict)
+
+    def test_lock_snapshot_matches_current_runtime_surface(self) -> None:
+        payload = json.loads(LOCK_PATH.read_text(encoding="utf-8"))
+        expected_snapshot = payload["snapshot"]
+        current_snapshot = build_current_snapshot(REPO_ROOT)
+        self.assertDictEqual(current_snapshot, expected_snapshot)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_v1_contract_gate.py
+++ b/tests/unit/test_v1_contract_gate.py
@@ -1,0 +1,39 @@
+import unittest
+
+from scripts.check_v1_contract import evaluate_version_bump_policy
+
+
+class V1ContractGatePolicyTest(unittest.TestCase):
+    def test_changed_contract_without_version_bump_fails(self) -> None:
+        ok, message = evaluate_version_bump_policy(
+            previous_snapshot={"a": 1},
+            current_snapshot={"a": 2},
+            previous_package_version="0.1.7",
+            current_package_version="0.1.7",
+        )
+        self.assertFalse(ok)
+        self.assertIn("without an explicit package version bump", message)
+
+    def test_changed_contract_with_version_bump_passes(self) -> None:
+        ok, message = evaluate_version_bump_policy(
+            previous_snapshot={"a": 1},
+            current_snapshot={"a": 2},
+            previous_package_version="0.1.7",
+            current_package_version="0.1.8",
+        )
+        self.assertTrue(ok)
+        self.assertIn("with explicit package version bump", message)
+
+    def test_unchanged_contract_does_not_require_version_bump(self) -> None:
+        ok, message = evaluate_version_bump_policy(
+            previous_snapshot={"a": 1},
+            current_snapshot={"a": 1},
+            previous_package_version="0.1.7",
+            current_package_version="0.1.7",
+        )
+        self.assertTrue(ok)
+        self.assertIn("No contract lock change detected", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/check_v1_contract.py` to snapshot/verify frozen v1 contract surface
- add `docs/v1_contract_lock.json` and CI gate to fail on drift
- enforce version-bump policy when contract lock changes
- add contract and unit tests for lock + policy behavior
- update v1/release docs and stabilization checklist for the new gate

## Validation
- `PYTHONPATH=. .venv/bin/python scripts/check_v1_contract.py`
- `PYTHONPATH=. .venv/bin/python -m unittest tests.unit.test_v1_contract_gate tests.contract.test_v1_contract_lock`
- `PYTHONPATH=. .venv/bin/python -m pytest -q tests/contract/test_v1_contract_lock.py tests/unit/test_v1_contract_gate.py`

Linear: GEN-50 (EAP-090)
