### PR TITLE
docs: mark EAP-094 and phase 8 complete

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Publish updated competitive proof artifacts with reproducible evidence.
 - Checklist: `docs/phase7_competitive_openclaw_roadmap.md`
 
-## Phase 8: Adoption + Limits Closure (Now)
+## Phase 8: Adoption + Limits Closure (Completed)
 
 - Close remaining `responses`-mode parity gaps.
 - Convert pre-`1.0` uncertainty into explicit `v1` compatibility gates.
@@ -93,3 +93,4 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Phase 8 `EAP-091` one-command bootstrap completed (`GEN-51`, PR #46).
 - Phase 8 `EAP-092` guided onboarding + doctor completed (`GEN-52`, PR #48).
 - Phase 8 `EAP-093` self-hosted control-plane reference completed (`GEN-53`, PR #50).
+- Phase 8 `EAP-094` remote operations governance baseline completed (`GEN-54`, PR #52).

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -38,8 +38,9 @@ Updated: 2026-02-24
 | 8 | `EAP-091` | `GEN-51` | `Done` | One-command bootstrap |
 | 9 | `EAP-092` | `GEN-52` | `Done` | Guided onboarding + doctor |
 | 10 | `EAP-093` | `GEN-53` | `Done` | Self-hosted control-plane reference |
-| 11 | `EAP-094` | `GEN-54` | `Todo` | Remote operations governance baseline |
+| 11 | `EAP-094` | `GEN-54` | `Done` | Remote operations governance baseline |
 
 ## Execution Rule
 
-Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.
+Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
+Current state: no `Todo` items remain in the tracked queue.

--- a/docs/phase8_adoption_limits_closure_roadmap.md
+++ b/docs/phase8_adoption_limits_closure_roadmap.md
@@ -1,6 +1,6 @@
 # Phase 8 Adoption + Limits Closure Roadmap
 
-Status: In progress (started 2026-02-24)  
+Status: Completed (started 2026-02-24, completed 2026-02-24)  
 Source of truth: Linear project `Efficient Agent Protocol Roadmap`
 
 Current status:
@@ -9,7 +9,7 @@ Current status:
 - [x] `EAP-091` one-command bootstrap (`GEN-51`)
 - [x] `EAP-092` guided onboarding + doctor (`GEN-52`)
 - [x] `EAP-093` self-hosted control-plane reference (`GEN-53`)
-- [ ] `EAP-094` remote operations governance baseline (`GEN-54`)
+- [x] `EAP-094` remote operations governance baseline (`GEN-54`)
 
 ## Objective
 
@@ -45,4 +45,4 @@ Turn README caveats (`Not ideal yet` and `Current limits`) into concrete deliver
 
 ## Execution Constraint
 
-Only the first non-blocked `Todo` item may be started (currently `EAP-094`).
+No remaining `Todo` items in this phase. Start a new phase only after creating the next ordered queue entry in Linear and `docs/execution_protocol.md`.


### PR DESCRIPTION
## Summary
- mark `EAP-094` as `Done` in the execution queue mirror
- mark Phase 8 roadmap checklist as complete
- update top-level roadmap phase status and done log with PR #52

## Validation
- docs-only change; no code paths modified
