### PR TITLE
EAP-094: remote-ops governance controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Not ideal yet:
 - Evaluation harness with CI threshold gates (`scripts/eval_scorecard.py`)
 - Operator telemetry pack export (`scripts/export_telemetry_pack.py`)
 - Self-hosted control-plane reference stack (`deploy/self_hosted/docker-compose.yml`)
+- Scoped runtime auth + run ownership governance for remote operations
 - Built-in chat UI (Streamlit) with trace + data inspection
 - Conversation memory (full/window/summary)
 - Pluggable pointer storage backends (SQLite, Redis, PostgreSQL)
@@ -221,6 +222,7 @@ python3 -m build
   - `docs/observability.md`
   - `docs/operator_telemetry_pack.md`
   - `docs/self_hosted_control_plane.md`
+  - `docs/remote_ops_governance.md`
   - `docs/migrations.md`
 - Interop and starter packs:
   - `docs/openclaw_interop.md`

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -36,3 +36,5 @@ python3 scripts/migrate_state_db.py --db-path agent_state.db --backup
 ## Versioning
 
 - Current schema version is managed by `LATEST_SCHEMA_VERSION` in `protocol/migrations.py`.
+- Latest additive governance migration (`v5`) adds `actor_metadata_payload` to `execution_run_checkpoints`.
+- This column supports run ownership and scoped multi-user access enforcement in remote runtime mode.

--- a/docs/operator_telemetry_pack.md
+++ b/docs/operator_telemetry_pack.md
@@ -34,8 +34,12 @@ The exporter writes:
 - `saturation.json`
   - aggregate and per-run saturation metrics
   - includes wait times and rate-limit pressure
+- `actors.json`
+  - ownership and last-actor counts across analyzed runs
+  - per-run actor metadata (`owner_actor_id`, `actor_id`, `operation`, scopes)
 - `failed_run_diagnostics.json`
   - run summary
+  - actor metadata for the diagnosed run
   - root failure event
   - event timeline
   - dependency cascade count

--- a/docs/remote_ops_governance.md
+++ b/docs/remote_ops_governance.md
@@ -1,0 +1,90 @@
+# Remote Operations Governance Baseline (EAP-094)
+
+This baseline defines minimum controls for multi-user remote runtime operation.
+
+## Auth Scope Model
+
+Runtime operations map to required scopes:
+
+- `runs:execute`: `POST /v1/eap/macro/execute`
+- `runs:resume`: `POST /v1/eap/runs/{run_id}/resume`
+- `runs:read`: `GET /v1/eap/runs/{run_id}`
+- `pointers:read`: `GET /v1/eap/pointers/{pointer_id}/summary`
+
+Cross-run elevated scopes:
+
+- `runs:resume:any`: resume runs owned by other actors
+- `runs:read:any`: inspect runs owned by other actors
+- `pointers:read:any`: inspect pointers owned by other actors
+
+## Ownership And Access Boundaries
+
+- Every run records actor metadata (`owner_actor_id`, current `actor_id`, `actor_scopes`, `operation`).
+- Run ownership is established on execute and persisted in checkpoints/diagnostics.
+- By default, actors can only read/resume their own runs.
+- `*:any` scopes are required for cross-run access.
+
+Pointer summary access boundaries:
+
+- If pointer metadata includes `execution_run_id`, pointer reads are evaluated against run ownership rules.
+- Unscoped pointer reads across owners are denied.
+
+## Audit Logging Expectations
+
+Minimum operator log/audit fields to capture at ingress/proxy or service boundary:
+
+- actor identity (`actor_id` or mapped auth subject)
+- endpoint + HTTP method
+- authorization result (allowed/denied)
+- run ID and pointer ID (when present)
+- timestamp and source IP
+
+EAP runtime trace and diagnostics include actor metadata for run-affecting operations.
+
+## Retention Baseline
+
+Recommended defaults (tune per compliance needs):
+
+- `execution_trace_events`: 30-90 days
+- `execution_run_summaries`: 90-180 days
+- `execution_run_diagnostics`: 30-90 days
+- pointer payloads: policy-driven; ensure TTL and cleanup for sensitive data
+
+Operational controls:
+
+- periodic backup of runtime state volume
+- periodic pointer TTL cleanup
+- access review for scoped tokens and elevated (`*:any`) scopes
+
+## Scoped Token Config Example
+
+`scripts/eap_runtime_service.py` accepts `--scoped-auth-config` with this schema:
+
+```json
+{
+  "tokens": [
+    {
+      "token": "token-ops-read",
+      "actor_id": "ops-reader",
+      "scopes": ["runs:read", "pointers:read", "runs:read:any", "pointers:read:any"]
+    },
+    {
+      "token": "token-ops-write",
+      "actor_id": "ops-writer",
+      "scopes": ["runs:execute", "runs:resume", "runs:read", "pointers:read"]
+    }
+  ]
+}
+```
+
+Run with scoped config:
+
+```bash
+python scripts/eap_runtime_service.py \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --db-path /var/lib/eap/agent_state.db \
+  --scoped-auth-config /etc/eap/scoped_auth.json
+```
+
+You may keep `--bearer-token` as an emergency admin token with full runtime scopes.

--- a/docs/self_hosted_control_plane.md
+++ b/docs/self_hosted_control_plane.md
@@ -68,16 +68,34 @@ The smoke validates:
 - Runtime API expects `Authorization: Bearer <token>`.
 - Token source: `EAP_RUNTIME_BEARER_TOKEN` in `deploy/self_hosted/.env`.
 - Requests without valid bearer token return `401 unauthorized`.
+- Runtime also supports scoped tokens via `--scoped-auth-config` for multi-user governance.
+
+Scope baseline:
+- `runs:execute`, `runs:resume`, `runs:read`, `pointers:read`
+- elevated cross-run scopes: `runs:resume:any`, `runs:read:any`, `pointers:read:any`
+
+Ownership baseline:
+- run owners can read/resume their own runs.
+- cross-run access requires `*:any` scope.
+- pointer summary checks ownership when pointer metadata includes `execution_run_id`.
+
+See `docs/remote_ops_governance.md` for governance rules and scoped token examples.
 
 ## Credential Management
 
 - Use a strong, randomly generated runtime token.
+- Prefer role-scoped tokens for operators instead of sharing one global token.
 - Do not commit `deploy/self_hosted/.env` to source control.
 - Rotate token by updating `EAP_RUNTIME_BEARER_TOKEN` and restarting the stack:
 
 ```bash
 docker compose --env-file deploy/self_hosted/.env -f deploy/self_hosted/docker-compose.yml up -d --force-recreate
 ```
+
+Scoped-token rollout pattern:
+1. Keep the admin token for break-glass only.
+2. Issue dedicated scoped tokens per operator role.
+3. Audit and rotate `*:any` scopes first.
 
 ## TLS / Proxy Guidance
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -90,6 +90,20 @@ Fix:
 - Pass the exact configured token:
   - `python scripts/self_hosted_stack_smoke.py --base-url http://127.0.0.1:8080 --bearer-token "<runtime-token>"`
 
+### Runtime API returns `403 forbidden` with missing scope message
+Cause:
+- Scoped auth is enabled and the caller token lacks the endpoint scope.
+
+Fix:
+- Ensure the token includes the required scope:
+  - execute: `runs:execute`
+  - resume: `runs:resume`
+  - run inspect: `runs:read`
+  - pointer summary: `pointers:read`
+- For cross-run operations, include corresponding `*:any` scopes.
+- See:
+  - `docs/remote_ops_governance.md`
+
 ### Operator UI is reachable but no runs appear
 Cause:
 - No workflow has executed yet, or runtime and UI are not sharing the same state volume.

--- a/eap/runtime/http_api.py
+++ b/eap/runtime/http_api.py
@@ -4,13 +4,32 @@ import threading
 import uuid
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set
 from urllib.parse import unquote, urlparse
 
 from pydantic import ValidationError
 
 from eap.environment import AsyncLocalExecutor
 from eap.protocol import BatchedMacroRequest, StateManager
+
+
+SCOPE_RUNS_EXECUTE = "runs:execute"
+SCOPE_RUNS_RESUME = "runs:resume"
+SCOPE_RUNS_READ = "runs:read"
+SCOPE_POINTERS_READ = "pointers:read"
+SCOPE_RUNS_RESUME_ANY = "runs:resume:any"
+SCOPE_RUNS_READ_ANY = "runs:read:any"
+SCOPE_POINTERS_READ_ANY = "pointers:read:any"
+
+FULL_RUNTIME_SCOPES = {
+    SCOPE_RUNS_EXECUTE,
+    SCOPE_RUNS_RESUME,
+    SCOPE_RUNS_READ,
+    SCOPE_POINTERS_READ,
+    SCOPE_RUNS_RESUME_ANY,
+    SCOPE_RUNS_READ_ANY,
+    SCOPE_POINTERS_READ_ANY,
+}
 
 
 def _timestamp_utc() -> str:
