### PR TITLE
Docs: mark EAP-091 done and set EAP-092 next

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,3 +90,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 7 `EAP-088` OpenAI Responses API adapter path completed (`GEN-47`).
 - Phase 8 `EAP-089` Responses streaming parity completed (`GEN-49`, PR #42).
 - Phase 8 `EAP-090` v1 compatibility enforcement completed (`GEN-50`, PR #44).
+- Phase 8 `EAP-091` one-command bootstrap completed (`GEN-51`, PR #46).

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -35,8 +35,8 @@ Updated: 2026-02-24
 | 5 | `EAP-088` | `GEN-47` | `Done` | OpenAI Responses API adapter path |
 | 6 | `EAP-089` | `GEN-49` | `Done` | Responses streaming parity |
 | 7 | `EAP-090` | `GEN-50` | `Done` | v1 compatibility enforcement |
-| 8 | `EAP-091` | `GEN-51` | `Todo` | One-command bootstrap |
-| 9 | `EAP-092` | `GEN-52` | `Todo (Blocked)` | Blocked by `GEN-51` |
+| 8 | `EAP-091` | `GEN-51` | `Done` | One-command bootstrap |
+| 9 | `EAP-092` | `GEN-52` | `Todo` | Guided onboarding + doctor |
 | 10 | `EAP-093` | `GEN-53` | `Todo (Blocked)` | Blocked by `GEN-52` |
 | 11 | `EAP-094` | `GEN-54` | `Todo (Blocked)` | Blocked by `GEN-53` |
 

--- a/docs/phase8_adoption_limits_closure_roadmap.md
+++ b/docs/phase8_adoption_limits_closure_roadmap.md
@@ -6,7 +6,7 @@ Source of truth: Linear project `Efficient Agent Protocol Roadmap`
 Current status:
 - [x] `EAP-089` Responses streaming parity (`GEN-49`)
 - [x] `EAP-090` v1 compatibility enforcement (`GEN-50`)
-- [ ] `EAP-091` one-command bootstrap (`GEN-51`)
+- [x] `EAP-091` one-command bootstrap (`GEN-51`)
 - [ ] `EAP-092` guided onboarding + doctor (`GEN-52`)
 - [ ] `EAP-093` self-hosted control-plane reference (`GEN-53`)
 - [ ] `EAP-094` remote operations governance baseline (`GEN-54`)
@@ -45,4 +45,4 @@ Turn README caveats (`Not ideal yet` and `Current limits`) into concrete deliver
 
 ## Execution Constraint
 
-Only the first non-blocked `Todo` item may be started (currently `EAP-091`).
+Only the first non-blocked `Todo` item may be started (currently `EAP-092`).


### PR DESCRIPTION
## Summary
- mark `EAP-091` as done in execution queue and phase roadmap
- advance first non-blocked todo to `EAP-092`
- add roadmap done-entry for `EAP-091` completion (PR #46)

Linear alignment:
- `GEN-51` done
- next executable item is `GEN-52` / `EAP-092`
