### PR TITLE
docs: mark EAP-092 complete and advance phase 8 queue

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,3 +91,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 8 `EAP-089` Responses streaming parity completed (`GEN-49`, PR #42).
 - Phase 8 `EAP-090` v1 compatibility enforcement completed (`GEN-50`, PR #44).
 - Phase 8 `EAP-091` one-command bootstrap completed (`GEN-51`, PR #46).
+- Phase 8 `EAP-092` guided onboarding + doctor completed (`GEN-52`, PR #48).

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -36,8 +36,8 @@ Updated: 2026-02-24
 | 6 | `EAP-089` | `GEN-49` | `Done` | Responses streaming parity |
 | 7 | `EAP-090` | `GEN-50` | `Done` | v1 compatibility enforcement |
 | 8 | `EAP-091` | `GEN-51` | `Done` | One-command bootstrap |
-| 9 | `EAP-092` | `GEN-52` | `Todo` | Guided onboarding + doctor |
-| 10 | `EAP-093` | `GEN-53` | `Todo (Blocked)` | Blocked by `GEN-52` |
+| 9 | `EAP-092` | `GEN-52` | `Done` | Guided onboarding + doctor |
+| 10 | `EAP-093` | `GEN-53` | `Todo` | Self-hosted control-plane reference |
 | 11 | `EAP-094` | `GEN-54` | `Todo (Blocked)` | Blocked by `GEN-53` |
 
 ## Execution Rule

--- a/docs/phase8_adoption_limits_closure_roadmap.md
+++ b/docs/phase8_adoption_limits_closure_roadmap.md
@@ -7,7 +7,7 @@ Current status:
 - [x] `EAP-089` Responses streaming parity (`GEN-49`)
 - [x] `EAP-090` v1 compatibility enforcement (`GEN-50`)
 - [x] `EAP-091` one-command bootstrap (`GEN-51`)
-- [ ] `EAP-092` guided onboarding + doctor (`GEN-52`)
+- [x] `EAP-092` guided onboarding + doctor (`GEN-52`)
 - [ ] `EAP-093` self-hosted control-plane reference (`GEN-53`)
 - [ ] `EAP-094` remote operations governance baseline (`GEN-54`)
 
@@ -45,4 +45,4 @@ Turn README caveats (`Not ideal yet` and `Current limits`) into concrete deliver
 
 ## Execution Constraint
 
-Only the first non-blocked `Todo` item may be started (currently `EAP-092`).
+Only the first non-blocked `Todo` item may be started (currently `EAP-093`).


### PR DESCRIPTION
## Summary\n- mark EAP-092 as Done in the execution queue\n- unblock EAP-093 as the next executable phase 8 item\n- update phase 8 checklist and roadmap completion log\n\n## Validation\n- docs-only changes\n- verified queue pointers and roadmap entries are consistent