@@ -51,21 +70,91 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
         # Keep test/runtime output quiet unless callers choose to add logging.
         return
 
-    def _require_auth(self) -> bool:
-        required = self.server.required_bearer_token
-        if not required:
-            return True
-
+    def _parse_bearer_token(self) -> Optional[str]:
         auth_header = (self.headers.get("Authorization") or "").strip()
         if not auth_header.startswith("Bearer "):
-            self._send_error(401, "unauthorized", "Missing or invalid bearer token.")
-            return False
-
+            return None
         token = auth_header[len("Bearer ") :].strip()
-        if token != required:
+        return token or None
+
+    def _resolve_auth_context(self) -> Optional[Dict[str, Any]]:
+        token = self._parse_bearer_token()
+        scoped_policies = self.server.scoped_bearer_tokens
+        required = self.server.required_bearer_token
+
+        if not required and not scoped_policies:
+            return {
+                "actor_id": "anonymous",
+                "scopes": set(FULL_RUNTIME_SCOPES),
+                "auth_subject": "anonymous",
+            }
+
+        if not token:
+            return None
+
+        if token in scoped_policies:
+            policy = scoped_policies[token]
+            return {
+                "actor_id": policy.get("actor_id"),
+                "scopes": set(policy.get("scopes", set())),
+                "auth_subject": policy.get("auth_subject"),
+            }
+
+        if required and token == required:
+            return {
+                "actor_id": "runtime-admin",
+                "scopes": set(FULL_RUNTIME_SCOPES),
+                "auth_subject": "required_bearer_token",
+            }
+        return None
+
+    def _require_auth(self, required_scope: str) -> Optional[Dict[str, Any]]:
+        context = self._resolve_auth_context()
+        if context is None:
             self._send_error(401, "unauthorized", "Missing or invalid bearer token.")
-            return False
-        return True
+            return None
+
+        scopes: Set[str] = set(context.get("scopes", set()))
+        if required_scope not in scopes and "*" not in scopes:
+            self._send_error(
+                403,
+                "forbidden",
+                f"Missing required scope '{required_scope}'.",
+            )
+            return None
+        return context
+
+    def _to_actor_metadata(self, auth_context: Dict[str, Any], operation: str) -> Dict[str, Any]:
+        return {
+            "actor_id": auth_context.get("actor_id"),
+            "owner_actor_id": auth_context.get("actor_id"),
+            "actor_scopes": sorted(set(auth_context.get("scopes", set()))),
+            "operation": operation,
+            "auth_subject": auth_context.get("auth_subject"),
+        }
+
+    def _check_run_access(
+        self,
+        run_id: str,
+        auth_context: Dict[str, Any],
+        *,
+        allow_any_scope: str,
+    ) -> bool:
+        actor_metadata = self.server.state_manager.get_run_actor_metadata(run_id=run_id)
+        owner_actor_id = actor_metadata.get("owner_actor_id") or actor_metadata.get("actor_id")
+        if not owner_actor_id:
+            return True
+
+        actor_id = auth_context.get("actor_id")
+        scopes: Set[str] = set(auth_context.get("scopes", set()))
+        if actor_id == owner_actor_id or allow_any_scope in scopes or "*" in scopes:
+            return True
+        self._send_error(
+            403,
+            "forbidden",
+            f"Actor '{actor_id}' is not allowed to access run '{run_id}'.",
+        )
+        return False
 
     def _read_json_body(self, required: bool = True) -> Optional[Dict[str, Any]]:
         content_length_header = self.headers.get("Content-Length")
@@ -98,7 +187,8 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
         return payload
 
     def _handle_execute_macro(self) -> None:
-        if not self._require_auth():
+        auth_context = self._require_auth(SCOPE_RUNS_EXECUTE)
+        if auth_context is None:
             return
 
         payload = self._read_json_body()
@@ -122,7 +212,12 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
             return
 
         try:
-            result = asyncio.run(self.server.executor.execute_macro(macro))
+            result = asyncio.run(
+                self.server.executor.execute_macro(
+                    macro,
+                    actor_metadata=self._to_actor_metadata(auth_context, operation="execute"),
+                )
+            )
         except Exception as exc:  # pragma: no cover - defensive safeguard
             self._send_error(
                 500,
@@ -149,10 +244,17 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
         self._send_json(200, response_payload)
 
     def _handle_resume_run(self, run_id: str) -> None:
-        if not self._require_auth():
+        auth_context = self._require_auth(SCOPE_RUNS_RESUME)
+        if auth_context is None:
             return
         if not run_id:
             self._send_error(400, "validation_error", "run_id is required.")
+            return
+        if not self._check_run_access(
+            run_id=run_id,
+            auth_context=auth_context,
+            allow_any_scope=SCOPE_RUNS_RESUME_ANY,
+        ):
             return
 
         payload = self._read_json_body(required=False)
@@ -164,7 +266,13 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
             return
 
         try:
-            result = asyncio.run(self.server.executor.resume_run(run_id=run_id, approvals=approvals))
+            result = asyncio.run(
+                self.server.executor.resume_run(
+                    run_id=run_id,
+                    approvals=approvals,
+                    actor_metadata=self._to_actor_metadata(auth_context, operation="resume"),
+                )
+            )
         except KeyError:
             self._send_error(404, "not_found", f"Execution checkpoint for run '{run_id}' not found.")
             return
@@ -206,10 +314,17 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
         self._send_json(200, response_payload)
 
     def _handle_get_run(self, run_id: str) -> None:
-        if not self._require_auth():
+        auth_context = self._require_auth(SCOPE_RUNS_READ)
+        if auth_context is None:
             return
         if not run_id:
             self._send_error(400, "validation_error", "run_id is required.")
+            return
+        if not self._check_run_access(
+            run_id=run_id,
+            auth_context=auth_context,
+            allow_any_scope=SCOPE_RUNS_READ_ANY,
+        ):
             return
 
         try:
@@ -222,6 +337,7 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
             event.model_dump(mode="json")
             for event in self.server.state_manager.list_trace_events(run_id)
         ]
+        actor_metadata = self.server.state_manager.get_run_actor_metadata(run_id=run_id)
         status = "failed" if summary.get("failed_steps", 0) > 0 else "succeeded"
 
         response_payload = {
@@ -230,13 +346,15 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
             "run_id": run_id,
             "status": status,
             "summary": summary,
+            "actor_metadata": actor_metadata,
             "trace_event_count": len(trace_events),
             "trace_events": trace_events,
         }
         self._send_json(200, response_payload)
 
     def _handle_get_pointer_summary(self, pointer_id: str) -> None:
-        if not self._require_auth():
+        auth_context = self._require_auth(SCOPE_POINTERS_READ)
+        if auth_context is None:
             return
         if not pointer_id:
             self._send_error(400, "validation_error", "pointer_id is required.")
@@ -253,6 +371,18 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
         if pointer is None:
             self._send_error(404, "not_found", f"Pointer '{pointer_id}' not found.")
             return
+
+        pointer_metadata = pointer.get("metadata") if isinstance(pointer.get("metadata"), dict) else {}
+        run_id = pointer_metadata.get("execution_run_id")
+        if isinstance(run_id, str) and run_id:
+            scopes: Set[str] = set(auth_context.get("scopes", set()))
+            if SCOPE_POINTERS_READ_ANY not in scopes and "*" not in scopes:
+                if not self._check_run_access(
+                    run_id=run_id,
+                    auth_context=auth_context,
+                    allow_any_scope=SCOPE_RUNS_READ_ANY,
+                ):
+                    return
 
         response_payload = {
             "request_id": _request_id(),
@@ -301,15 +431,52 @@ class _RuntimeHTTPServer(ThreadingHTTPServer):
         executor: AsyncLocalExecutor,
         state_manager: StateManager,
         required_bearer_token: Optional[str],
+        scoped_bearer_tokens: Optional[Dict[str, Dict[str, Any]]],
     ):
         super().__init__(server_address, RequestHandlerClass)
         self.executor = executor
         self.state_manager = state_manager
         self.required_bearer_token = required_bearer_token
+        self.scoped_bearer_tokens = scoped_bearer_tokens or {}
 
 
 class EAPRuntimeHTTPServer:
     """Minimal HTTP runtime endpoints for external orchestrator integration."""
