### PR TITLE
Docs: mark EAP-090 done and set EAP-091 next

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,3 +89,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-087` OpenClaw `/tools/invoke` bridge merged (`PR #37`).
 - Phase 7 `EAP-088` OpenAI Responses API adapter path completed (`GEN-47`).
 - Phase 8 `EAP-089` Responses streaming parity completed (`GEN-49`, PR #42).
+- Phase 8 `EAP-090` v1 compatibility enforcement completed (`GEN-50`, PR #44).

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -34,8 +34,8 @@ Updated: 2026-02-24
 | 4 | `EAP-087` | `GEN-48` | `Done` | OpenClaw `/tools/invoke` bridge |
 | 5 | `EAP-088` | `GEN-47` | `Done` | OpenAI Responses API adapter path |
 | 6 | `EAP-089` | `GEN-49` | `Done` | Responses streaming parity |
-| 7 | `EAP-090` | `GEN-50` | `Todo` | v1 compatibility enforcement |
-| 8 | `EAP-091` | `GEN-51` | `Todo (Blocked)` | Blocked by `GEN-50` |
+| 7 | `EAP-090` | `GEN-50` | `Done` | v1 compatibility enforcement |
+| 8 | `EAP-091` | `GEN-51` | `Todo` | One-command bootstrap |
 | 9 | `EAP-092` | `GEN-52` | `Todo (Blocked)` | Blocked by `GEN-51` |
 | 10 | `EAP-093` | `GEN-53` | `Todo (Blocked)` | Blocked by `GEN-52` |
 | 11 | `EAP-094` | `GEN-54` | `Todo (Blocked)` | Blocked by `GEN-53` |

--- a/docs/phase8_adoption_limits_closure_roadmap.md
+++ b/docs/phase8_adoption_limits_closure_roadmap.md
@@ -5,7 +5,7 @@ Source of truth: Linear project `Efficient Agent Protocol Roadmap`
 
 Current status:
 - [x] `EAP-089` Responses streaming parity (`GEN-49`)
-- [ ] `EAP-090` v1 compatibility enforcement (`GEN-50`)
+- [x] `EAP-090` v1 compatibility enforcement (`GEN-50`)
 - [ ] `EAP-091` one-command bootstrap (`GEN-51`)
 - [ ] `EAP-092` guided onboarding + doctor (`GEN-52`)
 - [ ] `EAP-093` self-hosted control-plane reference (`GEN-53`)
@@ -45,4 +45,4 @@ Turn README caveats (`Not ideal yet` and `Current limits`) into concrete deliver
 
 ## Execution Constraint
 
-Only the first non-blocked `Todo` item may be started (currently `EAP-090`).
+Only the first non-blocked `Todo` item may be started (currently `EAP-091`).


### PR DESCRIPTION
## Summary
- mark `EAP-090` as done in the execution queue mirror
- advance Phase 8 execution constraint to `EAP-091` as the first non-blocked todo
- add roadmap done-entry for `EAP-090` completion (PR #44)

Linear alignment:
- `GEN-50` moved to Done
- next executable item is `GEN-51` / `EAP-091`