+
+    @staticmethod
+    def _normalize_scoped_bearer_tokens(
+        scoped_bearer_tokens: Optional[Dict[str, Dict[str, Any]]],
+    ) -> Dict[str, Dict[str, Any]]:
+        normalized: Dict[str, Dict[str, Any]] = {}
+        if not scoped_bearer_tokens:
+            return normalized
+
+        for raw_token, raw_policy in scoped_bearer_tokens.items():
+            token = str(raw_token).strip()
+            if not token or not isinstance(raw_policy, dict):
+                continue
+            actor_id = str(raw_policy.get("actor_id", "")).strip()
+            auth_subject = str(raw_policy.get("auth_subject", "")).strip()
+
+            scopes_value = raw_policy.get("scopes", [])
+            if isinstance(scopes_value, str):
+                scopes = [scope.strip() for scope in scopes_value.split(",") if scope.strip()]
+            elif isinstance(scopes_value, list):
+                scopes = [str(scope).strip() for scope in scopes_value if str(scope).strip()]
+            else:
+                scopes = []
+            scopes = [scope for scope in scopes if scope in FULL_RUNTIME_SCOPES or scope == "*"]
+
+            if not actor_id:
+                continue
+            if not scopes:
+                continue
+            normalized[token] = {
+                "actor_id": actor_id,
+                "auth_subject": auth_subject or f"scoped_token:{actor_id}",
+                "scopes": sorted(set(scopes)),
+            }
+        return normalized
 
     def __init__(
         self,
@@ -318,14 +485,17 @@ class EAPRuntimeHTTPServer:
         host: str = "127.0.0.1",
         port: int = 0,
         required_bearer_token: Optional[str] = None,
+        scoped_bearer_tokens: Optional[Dict[str, Dict[str, Any]]] = None,
     ):
         self._host = host
+        normalized_scoped_tokens = self._normalize_scoped_bearer_tokens(scoped_bearer_tokens)
         self._httpd = _RuntimeHTTPServer(
             (host, port),
             _RuntimeRequestHandler,
             executor=executor,
             state_manager=state_manager,
             required_bearer_token=required_bearer_token,
+            scoped_bearer_tokens=normalized_scoped_tokens,
         )
         self._thread: Optional[threading.Thread] = None
 

--- a/environment/executor.py
+++ b/environment/executor.py
@@ -63,14 +63,42 @@ class AsyncLocalExecutor:
         self.registry = registry
         self.default_execution_limits = default_execution_limits or ExecutionLimits()
 
+    @staticmethod
+    def _normalize_actor_metadata(
+        actor_metadata: Optional[Dict[str, Any]],
+        operation: str,
+    ) -> Dict[str, Any]:
+        source = actor_metadata if isinstance(actor_metadata, dict) else {}
+        actor_id = str(source.get("actor_id", "")).strip()
+        owner_actor_id = str(source.get("owner_actor_id", "")).strip()
+        scopes_raw = source.get("actor_scopes", source.get("scopes", []))
+        if isinstance(scopes_raw, str):
+            scopes = [scope.strip() for scope in scopes_raw.split(",") if scope.strip()]
+        elif isinstance(scopes_raw, list):
+            scopes = [str(scope).strip() for scope in scopes_raw if str(scope).strip()]
+        else:
+            scopes = []
+
+        metadata: Dict[str, Any] = {
+            "operation": operation,
+            "actor_id": actor_id or None,
+            "owner_actor_id": owner_actor_id or None,
+            "actor_scopes": sorted(set(scopes)),
+        }
+        if isinstance(source.get("auth_subject"), str) and source["auth_subject"].strip():
+            metadata["auth_subject"] = source["auth_subject"].strip()
+        return metadata
+
     async def execute_macro(
         self,
         macro: BatchedMacroRequest,
         run_id: Optional[str] = None,
         resume: bool = False,
+        actor_metadata: Optional[Dict[str, Any]] = None,
     ) -> dict:
         run_id = run_id or f"run_{uuid.uuid4().hex[:12]}"
         run_started_at = datetime.now(timezone.utc)
+        operation = "resume" if resume else "execute"
         replayed_step_ids: Set[str] = set()
         logger.info(
             "received macro batch",
@@ -86,6 +114,8 @@ class AsyncLocalExecutor:
         branch_decisions: Dict[str, Set[str]] = {}
         early_exit_event = asyncio.Event()
         checkpoint_lock = asyncio.Lock()
+        normalized_actor_metadata = self._normalize_actor_metadata(actor_metadata, operation=operation)
+        run_actor_metadata: Dict[str, Any] = dict(normalized_actor_metadata)
 
         if resume:
             checkpoint = self.state_manager.get_run_checkpoint(run_id)
@@ -101,6 +131,35 @@ class AsyncLocalExecutor:
                 step_id: set(targets)
                 for step_id, targets in (checkpoint.get("branch_decisions") or {}).items()
             }
+            checkpoint_actor_metadata = (
+                checkpoint.get("actor_metadata")
+                if isinstance(checkpoint.get("actor_metadata"), dict)
+                else {}
+            )
+            if checkpoint_actor_metadata:
+                merged_actor_metadata = dict(checkpoint_actor_metadata)
+                if normalized_actor_metadata.get("actor_id"):
+                    merged_actor_metadata["actor_id"] = normalized_actor_metadata["actor_id"]
+                if normalized_actor_metadata.get("actor_scopes"):
+                    merged_actor_metadata["actor_scopes"] = normalized_actor_metadata["actor_scopes"]
+                if normalized_actor_metadata.get("auth_subject"):
+                    merged_actor_metadata["auth_subject"] = normalized_actor_metadata["auth_subject"]
+                merged_actor_metadata["operation"] = operation
+                run_actor_metadata = merged_actor_metadata
+
+        if not run_actor_metadata.get("owner_actor_id"):
+            run_actor_metadata["owner_actor_id"] = run_actor_metadata.get("actor_id")
+        if not run_actor_metadata.get("actor_id"):
+            run_actor_metadata["actor_id"] = run_actor_metadata.get("owner_actor_id")
+        scopes_value = run_actor_metadata.get("actor_scopes", run_actor_metadata.get("scopes", []))
+        if isinstance(scopes_value, str):
+            normalized_scopes = [scope.strip() for scope in scopes_value.split(",") if scope.strip()]
+        elif isinstance(scopes_value, list):
+            normalized_scopes = [str(scope).strip() for scope in scopes_value if str(scope).strip()]
+        else:
+            normalized_scopes = []
+        run_actor_metadata["actor_scopes"] = sorted(set(normalized_scopes))
+        run_actor_metadata["operation"] = operation
 
         def _hydrate_pointer_response(pointer_id: Optional[str], step_id: str) -> Dict[str, Any]:
             if not pointer_id:
@@ -162,6 +221,7 @@ class AsyncLocalExecutor:
                         step_id: sorted(targets) for step_id, targets in branch_decisions.items()
                     },
                     final_pointer_id=final_pointer_id,
+                    actor_metadata=run_actor_metadata,
                 )
 
         await _persist_checkpoint(status="active")
@@ -301,6 +361,38 @@ class AsyncLocalExecutor:
                 return tool_name_or_hash
             return None
 
+        def _pointer_metadata(extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+            base: Dict[str, Any] = {
+                "execution_run_id": run_id,
+                "actor_id": run_actor_metadata.get("actor_id"),
+                "owner_actor_id": run_actor_metadata.get("owner_actor_id"),
+            }
+            if extra:
+                base.update(extra)
+            return base
+
+        def _append_trace_event(
+            step_id: str,
+            tool_name: str,
+            event_type: ExecutionTraceEventType,
+            **kwargs: Any,
+        ) -> None:
+            actor_scopes = run_actor_metadata.get("actor_scopes")
+            if isinstance(actor_scopes, list) and not actor_scopes:
+                actor_scopes = None
+            self.state_manager.append_trace_event(
+                ExecutionTraceEvent(
+                    run_id=run_id,
+                    step_id=step_id,
+                    tool_name=tool_name,
+                    event_type=event_type,
+                    actor_id=run_actor_metadata.get("actor_id"),
+                    actor_scopes=actor_scopes,
+                    operation=run_actor_metadata.get("operation"),
+                    **kwargs,
+                )
+            )
+
         async def _record_wait(metric_count_key: str, metric_time_key: str, waited_seconds: float) -> None:
             if waited_seconds <= 0:
                 return
@@ -342,14 +434,11 @@ class AsyncLocalExecutor:
                 if not step_futures[step.step_id].done():
                     step_futures[step.step_id].set_result(existing_pointer_id)
                 replayed_step_ids.add(step.step_id)
-                self.state_manager.append_trace_event(
-                    ExecutionTraceEvent(
-                        run_id=run_id,
-                        step_id=step.step_id,
-                        tool_name=step.tool_name,
-                        event_type=ExecutionTraceEventType.REPLAYED,
-                        output_pointer_id=existing_pointer_id,
-                    )
+                _append_trace_event(
+                    step_id=step.step_id,
+                    tool_name=step.tool_name,
+                    event_type=ExecutionTraceEventType.REPLAYED,
+                    output_pointer_id=existing_pointer_id,
                 )
                 logger.info(
                     "task replayed from checkpoint",
@@ -361,13 +450,10 @@ class AsyncLocalExecutor:
                 "task queued",
                 extra={"step_id": step.step_id, "tool_name": step.tool_name, "run_id": run_id},
             )
-            self.state_manager.append_trace_event(
-                ExecutionTraceEvent(
-                    run_id=run_id,
-                    step_id=step.step_id,
-                    tool_name=step.tool_name,
-                    event_type=ExecutionTraceEventType.QUEUED,
-                )
+            _append_trace_event(
+                step_id=step.step_id,
+                tool_name=step.tool_name,
+                event_type=ExecutionTraceEventType.QUEUED,
             )
             attempt_count = 0
             step_started_perf = time.perf_counter()
@@ -389,7 +475,9 @@ class AsyncLocalExecutor:
                         step_pointer = self.state_manager.store_and_point(
                             raw_data=skip_payload,
                             summary=f"Step {step.step_id} skipped (branch not selected).",
-                            metadata={"status": "skipped", "reason": "branch_not_selected"},
+                            metadata=_pointer_metadata(
+                                {"status": "skipped", "reason": "branch_not_selected"}
+                            ),
                         )
                         step_status[step.step_id] = {"status": "skipped", "pointer_id": step_pointer["pointer_id"]}
                         step_contexts[step.step_id] = {
@@ -418,7 +506,7 @@ class AsyncLocalExecutor:
                     step_pointer = self.state_manager.store_and_point(
                         raw_data=skip_payload,
                         summary=f"Step {step.step_id} skipped (early exit).",
-                        metadata={"status": "skipped", "reason": "early_exit"},
+                        metadata=_pointer_metadata({"status": "skipped", "reason": "early_exit"}),
                     )
                     step_status[step.step_id] = {"status": "skipped", "pointer_id": step_pointer["pointer_id"]}
                     step_contexts[step.step_id] = {
@@ -441,13 +529,10 @@ class AsyncLocalExecutor:
                 requires_approval = bool(step.approval and step.approval.required)
                 approval_decision = macro.approvals.get(step.step_id)
                 if requires_approval:
-                    self.state_manager.append_trace_event(
-                        ExecutionTraceEvent(
-                            run_id=run_id,
-                            step_id=step.step_id,
-                            tool_name=step.tool_name,
-                            event_type=ExecutionTraceEventType.APPROVAL_REQUIRED,
-                        )
+                    _append_trace_event(
+                        step_id=step.step_id,
+                        tool_name=step.tool_name,
+                        event_type=ExecutionTraceEventType.APPROVAL_REQUIRED,
                     )
                     if approval_decision is None:
                         pending_payload = {
@@ -459,11 +544,13 @@ class AsyncLocalExecutor:
                         step_pointer = self.state_manager.store_and_point(
                             raw_data=pending_payload,
                             summary=f"Step {step.step_id} paused awaiting approval.",
-                            metadata={
-                                "status": "paused",
-                                "reason": "awaiting_approval",
-                                "approval_prompt": step.approval.prompt if step.approval else None,
-                            },
+                            metadata=_pointer_metadata(
+                                {
+                                    "status": "paused",
+                                    "reason": "awaiting_approval",
+                                    "approval_prompt": step.approval.prompt if step.approval else None,
+                                }
+                            ),
                         )
                         step_status[step.step_id] = {
                             "status": "paused",
@@ -495,21 +582,20 @@ class AsyncLocalExecutor:
                             tool_name=step.tool_name,
                             details={"approval_prompt": step.approval.prompt if step.approval else None},
                         )
-                        self.state_manager.append_trace_event(
-                            ExecutionTraceEvent(
-                                run_id=run_id,
-                                step_id=step.step_id,
-                                tool_name=step.tool_name,
-                                event_type=ExecutionTraceEventType.REJECTED,
-                                attempt=1,
-                                error=error_payload,
-                            )
+                        _append_trace_event(
+                            step_id=step.step_id,
+                            tool_name=step.tool_name,
+                            event_type=ExecutionTraceEventType.REJECTED,
+                            attempt=1,
+                            error=error_payload,
                         )
                         rejection_payload = error_payload.model_dump(mode="json")
                         step_pointer = self.state_manager.store_and_point(
                             raw_data=rejection_payload,
                             summary=f"Step {step.step_id} rejected at approval checkpoint.",
-                            metadata={"status": "rejected", "error_type": "approval_rejected"},
+                            metadata=_pointer_metadata(
+                                {"status": "rejected", "error_type": "approval_rejected"}
+                            ),
                         )
                         step_status[step.step_id] = {
                             "status": "rejected",
@@ -531,13 +617,10 @@ class AsyncLocalExecutor:
                         )
                         return step_pointer
 
-                    self.state_manager.append_trace_event(
-                        ExecutionTraceEvent(
-                            run_id=run_id,
-                            step_id=step.step_id,
-                            tool_name=step.tool_name,
-                            event_type=ExecutionTraceEventType.APPROVED,
-                        )
+                    _append_trace_event(
+                        step_id=step.step_id,
+                        tool_name=step.tool_name,
+                        event_type=ExecutionTraceEventType.APPROVED,
                     )
 
                 resolved_args = {}
@@ -620,16 +703,13 @@ class AsyncLocalExecutor:
                             async with metric_lock:
                                 saturation_metrics["total_rate_limited_attempts"] += 1
 
-                        self.state_manager.append_trace_event(
-                            ExecutionTraceEvent(
-                                run_id=run_id,
-                                step_id=step.step_id,
-                                tool_name=step.tool_name,
-                                event_type=ExecutionTraceEventType.STARTED,
-                                attempt=attempt_count,
-                                resolved_arguments=resolved_args,
-                                input_pointer_ids=input_pointer_ids or None,
-                            )
+                        _append_trace_event(
+                            step_id=step.step_id,
+                            tool_name=step.tool_name,
+                            event_type=ExecutionTraceEventType.STARTED,
+                            attempt=attempt_count,
+                            resolved_arguments=resolved_args,
+                            input_pointer_ids=input_pointer_ids or None,
                         )
                         raw_output = await asyncio.to_thread(tool_func, **resolved_args)
                         break
@@ -645,18 +725,15 @@ class AsyncLocalExecutor:
                         retryable = error_name in retry_policy.retryable_error_types
                         if (not retryable) or (attempt_count >= retry_policy.max_attempts):
                             raise
-                        self.state_manager.append_trace_event(
-                            ExecutionTraceEvent(
-                                run_id=run_id,
-                                step_id=step.step_id,
-                                tool_name=step.tool_name,
-                                event_type=ExecutionTraceEventType.RETRIED,
-                                attempt=attempt_count,
-                                retry_delay_seconds=delay,
-                                error=error_payload,
-                                resolved_arguments=resolved_args,
-                                input_pointer_ids=input_pointer_ids or None,
-                            )
+                        _append_trace_event(
+                            step_id=step.step_id,
+                            tool_name=step.tool_name,
+                            event_type=ExecutionTraceEventType.RETRIED,
+                            attempt=attempt_count,
+                            retry_delay_seconds=delay,
+                            error=error_payload,
+                            resolved_arguments=resolved_args,
+                            input_pointer_ids=input_pointer_ids or None,
                         )
                         logger.warning(
                             "task retrying",
@@ -681,20 +758,18 @@ class AsyncLocalExecutor:
                 step_pointer = self.state_manager.store_and_point(
                     raw_data=raw_output,
                     summary=f"Completed step {step.step_id} successfully.",
+                    metadata=_pointer_metadata({"step_id": step.step_id}),
                 )
                 step_duration_ms = round((time.perf_counter() - step_started_perf) * 1000, 3)
-                self.state_manager.append_trace_event(
-                    ExecutionTraceEvent(
-                        run_id=run_id,
-                        step_id=step.step_id,
-                        tool_name=step.tool_name,
-                        event_type=ExecutionTraceEventType.COMPLETED,
-                        attempt=attempt_count,
-                        resolved_arguments=resolved_args,
-                        input_pointer_ids=input_pointer_ids or None,
-                        output_pointer_id=step_pointer["pointer_id"],
-                        duration_ms=step_duration_ms,
-                    )
+                _append_trace_event(
+                    step_id=step.step_id,
+                    tool_name=step.tool_name,
+                    event_type=ExecutionTraceEventType.COMPLETED,
+                    attempt=attempt_count,
+                    resolved_arguments=resolved_args,
+                    input_pointer_ids=input_pointer_ids or None,
+                    output_pointer_id=step_pointer["pointer_id"],
+                    duration_ms=step_duration_ms,
                 )
                 step_status[step.step_id] = {"status": "ok", "pointer_id": step_pointer["pointer_id"]}
                 step_contexts[step.step_id] = {
@@ -733,21 +808,18 @@ class AsyncLocalExecutor:
                     details={"attempts": attempt_count},
                 ).model_dump()
                 step_duration_ms = round((time.perf_counter() - step_started_perf) * 1000, 3)
-                self.state_manager.append_trace_event(
-                    ExecutionTraceEvent(
-                        run_id=run_id,
-                        step_id=step.step_id,
-                        tool_name=step.tool_name,
-                        event_type=ExecutionTraceEventType.FAILED,
-                        attempt=max(1, attempt_count),
-                        error=ToolErrorPayload(**error_payload),
-                        duration_ms=step_duration_ms,
-                    )
+                _append_trace_event(
+                    step_id=step.step_id,
+                    tool_name=step.tool_name,
+                    event_type=ExecutionTraceEventType.FAILED,
+                    attempt=max(1, attempt_count),
+                    error=ToolErrorPayload(**error_payload),
+                    duration_ms=step_duration_ms,
                 )
                 step_pointer = self.state_manager.store_and_point(
                     raw_data=error_payload,
                     summary=f"Step {step.step_id} failed with {error_type}.",
-                    metadata={"status": "error", "error_type": error_type},
+                    metadata=_pointer_metadata({"status": "error", "error_type": error_type}),
                 )
                 step_status[step.step_id] = {"status": "error", "pointer_id": step_pointer["pointer_id"]}
                 step_contexts[step.step_id] = {
@@ -831,6 +903,7 @@ class AsyncLocalExecutor:
                 "approval_metrics": approval_metrics,
                 "saturation_metrics": final_saturation_metrics,
                 "step_status": step_status,
+                "actor_metadata": run_actor_metadata,
             },
         )
 
@@ -842,12 +915,14 @@ class AsyncLocalExecutor:
             final_result["metadata"]["replayed_steps"] = sorted(replayed_step_ids)
             final_result["metadata"]["approval_metrics"] = approval_metrics
             final_result["metadata"]["saturation_metrics"] = final_saturation_metrics
+            final_result["metadata"]["actor_metadata"] = run_actor_metadata
         return final_result
 
     async def resume_run(
         self,
         run_id: str,
         approvals: Optional[Dict[str, Any]] = None,
+        actor_metadata: Optional[Dict[str, Any]] = None,
     ) -> dict:
         checkpoint = self.state_manager.get_run_checkpoint(run_id)
         if checkpoint["status"] not in {"active", "awaiting_approval"}:
@@ -860,4 +935,9 @@ class AsyncLocalExecutor:
             merged_approvals.update(approvals)
             macro_payload["approvals"] = merged_approvals
         macro = BatchedMacroRequest.model_validate(macro_payload)
-        return await self.execute_macro(macro=macro, run_id=run_id, resume=True)
+        return await self.execute_macro(
+            macro=macro,
+            run_id=run_id,
+            resume=True,
+            actor_metadata=actor_metadata,
+        )

--- a/protocol/migrations.py
+++ b/protocol/migrations.py
@@ -58,6 +58,25 @@ MIGRATIONS: List[MigrationStep] = [
             """,
         ],
     ),
+    MigrationStep(
+        version=5,
+        description="Add actor metadata payload column to run checkpoints for governance",
+        statements=[
+            """
+            CREATE TABLE IF NOT EXISTS execution_run_checkpoints (
+                run_id TEXT PRIMARY KEY,
+                started_at_utc TEXT NOT NULL,
+                updated_at_utc TEXT NOT NULL,
+                status TEXT NOT NULL,
+                macro_payload TEXT NOT NULL,
+                step_status_payload TEXT NOT NULL,
+                branch_decisions_payload TEXT NOT NULL,
+                final_pointer_id TEXT
+            )
+            """,
+            "ALTER TABLE execution_run_checkpoints ADD COLUMN actor_metadata_payload TEXT",
+        ],
+    ),
 ]
 
 

--- a/protocol/models.py
+++ b/protocol/models.py
@@ -256,9 +256,30 @@ class ExecutionTraceEvent(BaseModel):
         default=None,
         description="Structured error payload for failed/retried events.",
     )
+    actor_id: Optional[str] = Field(
+        default=None,
+        description="Actor ID associated with the run-affecting operation for this event.",
+    )
+    actor_scopes: Optional[List[str]] = Field(
+        default=None,
+        description="Authorization scopes granted to the actor when the event was emitted.",
+    )
+    operation: Optional[str] = Field(
+        default=None,
+        description="Run-affecting operation context for this event: execute | resume.",
+    )
 
     @model_validator(mode="after")
     def validate_event_contract(self) -> "ExecutionTraceEvent":
+        if self.actor_scopes is not None:
+            normalized_scopes = sorted({scope.strip() for scope in self.actor_scopes if scope.strip()})
+            if not normalized_scopes:
+                raise ValueError("actor_scopes must include at least one non-empty scope when provided")
+            self.actor_scopes = normalized_scopes
+
+        if self.operation is not None and self.operation not in {"execute", "resume"}:
+            raise ValueError("operation must be one of: execute, resume")
+
         if self.event_type == ExecutionTraceEventType.REPLAYED:
             if not self.output_pointer_id:
                 raise ValueError("replayed events must include output_pointer_id")

--- a/protocol/state_manager.py
+++ b/protocol/state_manager.py
@@ -268,6 +268,11 @@ class StateManager:
             )
 
     def list_trace_events(self, run_id: str) -> List[ExecutionTraceEvent]:
+        actor_metadata = self.get_run_actor_metadata(run_id=run_id)
+        actor_id = actor_metadata.get("actor_id") or actor_metadata.get("owner_actor_id")
+        actor_scopes = actor_metadata.get("actor_scopes") or actor_metadata.get("scopes")
+        operation = actor_metadata.get("operation")
+
         with sqlite3.connect(self.db_path) as conn:
             rows = conn.execute(
                 """
@@ -296,6 +301,9 @@ class StateManager:
                     duration_ms=row[8],
                     retry_delay_seconds=row[9],
                     error=json.loads(row[10]) if row[10] else None,
+                    actor_id=actor_id,
+                    actor_scopes=actor_scopes,
+                    operation=operation,
                 )
             )
         return events
@@ -340,6 +348,7 @@ class StateManager:
         step_status: Dict[str, Dict[str, Any]],
         branch_decisions: Dict[str, List[str]],
         final_pointer_id: Optional[str] = None,
+        actor_metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         updated_at_utc = self._now_utc_iso()
         with sqlite3.connect(self.db_path) as conn:
@@ -347,8 +356,8 @@ class StateManager:
                 """
                 INSERT OR REPLACE INTO execution_run_checkpoints (
                     run_id, started_at_utc, updated_at_utc, status, macro_payload,
-                    step_status_payload, branch_decisions_payload, final_pointer_id
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    step_status_payload, branch_decisions_payload, final_pointer_id, actor_metadata_payload
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     run_id,
@@ -359,6 +368,7 @@ class StateManager:
                     json.dumps(step_status),
                     json.dumps(branch_decisions),
                     final_pointer_id,
+                    json.dumps(actor_metadata) if actor_metadata is not None else None,
                 ),
             )
 
@@ -367,7 +377,7 @@ class StateManager:
             row = conn.execute(
                 """
                 SELECT started_at_utc, updated_at_utc, status, macro_payload,
-                       step_status_payload, branch_decisions_payload, final_pointer_id
+                       step_status_payload, branch_decisions_payload, final_pointer_id, actor_metadata_payload
                 FROM execution_run_checkpoints
                 WHERE run_id = ?
                 """,
@@ -386,11 +396,12 @@ class StateManager:
             "step_status": json.loads(row[4]) if row[4] else {},
             "branch_decisions": json.loads(row[5]) if row[5] else {},
             "final_pointer_id": row[6],
+            "actor_metadata": json.loads(row[7]) if row[7] else {},
         }
 
     def list_run_checkpoints(self, status: Optional[str] = None, limit: int = 50) -> List[Dict[str, Any]]:
         query = """
-            SELECT run_id, started_at_utc, updated_at_utc, status, final_pointer_id
+            SELECT run_id, started_at_utc, updated_at_utc, status, final_pointer_id, actor_metadata_payload
             FROM execution_run_checkpoints
         """
         params: tuple[Any, ...] = ()
@@ -410,9 +421,51 @@ class StateManager:
                 "updated_at_utc": row[2],
                 "status": row[3],
                 "final_pointer_id": row[4],
+                "actor_metadata": json.loads(row[5]) if row[5] else {},
             }
             for row in rows
         ]
+
+    def get_run_actor_metadata(self, run_id: str) -> Dict[str, Any]:
+        with sqlite3.connect(self.db_path) as conn:
+            checkpoint_row = conn.execute(
+                """
+                SELECT actor_metadata_payload
+                FROM execution_run_checkpoints
+                WHERE run_id = ?
+                """,
+                (run_id,),
+            ).fetchone()
+
+            if checkpoint_row and checkpoint_row[0]:
+                try:
+                    value = json.loads(checkpoint_row[0])
+                except json.JSONDecodeError:
+                    value = {}
+                if isinstance(value, dict):
+                    return value
+
+            diagnostics_row = conn.execute(
+                """
+                SELECT payload_json
+                FROM execution_run_diagnostics
+                WHERE run_id = ?
+                """,
+                (run_id,),
+            ).fetchone()
+
+        if not diagnostics_row or not diagnostics_row[0]:
+            return {}
+        try:
+            diagnostics_payload = json.loads(diagnostics_row[0])
+        except json.JSONDecodeError:
+            return {}
+        if not isinstance(diagnostics_payload, dict):
+            return {}
+        actor_payload = diagnostics_payload.get("actor_metadata")
+        if not isinstance(actor_payload, dict):
+            return {}
+        return actor_payload
 
     def get_execution_summary(self, run_id: str) -> Dict[str, Any]:
         with sqlite3.connect(self.db_path) as conn:

--- a/scripts/eap_runtime_service.py
+++ b/scripts/eap_runtime_service.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 import argparse
+import json
 import signal
 import threading
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Dict, Sequence
 
 from eap.environment import AsyncLocalExecutor, ToolRegistry
 from eap.environment.tools import ANALYZE_SCHEMA, FETCH_SCHEMA, analyze_data, fetch_user_data
@@ -33,8 +34,16 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--bearer-token",
-        required=True,
-        help="Required bearer token for /v1/eap/* endpoints.",
+        default="",
+        help="Optional admin bearer token for /v1/eap/* endpoints.",
+    )
+    parser.add_argument(
+        "--scoped-auth-config",
+        default="",
+        help=(
+            "Optional JSON file defining scoped bearer tokens. "
+            "Format: {\"tokens\":[{\"token\":\"...\",\"actor_id\":\"...\",\"scopes\":[\"runs:read\", ...]}]}"
+        ),
     )
     return parser.parse_args(argv)
 
@@ -45,14 +54,53 @@ def _register_default_tools(registry: ToolRegistry) -> None:
     registry.register("analyze_data", analyze_data, ANALYZE_SCHEMA)
 
 
+def _load_scoped_auth_config(path: str) -> Dict[str, Dict[str, Any]]:
+    if not path.strip():
+        return {}
+    config_path = Path(path).resolve()
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, list):
+        raise ValueError("scoped auth config must include a 'tokens' array.")
+
+    scoped_tokens: Dict[str, Dict[str, Any]] = {}
+    for item in tokens:
+        if not isinstance(item, dict):
+            continue
+        token = str(item.get("token", "")).strip()
+        actor_id = str(item.get("actor_id", "")).strip()
+        scopes = item.get("scopes", [])
+        if isinstance(scopes, str):
+            scopes = [part.strip() for part in scopes.split(",") if part.strip()]
+        elif isinstance(scopes, list):
+            scopes = [str(part).strip() for part in scopes if str(part).strip()]
+        else:
+            scopes = []
+        if not token or not actor_id or not scopes:
+            continue
+        scoped_tokens[token] = {
+            "actor_id": actor_id,
+            "auth_subject": str(item.get("auth_subject", "")).strip() or f"scoped_token:{actor_id}",
+            "scopes": scopes,
+        }
+    return scoped_tokens
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
 
     if args.port <= 0 or args.port > 65535:
         print("[runtime:error] --port must be between 1 and 65535.")
         return 1
-    if not args.bearer_token.strip():
-        print("[runtime:error] --bearer-token cannot be empty.")
+    bearer_token = args.bearer_token.strip()
+    try:
+        scoped_tokens = _load_scoped_auth_config(args.scoped_auth_config)
+    except Exception as exc:
+        print(f"[runtime:error] failed to load --scoped-auth-config: {exc}")
+        return 1
+
+    if not bearer_token and not scoped_tokens:
+        print("[runtime:error] provide --bearer-token and/or --scoped-auth-config.")
         return 1
 
     db_path = Path(args.db_path).resolve()
@@ -68,7 +116,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         state_manager=state_manager,
         host=args.host,
         port=args.port,
-        required_bearer_token=args.bearer_token.strip(),
+        required_bearer_token=bearer_token or None,
+        scoped_bearer_tokens=scoped_tokens or None,
     ).start()
 
     stop_event = threading.Event()
@@ -83,6 +132,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     print("[runtime] EAP runtime server started.")
     print(f"[runtime] base_url={server.base_url}")
     print(f"[runtime] db_path={db_path}")
+    print(f"[runtime] scoped_auth_tokens={len(scoped_tokens)}")
     print("[runtime] tools=fetch_user_data,analyze_data")
 
     try:

--- a/scripts/export_telemetry_pack.py
+++ b/scripts/export_telemetry_pack.py
@@ -290,6 +290,51 @@ def _build_saturation_view(
     return {"aggregate": aggregate, "per_run": per_run_rows[:100]}
 
 
+def _build_actor_view(
+    runs: Sequence[Dict[str, Any]],
+    diagnostics_by_run: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    owner_counts: Dict[str, int] = {}
+    last_actor_counts: Dict[str, int] = {}
+    operation_counts: Dict[str, int] = {}
+    run_actor_rows: List[Dict[str, Any]] = []
+
+    for run in runs:
+        run_id = run["run_id"]
+        diagnostics = diagnostics_by_run.get(run_id, {})
+        payload = diagnostics.get("payload", {})
+        actor_metadata = payload.get("actor_metadata") if isinstance(payload, dict) else {}
+        actor_metadata = actor_metadata if isinstance(actor_metadata, dict) else {}
+
+        owner_actor_id = actor_metadata.get("owner_actor_id")
+        last_actor_id = actor_metadata.get("actor_id")
+        operation = actor_metadata.get("operation")
+
+        if isinstance(owner_actor_id, str) and owner_actor_id:
+            owner_counts[owner_actor_id] = owner_counts.get(owner_actor_id, 0) + 1
+        if isinstance(last_actor_id, str) and last_actor_id:
+            last_actor_counts[last_actor_id] = last_actor_counts.get(last_actor_id, 0) + 1
+        if isinstance(operation, str) and operation:
+            operation_counts[operation] = operation_counts.get(operation, 0) + 1
+
+        run_actor_rows.append(
+            {
+                "run_id": run_id,
+                "owner_actor_id": owner_actor_id,
+                "actor_id": last_actor_id,
+                "operation": operation,
+                "actor_scopes": actor_metadata.get("actor_scopes") or [],
+            }
+        )
+
+    return {
+        "owner_actor_counts": owner_counts,
+        "last_actor_counts": last_actor_counts,
+        "operation_counts": operation_counts,
+        "per_run": run_actor_rows[:100],
+    }
+
+
 def _select_failed_run(
     runs: Sequence[Dict[str, Any]],
     requested_run_id: Optional[str] = None,
@@ -368,9 +413,16 @@ def _build_failed_run_diagnostics(
         }
 
     diagnostics_payload = diagnostics_by_run.get(failed_run_id, {}).get("payload", {})
+    actor_metadata = (
+        diagnostics_payload.get("actor_metadata")
+        if isinstance(diagnostics_payload, dict)
+        else {}
+    )
+    actor_metadata = actor_metadata if isinstance(actor_metadata, dict) else {}
     return {
         "failed_run_id": failed_run_id,
         "run_summary": run_row,
+        "actor_metadata": actor_metadata,
         "root_failure": root_failure_payload,
         "dependency_cascade_count": dependency_cascade_count,
         "timeline": timeline,
@@ -384,6 +436,7 @@ def _build_overview(
     fail_reasons_view: Dict[str, Any],
     latency_view: Dict[str, Any],
     saturation_view: Dict[str, Any],
+    actor_view: Dict[str, Any],
 ) -> Dict[str, Any]:
     run_count = len(runs)
     failed_run_count = sum(1 for run in runs if run["failed_steps"] > 0)
@@ -396,6 +449,11 @@ def _build_overview(
         "failed_event_total": fail_reasons_view["failed_event_total"],
         "latency": latency_view["overall"],
         "saturation": saturation_view["aggregate"],
+        "actors": {
+            "owner_actor_counts": actor_view.get("owner_actor_counts", {}),
+            "last_actor_counts": actor_view.get("last_actor_counts", {}),
+            "operation_counts": actor_view.get("operation_counts", {}),
+        },
     }
 
 
@@ -449,7 +507,14 @@ def _render_markdown_report(
         return "\n".join(lines) + "\n"
 
     root = failed_run_diagnostics.get("root_failure") or {}
+    actor_metadata = failed_run_diagnostics.get("actor_metadata") or {}
     lines.append(f"- Failed run: `{failed_run_id}`")
+    if actor_metadata:
+        lines.append(
+            f"- Owner actor: `{actor_metadata.get('owner_actor_id', 'unknown')}` | "
+            f"Last actor: `{actor_metadata.get('actor_id', 'unknown')}` | "
+            f"Operation: `{actor_metadata.get('operation', 'unknown')}`"
+        )
     lines.append(
         f"- Root failure: `{root.get('error_type', 'unknown')}` in `{root.get('tool_name', 'unknown')}`/"
         f"`{root.get('step_id', 'unknown')}`"
@@ -517,6 +582,7 @@ def main() -> int:
     fail_reasons_view = _build_fail_reasons_view(trace_rows)
     latency_view = _build_latency_view(trace_rows)
     saturation_view = _build_saturation_view(runs, diagnostics_by_run=diagnostics_by_run)
+    actor_view = _build_actor_view(runs, diagnostics_by_run=diagnostics_by_run)
     failed_run_id = _select_failed_run(runs, requested_run_id=args.failed_run_id)
     failed_run_diagnostics = _build_failed_run_diagnostics(
         runs=runs,
@@ -530,6 +596,7 @@ def main() -> int:
         fail_reasons_view=fail_reasons_view,
         latency_view=latency_view,
         saturation_view=saturation_view,
+        actor_view=actor_view,
     )
 
     outputs = {
@@ -538,6 +605,7 @@ def main() -> int:
         "fail_reasons.json": fail_reasons_view,
         "latency_percentiles.json": latency_view,
         "saturation.json": saturation_view,
+        "actors.json": actor_view,
         "failed_run_diagnostics.json": failed_run_diagnostics,
     }
     for filename, payload in outputs.items():

--- a/tests/contract/test_runtime_auth_scopes.py
+++ b/tests/contract/test_runtime_auth_scopes.py
@@ -1,0 +1,77 @@
+import os
+import tempfile
+import time
+import unittest
+
+import requests
+
+from eap.environment import AsyncLocalExecutor, ToolRegistry
+from eap.protocol import StateManager
+from eap.runtime import EAPRuntimeHTTPServer
+
+
+def echo_text(text: str) -> str:
+    return f"echo:{text}"
+
+
+ECHO_SCHEMA = {
+    "name": "echo_text",
+    "parameters": {
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"],
+        "additionalProperties": False,
+    },
+}
+
+
+class RuntimeAuthScopesContractTest(unittest.TestCase):
+    def setUp(self) -> None:
+        fd, self.db_path = tempfile.mkstemp(prefix="eap-auth-contract-", suffix=".db")
+        os.close(fd)
+
+        state_manager = StateManager(db_path=self.db_path)
+        registry = ToolRegistry()
+        registry.register("echo_text", echo_text, ECHO_SCHEMA)
+        executor = AsyncLocalExecutor(state_manager, registry)
+
+        self.server = EAPRuntimeHTTPServer(
+            executor=executor,
+            state_manager=state_manager,
+            scoped_bearer_tokens={
+                "writer-token": {"actor_id": "writer", "scopes": ["runs:execute", "runs:read"]},
+                "reader-token": {"actor_id": "reader", "scopes": ["runs:read"]},
+            },
+        ).start()
+        time.sleep(0.05)
+
+    def tearDown(self) -> None:
+        self.server.stop()
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_execute_requires_runs_execute_scope(self) -> None:
+        response = requests.post(
+            f"{self.server.base_url}/v1/eap/macro/execute",
+            headers={"Authorization": "Bearer reader-token"},
+            json={
+                "macro": {
+                    "steps": [
+                        {
+                            "step_id": "step_1",
+                            "tool_name": "echo_text",
+                            "arguments": {"text": "hello"},
+                        }
+                    ]
+                }
+            },
+            timeout=5,
+        )
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["error_type"], "forbidden")
+        self.assertIn("runs:execute", payload["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_runtime_http_api.py
+++ b/tests/integration/test_runtime_http_api.py
@@ -159,5 +159,145 @@ class RuntimeHttpApiIntegrationTest(unittest.TestCase):
         self.assertEqual(run_response.json()["status"], "succeeded")
 
 
+class RuntimeHttpApiScopedAuthIntegrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        fd, self.db_path = tempfile.mkstemp(prefix="eap-runtime-scoped-auth-", suffix=".db")
+        os.close(fd)
+
+        self.state_manager = StateManager(db_path=self.db_path)
+        registry = ToolRegistry()
+        registry.register("echo_text", echo_text, ECHO_SCHEMA)
+        executor = AsyncLocalExecutor(self.state_manager, registry)
+
+        self.server = EAPRuntimeHTTPServer(
+            executor=executor,
+            state_manager=self.state_manager,
+            scoped_bearer_tokens={
+                "alice-exec-token": {
+                    "actor_id": "alice",
+                    "scopes": ["runs:execute", "runs:resume", "runs:read", "pointers:read"],
+                },
+                "bob-read-token": {
+                    "actor_id": "bob",
+                    "scopes": ["runs:read", "pointers:read"],
+                },
+                "charlie-resume-token": {
+                    "actor_id": "charlie",
+                    "scopes": ["runs:resume"],
+                },
+                "ops-admin-token": {
+                    "actor_id": "ops-admin",
+                    "scopes": [
+                        "runs:read",
+                        "runs:resume",
+                        "pointers:read",
+                        "runs:read:any",
+                        "runs:resume:any",
+                        "pointers:read:any",
+                    ],
+                },
+            },
+        ).start()
+        time.sleep(0.05)
+
+    def tearDown(self) -> None:
+        self.server.stop()
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def _execute(self, token: str, *, approval_required: bool = False) -> requests.Response:
+        step = {
+            "step_id": "step_1",
+            "tool_name": "echo_text",
+            "arguments": {"text": "hello"},
+        }
+        if approval_required:
+            step["approval"] = {"required": True}
+        return requests.post(
+            f"{self.server.base_url}/v1/eap/macro/execute",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"macro": {"steps": [step]}},
+            timeout=5,
+        )
+
+    def test_scoped_auth_rejects_missing_execute_scope(self) -> None:
+        response = self._execute("bob-read-token")
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error_type"], "forbidden")
+
+    def test_scoped_auth_enforces_run_and_pointer_ownership(self) -> None:
+        execute_response = self._execute("alice-exec-token")
+        self.assertEqual(execute_response.status_code, 200)
+        body = execute_response.json()
+        run_id = body["metadata"]["execution_run_id"]
+        pointer_id = body["pointer_id"]
+
+        bob_run_response = requests.get(
+            f"{self.server.base_url}/v1/eap/runs/{run_id}",
+            headers={"Authorization": "Bearer bob-read-token"},
+            timeout=5,
+        )
+        self.assertEqual(bob_run_response.status_code, 403)
+        self.assertEqual(bob_run_response.json()["error_type"], "forbidden")
+
+        admin_run_response = requests.get(
+            f"{self.server.base_url}/v1/eap/runs/{run_id}",
+            headers={"Authorization": "Bearer ops-admin-token"},
+            timeout=5,
+        )
+        self.assertEqual(admin_run_response.status_code, 200)
+        run_body = admin_run_response.json()
+        self.assertEqual(run_body["actor_metadata"]["owner_actor_id"], "alice")
+        self.assertGreater(run_body["trace_event_count"], 0)
+        self.assertEqual(run_body["trace_events"][0]["actor_id"], "alice")
+
+        bob_pointer_response = requests.get(
+            f"{self.server.base_url}/v1/eap/pointers/{pointer_id}/summary",
+            headers={"Authorization": "Bearer bob-read-token"},
+            timeout=5,
+        )
+        self.assertEqual(bob_pointer_response.status_code, 403)
+        self.assertEqual(bob_pointer_response.json()["error_type"], "forbidden")
+
+        admin_pointer_response = requests.get(
+            f"{self.server.base_url}/v1/eap/pointers/{pointer_id}/summary",
+            headers={"Authorization": "Bearer ops-admin-token"},
+            timeout=5,
+        )
+        self.assertEqual(admin_pointer_response.status_code, 200)
+
+    def test_scoped_auth_enforces_resume_ownership_unless_any_scope(self) -> None:
+        execute_response = self._execute("alice-exec-token", approval_required=True)
+        self.assertEqual(execute_response.status_code, 200)
+        run_id = execute_response.json()["metadata"]["execution_run_id"]
+
+        unauthorized_resume = requests.post(
+            f"{self.server.base_url}/v1/eap/runs/{run_id}/resume",
+            headers={"Authorization": "Bearer charlie-resume-token"},
+            json={"approvals": {"step_1": {"decision": "approve"}}},
+            timeout=5,
+        )
+        self.assertEqual(unauthorized_resume.status_code, 403)
+        self.assertEqual(unauthorized_resume.json()["error_type"], "forbidden")
+
+        admin_resume = requests.post(
+            f"{self.server.base_url}/v1/eap/runs/{run_id}/resume",
+            headers={"Authorization": "Bearer ops-admin-token"},
+            json={"approvals": {"step_1": {"decision": "approve"}}},
+            timeout=5,
+        )
+        self.assertEqual(admin_resume.status_code, 200)
+        run_response = requests.get(
+            f"{self.server.base_url}/v1/eap/runs/{run_id}",
+            headers={"Authorization": "Bearer ops-admin-token"},
+            timeout=5,
+        )
+        self.assertEqual(run_response.status_code, 200)
+        run_body = run_response.json()
+        self.assertEqual(run_body["actor_metadata"]["owner_actor_id"], "alice")
+        self.assertEqual(run_body["actor_metadata"]["actor_id"], "ops-admin")
+        self.assertEqual(run_body["status"], "succeeded")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/integration/test_telemetry_pack.py
+++ b/tests/integration/test_telemetry_pack.py
@@ -139,6 +139,7 @@ class TelemetryPackIntegrationTest(unittest.TestCase):
                 "fail_reasons.json",
                 "latency_percentiles.json",
                 "saturation.json",
+                "actors.json",
                 "failed_run_diagnostics.json",
                 "operator_report.md",
                 "manifest.json",
@@ -150,6 +151,7 @@ class TelemetryPackIntegrationTest(unittest.TestCase):
             retries = json.loads((Path(temp_dir) / "retries.json").read_text(encoding="utf-8"))
             fail_reasons = json.loads((Path(temp_dir) / "fail_reasons.json").read_text(encoding="utf-8"))
             saturation = json.loads((Path(temp_dir) / "saturation.json").read_text(encoding="utf-8"))
+            actors = json.loads((Path(temp_dir) / "actors.json").read_text(encoding="utf-8"))
             failed_diag = json.loads(
                 (Path(temp_dir) / "failed_run_diagnostics.json").read_text(encoding="utf-8")
             )
@@ -160,8 +162,10 @@ class TelemetryPackIntegrationTest(unittest.TestCase):
             self.assertGreaterEqual(fail_reasons["failed_event_total"], 1)
             self.assertIn("tool_execution_error", fail_reasons["error_type_counts"])
             self.assertIn("global_rate_wait_seconds", saturation["aggregate"])
+            self.assertIn("owner_actor_counts", actors)
             self.assertEqual(failed_diag["failed_run_id"], failed_run_id)
             self.assertEqual(failed_diag["root_failure"]["error_type"], "tool_execution_error")
+            self.assertIn("actor_metadata", failed_diag)
             self.assertIn(failed_run_id, report)
 
 

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -41,6 +41,20 @@ def _create_legacy_schema(db_path: str) -> None:
             )
             """
         )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS execution_run_checkpoints (
+                run_id TEXT PRIMARY KEY,
+                started_at_utc TEXT NOT NULL,
+                updated_at_utc TEXT NOT NULL,
+                status TEXT NOT NULL,
+                macro_payload TEXT NOT NULL,
+                step_status_payload TEXT NOT NULL,
+                branch_decisions_payload TEXT NOT NULL,
+                final_pointer_id TEXT
+            )
+            """
+        )
 
 
 class SqliteMigrationTest(unittest.TestCase):
@@ -58,7 +72,7 @@ class SqliteMigrationTest(unittest.TestCase):
         self.assertEqual([step.version for step in pending], list(range(1, LATEST_SCHEMA_VERSION + 1)))
 
         result = apply_sqlite_migrations(self.db_path, dry_run=True)
-        self.assertEqual(result["planned_versions"], [1, 2, 3, 4])
+        self.assertEqual(result["planned_versions"], [1, 2, 3, 4, 5])
         self.assertEqual(result["applied_versions"], [])
 
         with sqlite3.connect(self.db_path) as conn:
@@ -69,7 +83,7 @@ class SqliteMigrationTest(unittest.TestCase):
 
     def test_apply_migrations_is_idempotent(self) -> None:
         first = apply_sqlite_migrations(self.db_path)
-        self.assertEqual(first["applied_versions"], [1, 2, 3, 4])
+        self.assertEqual(first["applied_versions"], [1, 2, 3, 4, 5])
         self.assertEqual(first["final_version"], LATEST_SCHEMA_VERSION)
 
         with sqlite3.connect(self.db_path) as conn:
@@ -99,6 +113,11 @@ class SqliteMigrationTest(unittest.TestCase):
                 "SELECT 1 FROM sqlite_master WHERE type='table' AND name='execution_run_diagnostics'"
             ).fetchone()
             self.assertIsNotNone(diagnostics_row)
+            checkpoint_columns = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(execution_run_checkpoints)").fetchall()
+            }
+            self.assertIn("actor_metadata_payload", checkpoint_columns)
 
         second = apply_sqlite_migrations(self.db_path)
         self.assertEqual(second["applied_versions"], [])

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -86,6 +86,7 @@ class StateManagerTest(unittest.TestCase):
             step_status={"s1": {"status": "ok", "pointer_id": "ptr_1"}},
             branch_decisions={"s1": ["s2"]},
             final_pointer_id="ptr_final",
+            actor_metadata={"owner_actor_id": "actor_alice", "actor_id": "actor_alice"},
         )
         checkpoint = self.manager.get_run_checkpoint("run_ckpt")
         self.assertEqual(checkpoint["run_id"], "run_ckpt")
@@ -93,6 +94,35 @@ class StateManagerTest(unittest.TestCase):
         self.assertEqual(checkpoint["step_status"]["s1"]["pointer_id"], "ptr_1")
         self.assertEqual(checkpoint["branch_decisions"]["s1"], ["s2"])
         self.assertEqual(checkpoint["final_pointer_id"], "ptr_final")
+        self.assertEqual(checkpoint["actor_metadata"]["owner_actor_id"], "actor_alice")
+
+    def test_list_trace_events_includes_actor_metadata_when_available(self) -> None:
+        self.manager.upsert_run_checkpoint(
+            run_id="run_actor_trace",
+            started_at_utc="2026-02-23T00:00:00+00:00",
+            status="active",
+            macro_payload={"steps": []},
+            step_status={},
+            branch_decisions={},
+            actor_metadata={
+                "owner_actor_id": "actor_owner",
+                "actor_id": "actor_owner",
+                "actor_scopes": ["runs:execute", "runs:read"],
+                "operation": "execute",
+            },
+        )
+        self.manager.append_trace_event(
+            ExecutionTraceEvent(
+                run_id="run_actor_trace",
+                step_id="step_1",
+                tool_name="tool_a",
+                event_type=ExecutionTraceEventType.QUEUED,
+            )
+        )
+        event = self.manager.list_trace_events("run_actor_trace")[0]
+        self.assertEqual(event.actor_id, "actor_owner")
+        self.assertEqual(event.actor_scopes, ["runs:execute", "runs:read"])
+        self.assertEqual(event.operation, "execute")
 
     def test_list_run_checkpoints_filters_by_status(self) -> None:
         self.manager.upsert_run_checkpoint(


### PR DESCRIPTION
## Summary
- add scoped runtime bearer-token auth with endpoint-level scope enforcement
- enforce run/pointer ownership rules with explicit elevated `*:any` scopes
- persist and surface actor metadata in checkpoints, traces, diagnostics, and telemetry exports
- add migration v5 for checkpoint actor metadata and document remote-ops governance config

## Validation
- `PYTHONPATH=. .venv/bin/python scripts/check_v1_contract.py --skip-version-history-check`
- `PYTHONPATH=. .venv/bin/python -m pytest -q tests/contract/test_runtime_auth_scopes.py tests/integration/test_runtime_http_api.py tests/integration/test_telemetry_pack.py tests/unit/test_migrations.py tests/unit/test_state_manager.py`
- `PYTHONPATH=. .venv/bin/python -m pytest -q`
