### PR TITLE
Add Phase 13 production hardening roadmap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/GenieWeenie/efficient-agent-protocol/actions/workflows/ci.yml/badge.svg)](https://github.com/GenieWeenie/efficient-agent-protocol/actions/workflows/ci.yml)
 [![Coverage Gate](https://img.shields.io/badge/coverage-gated%20in%20CI-brightgreen)](https://github.com/GenieWeenie/efficient-agent-protocol/actions/workflows/ci.yml)
-[![Python](https://img.shields.io/badge/python-3.9--3.13-blue)](./pyproject.toml)
+[![Python](https://img.shields.io/badge/python-3.10--3.13-blue)](./pyproject.toml)
 [![Release](https://img.shields.io/github/v/release/GenieWeenie/efficient-agent-protocol)](https://github.com/GenieWeenie/efficient-agent-protocol/releases)
 
 > Status: v1.0 Release Candidate. Core APIs and schema are frozen per [`docs/v1_contract.md`](docs/v1_contract.md).
@@ -108,7 +108,7 @@ Not ideal for:
 ## Quickstart (GitHub-first)
 
 Requirements:
-- Python 3.9-3.13 (3.11 recommended)
+- Python 3.10-3.13 (3.11 recommended)
 
 Recommended one-command bootstrap (macOS/Linux):
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,6 +93,13 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Complete RC dry-run and go/no-go checklist before v1 cut.
 - Checklist: `docs/phase12_v1_launch_readiness_roadmap.md`
 
+## Phase 13: Production Hardening / v1.0.1 Blockers (Active)
+
+- Execute ordered production-hardening queue (`EAP-119` to `EAP-128`) tracked in Linear.
+- Close confirmed P0 risks from the production-hardening brief before strengthening production-readiness claims.
+- Prioritize package ownership, runtime server/auth safety, sandboxed tools, SSRF controls, macro hang protection, and regression gates.
+- Checklist: `docs/phase13_production_hardening_roadmap.md`
+
 ## Post-v1: Hardening and Ecosystem (Completed)
 
 Post-v1.0.0 work tracked as Linear issues GEN-75 through GEN-81.

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -4,7 +4,7 @@ This project is in **v1.0 Release Candidate** status. Core APIs, workflow schema
 
 ## Current Guarantees
 
-- Python runtime requirement (`>=3.9`) is intentional and documented.
+- Python runtime requirement (`>=3.10`) is intentional and documented.
 - CI must pass for merges to `main`.
 - Tagged releases are used for published milestones.
 - The v1 contract surface (`eap.protocol`, `eap.environment`, `eap.agent`, `eap.runtime`) is frozen and covered by contract tests.

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,5 +94,6 @@
 | [phase8_adoption_limits_closure_roadmap.md](phase8_adoption_limits_closure_roadmap.md) | Adoption improvements (completed) |
 | [phase9_production_readiness_roadmap.md](phase9_production_readiness_roadmap.md) | Production readiness controls (completed) |
 | [phase10_competitiveness_hardening_roadmap.md](phase10_competitiveness_hardening_roadmap.md) | Competitive hardening (completed) |
-| [phase11_typing_rigor_completion_roadmap.md](phase11_typing_rigor_completion_roadmap.md) | Typing rigor completion (in progress) |
-| [phase12_v1_launch_readiness_roadmap.md](phase12_v1_launch_readiness_roadmap.md) | V1 launch readiness stabilization (planned) |
+| [phase11_typing_rigor_completion_roadmap.md](phase11_typing_rigor_completion_roadmap.md) | Typing rigor completion (completed) |
+| [phase12_v1_launch_readiness_roadmap.md](phase12_v1_launch_readiness_roadmap.md) | V1 launch readiness stabilization (completed) |
+| [phase13_production_hardening_roadmap.md](phase13_production_hardening_roadmap.md) | Production hardening and v1.0.1 blockers (active) |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -64,7 +64,7 @@ This command emits:
 
 ## Baseline (2026-02-23)
 
-Measured on local macOS development machine, Python 3.9:
+Measured on local macOS development machine, Python 3.11:
 
 - `tests/perf/test_concurrency_limits.py::ConcurrencyLimitsPerfTest::test_rate_limit_generates_saturation_metrics`: `1.70s`
 - `tests/perf/test_concurrency_limits.py::ConcurrencyLimitsPerfTest::test_global_concurrency_limit_caps_parallel_work`: `0.28s`

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -6,7 +6,7 @@ This protocol prevents ad-hoc execution and keeps all work in a visible ordered 
 
 1. Linear issue state is the execution authority.
 2. This file mirrors the active order (`Now`, `Next`, `Blocked`).
-3. `docs/phase7_competitive_openclaw_roadmap.md`, `docs/phase8_adoption_limits_closure_roadmap.md`, `docs/phase9_production_readiness_roadmap.md`, and `docs/phase10_competitiveness_hardening_roadmap.md` are narrative roadmaps, not the live queue.
+3. Phase roadmap docs are planning artifacts; this file mirrors the live queue.
 
 ## Start Gate (Must Be True Before Coding)
 
@@ -24,7 +24,7 @@ This protocol prevents ad-hoc execution and keeps all work in a visible ordered 
 
 ## Current Ordered Queue
 
-Updated: 2026-02-27 (v0.1.9 baseline)
+Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 
 | Order | EAP ID | Linear | Status | Notes |
 | --- | --- | --- | --- | --- |
@@ -59,8 +59,18 @@ Updated: 2026-02-27 (v0.1.9 baseline)
 | 29 | `EAP-116` | `GEN-72` | `Done` | README/docs v1 alignment pass |
 | 30 | `EAP-117` | `GEN-73` | `Done` | Release + maintainer runbook v1 finalization |
 | 31 | `EAP-118` | `GEN-74` | `Done` | V1 upgrade handoff artifact + RC dry-run |
+| 32 | `EAP-119` | `GEN-199` | `In Progress` | Production hardening intake and v1.0.1 blocker plan |
+| 33 | `EAP-120` | `GEN-200` | `Todo` | Collapse duplicate package trees and define canonical imports |
+| 34 | `EAP-121` | `GEN-201` | `Todo` | Add import and package compatibility migration tests |
+| 35 | `EAP-122` | `GEN-202` | `Todo` | Replace runtime HTTP server with production ASGI path |
+| 36 | `EAP-123` | `GEN-203` | `Todo` | Fail-closed runtime auth defaults |
+| 37 | `EAP-124` | `GEN-204` | `Todo` | Sandbox local file tools |
+| 38 | `EAP-125` | `GEN-205` | `Todo` | Add SSRF protection and streaming byte caps to web tools |
+| 39 | `EAP-126` | `GEN-206` | `Todo` | Add macro cycle detection and execution timeout controls |
+| 40 | `EAP-127` | `GEN-207` | `Todo` | Harden connection pooling and request lifecycle |
+| 41 | `EAP-128` | `GEN-208` | `Todo` | Add production-hardening regression gatepack |
 
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 12 (V1 Launch Readiness) is complete.  All items `EAP-110` through `EAP-118` are `Done`.
+Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-119` is the current intake/tracker item; implementation starts with `EAP-120` only after `EAP-119` is complete and the queue is confirmed.

--- a/docs/phase13_production_hardening_roadmap.md
+++ b/docs/phase13_production_hardening_roadmap.md
@@ -1,0 +1,63 @@
+# Phase 13 Production Hardening Roadmap
+
+Status: Active  
+Source of truth: Linear project `Efficient Agent Protocol Roadmap`  
+Intake source: production-hardening review received 2026-04-28
+
+Current status:
+- [ ] `EAP-119` production hardening intake and v1.0.1 blocker plan (`GEN-199`)
+- [ ] `EAP-120` collapse duplicate package trees and define canonical imports (`GEN-200`)
+- [ ] `EAP-121` add import and package compatibility migration tests (`GEN-201`)
+- [ ] `EAP-122` replace runtime HTTP server with production ASGI path (`GEN-202`)
+- [ ] `EAP-123` fail-closed runtime auth defaults (`GEN-203`)
+- [ ] `EAP-124` sandbox local file tools (`GEN-204`)
+- [ ] `EAP-125` add SSRF protection and streaming byte caps to web tools (`GEN-205`)
+- [ ] `EAP-126` add macro cycle detection and execution timeout controls (`GEN-206`)
+- [ ] `EAP-127` harden connection pooling and request lifecycle (`GEN-207`)
+- [ ] `EAP-128` add production-hardening regression gatepack (`GEN-208`)
+
+## Objective
+
+Close the production blockers identified after the v1.0.0 baseline before strengthening production-readiness claims or cutting the next patch release.
+
+This phase is intentionally blocker-first. It prioritizes correctness, security posture, and operational safety over new ecosystem features.
+
+## Scope
+
+The Phase 13 queue targets the confirmed P0/P1 risks from the production-hardening brief:
+
+- duplicate package trees and ambiguous import/runtime ownership
+- runtime HTTP server architecture and per-request event-loop creation
+- fail-open anonymous trusted runtime auth defaults
+- unrestricted local filesystem tool access
+- SSRF exposure and post-load response size limiting in web tools
+- macro cycle/hang risk and missing total execution timeout controls
+- missing durable regression gates for these production-risk classes
+
+## Ordered Implementation Items
+
+| Order | EAP ID | Linear | Priority | Scope | Deliverable | Done Criteria |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | `EAP-119` | `GEN-199` | P0 | Intake and tracker | Create this roadmap, update `ROADMAP.md` and `docs/execution_protocol.md`, and create Linear issues for the ordered queue | Roadmap and Linear are aligned; no implementation starts before the queue is visible |
+| 2 | `EAP-120` | `GEN-200` | P0 | Package ownership | Collapse duplicate runtime package trees and define `eap.*` as canonical | Fresh install exposes the intended import surface; duplicate runtime implementations are not packaged |
+| 3 | `EAP-121` | `GEN-201` | P0 | Package regression tests | Add installed-package import and duplicate-tree detection tests | CI catches duplicate package regressions and docs/examples use canonical imports |
+| 4 | `EAP-122` | `GEN-202` | P0 | Runtime HTTP server | Replace `ThreadingHTTPServer` / per-request `asyncio.run()` path with production ASGI path | Runtime endpoint contract tests pass through ASGI; production launch docs updated |
+| 5 | `EAP-123` | `GEN-203` | P0 | Runtime auth | Make runtime auth fail closed unless explicit local-dev mode is selected | Unauthenticated requests are denied by default; dev escape hatch is explicit and documented |
+| 6 | `EAP-124` | `GEN-204` | P0 | File tools | Add configurable filesystem sandbox with traversal and symlink escape protection | Read/write/list tests reject path escapes while allowed in-root operations still work |
+| 7 | `EAP-125` | `GEN-205` | P0 | Web tools | Add DNS-aware SSRF protection and stream-enforced byte caps | Private/loopback/redirect SSRF cases are blocked; large responses stop at configured cap |
+| 8 | `EAP-126` | `GEN-206` | P0 | Macro execution safety | Add cycle detection and total macro execution timeout controls | Direct/indirect cycles and timeout cases fail deterministically with structured errors |
+| 9 | `EAP-127` | `GEN-207` | P1 | Network lifecycle | Harden connection pooling, timeout, and retry lifecycle for critical paths | Critical network paths use bounded clients or justified one-shot calls; docs cover tuning |
+| 10 | `EAP-128` | `GEN-208` | P1 | Release gates | Add production-hardening regression gatepack to CI/readiness docs | CI/release gates cover all Phase 13 P0 classes with documented local command |
+
+## Dependency Order
+
+1. `EAP-119` must complete first so the work is visible and tracked.
+2. `EAP-120` and `EAP-121` come before deeper runtime work to remove package/import ambiguity.
+3. `EAP-122` and `EAP-123` harden the remote runtime boundary.
+4. `EAP-124`, `EAP-125`, and `EAP-126` harden exposed tool and macro execution surfaces.
+5. `EAP-127` follows the core P0s as the first P1 reliability tranche.
+6. `EAP-128` closes the phase by making the fixes durable through CI/release gates.
+
+## Execution Constraint
+
+Do not start implementation until the ordered queue is confirmed in Linear and mirrored in `docs/execution_protocol.md`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,12 +27,12 @@ Fix:
 
 ### Bootstrap fails with Python version error
 Cause:
-- Bootstrap supports Python `3.9` through `3.13`.
+- Bootstrap supports Python `3.10` through `3.13`.
 
 Fix:
 - Check version:
   - `python3 --version`
-- Use Python `3.11` or another `3.9-3.13` interpreter:
+- Use Python `3.11` or another `3.10-3.13` interpreter:
   - `./scripts/bootstrap_local.sh --python python3.11`
 
 ### Smoke workflow failed during bootstrap

--- a/docs/v1_go_no_go_checklist.md
+++ b/docs/v1_go_no_go_checklist.md
@@ -91,7 +91,7 @@ Document the following for each RC:
 
 - [ ] All 9 readiness gates pass (`scripts/v1_readiness_gatepack.py` reports `PASS 9/9`).
 - [ ] `docs/v1_stabilization_checklist.md` — all stabilization items checked.
-- [ ] CI green on `main`: lint/test (py3.9, 3.10, 3.11), coverage gates, contract gate, upgrade migration, eval scorecard, competitive benchmark, soak+chaos, security scans.
+- [ ] CI green on `main`: lint/test (py3.10, 3.11), coverage gates, contract gate, upgrade migration, eval scorecard, competitive benchmark, soak+chaos, security scans.
 - [ ] RC release workflow succeeds (build + TestPyPI publish).
 - [ ] RC installs cleanly from TestPyPI and passes smoke test.
 - [ ] `docs/upgrade_notes_v1.md` covers all 5 required sections (scope, breaking changes, migration, verification, rollback).
@@ -102,7 +102,7 @@ Document the following for each RC:
 
 ### Should-Pass (non-blocking but tracked)
 
-- [ ] TestPyPI package installs and imports on Python 3.9, 3.10, and 3.11.
+- [ ] TestPyPI package installs and imports on Python 3.10 and 3.11.
 - [ ] Self-hosted stack smoke test passes against RC build.
 - [ ] OpenClaw interop smoke tests pass.
 - [ ] Documentation links in README all resolve.

--- a/docs/v1_readiness_gates.md
+++ b/docs/v1_readiness_gates.md
@@ -115,7 +115,7 @@ The following are enforced automatically by GitHub Actions CI on every push:
 
 | CI Job | What it checks |
 | --- | --- |
-| Lint/Test (py3.9, 3.10, 3.11) | Full test suite on three Python versions |
+| Lint/Test (py3.10, 3.11) | Full test suite on supported Python versions |
 | Coverage gates (py3.11) | Line/branch thresholds |
 | V1 compatibility contract gate | Contract lock + contract tests |
 | Upgrade migration verification | Baseline upgrade path |

--- a/examples/plugins/sample_plugin/pyproject.toml
+++ b/examples/plugins/sample_plugin/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "eap-sample-plugin"
 version = "0.1.0"
 description = "Sample third-party plugin for Efficient Agent Protocol."
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.entry-points."eap.tool_plugins"]
 sample_plugin = "sample_plugin:get_plugin_manifest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ version = "1.0.0"
 description = "Local-first framework for multi-step tool workflows with pointer-backed state and DAG execution."
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.10,<3.14"
 
 dependencies = [
   "pydantic==2.6.1",
-  "requests==2.32.4",
+  "requests==2.33.0",
   "beautifulsoup4==4.12.3",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 pydantic==2.6.1
 
 # (Optional) Required if using the requests library to hit local model APIs
-requests==2.32.4
+requests==2.33.0
 
 # Required for HTML parsing in web_tools.py
 beautifulsoup4==4.12.3

--- a/scripts/bootstrap_local.sh
+++ b/scripts/bootstrap_local.sh
@@ -96,9 +96,9 @@ cd "${REPO_ROOT}"
 
 command -v "${PYTHON_CMD}" >/dev/null 2>&1 || fail "Python executable not found: ${PYTHON_CMD}"
 
-"${PYTHON_CMD}" - <<'PY' || fail "Python 3.9-3.13 is required. Install a supported Python version and retry."
+"${PYTHON_CMD}" - <<'PY' || fail "Python 3.10-3.13 is required. Install a supported Python version and retry."
 import sys
-if sys.version_info < (3, 9) or sys.version_info >= (3, 14):
+if sys.version_info < (3, 10) or sys.version_info >= (3, 14):
     raise SystemExit(1)
 PY
 

--- a/scripts/eap_doctor.py
+++ b/scripts/eap_doctor.py
@@ -243,15 +243,15 @@ def run_doctor(args: argparse.Namespace) -> int:
     load_settings = None
     state_manager_cls = None
 
-    if sys.version_info < (3, 9) or sys.version_info >= (3, 14):
+    if sys.version_info < (3, 10) or sys.version_info >= (3, 14):
         _record(
             records,
             check_id="python_version",
             category="tools",
             status="fail",
             message="Unsupported Python version.",
-            details={"python_version": sys.version.split()[0], "supported": ">=3.9,<3.14"},
-            remediation="Use Python 3.9-3.13 (`docs/troubleshooting.md#bootstrap-fails-with-python-version-error`).",
+            details={"python_version": sys.version.split()[0], "supported": ">=3.10,<3.14"},
+            remediation="Use Python 3.10-3.13 (`docs/troubleshooting.md#bootstrap-fails-with-python-version-error`).",
         )
     else:
         _record(

--- a/scripts/eap_onboarding_wizard.py
+++ b/scripts/eap_onboarding_wizard.py
@@ -44,8 +44,8 @@ def main() -> int:
     # Step 1: Check Python version
     print("[1/5] Checking Python version...")
     version = sys.version_info
-    if version < (3, 9) or version >= (3, 14):
-        print(f"  ERROR: Python {version.major}.{version.minor} is not supported. Use 3.9-3.13.")
+    if version < (3, 10) or version >= (3, 14):
+        print(f"  ERROR: Python {version.major}.{version.minor} is not supported. Use 3.10-3.13.")
         return 1
     print(f"  OK: Python {version.major}.{version.minor}.{version.micro}")
     print()

--- a/tests/contract/test_readme_conversion_pack_contract.py
+++ b/tests/contract/test_readme_conversion_pack_contract.py
@@ -17,7 +17,7 @@ class ReadmeConversionPackContractTest(unittest.TestCase):
         required_snippets = [
             "actions/workflows/ci.yml/badge.svg",
             "coverage-gated%20in%20CI",
-            "python-3.9--3.13-blue",
+            "python-3.10--3.13-blue",
             "img.shields.io/github/v/release/GenieWeenie/efficient-agent-protocol",
             "assets/readme/eap_demo.gif",
             "assets/readme/eap_architecture.jpg",

--- a/tests/integration/test_bootstrap_local.py
+++ b/tests/integration/test_bootstrap_local.py
@@ -17,7 +17,7 @@ class BootstrapLocalIntegrationTest(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.bootstrap_python = cls._find_supported_python()
         if cls.bootstrap_python is None:
-            raise unittest.SkipTest("No Python 3.9-3.13 interpreter available for bootstrap integration tests.")
+            raise unittest.SkipTest("No Python 3.10-3.13 interpreter available for bootstrap integration tests.")
 
     @staticmethod
     def _find_supported_python() -> Optional[str]:
@@ -27,7 +27,6 @@ class BootstrapLocalIntegrationTest(unittest.TestCase):
             "python3.12",
             "python3.11",
             "python3.10",
-            "python3.9",
             "python3",
         )
         for candidate in candidates:
@@ -38,7 +37,7 @@ class BootstrapLocalIntegrationTest(unittest.TestCase):
                 [
                     executable,
                     "-c",
-                    "import sys; raise SystemExit(0 if (3, 9) <= sys.version_info[:2] < (3, 14) else 1)",
+                    "import sys; raise SystemExit(0 if (3, 10) <= sys.version_info[:2] < (3, 14) else 1)",
                 ],
                 capture_output=True,
                 text=True,

--- a/tests/integration/test_eap_doctor.py
+++ b/tests/integration/test_eap_doctor.py
@@ -13,8 +13,8 @@ DOCTOR_SCRIPT = REPO_ROOT / "scripts" / "eap_doctor.py"
 class EAPDoctorIntegrationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        if not ((3, 9) <= sys.version_info[:2] < (3, 14)):
-            raise unittest.SkipTest("Doctor integration tests require Python 3.9-3.13.")
+        if not ((3, 10) <= sys.version_info[:2] < (3, 14)):
+            raise unittest.SkipTest("Doctor integration tests require Python 3.10-3.13.")
 
     def test_init_env_generates_runnable_env_and_doctor_json(self) -> None:
         with tempfile.TemporaryDirectory(prefix="eap-doctor-init-") as temp_dir:


### PR DESCRIPTION
## Summary
- add Phase 13 production-hardening roadmap for v1.0.1 blockers
- update ROADMAP.md and docs index with the active hardening phase
- update Linear-first execution protocol with EAP-119 through EAP-128 mapped to GEN-199 through GEN-208
- unblock CI security audit by moving supported Python floor to 3.10 and bumping requests to 2.33.0

## Notes
- planning/tracking first; runtime implementation starts after this queue is merged and confirmed
- raw hardening brief remains untracked because it is internal intake material
- Python 3.9 support was dropped because the requests security fix line requires Python >=3.10 and Python 3.9 is EOL

## Test
- git diff --check
- python3 file sanity check
- focused Python 3.11 tests in temporary venv: README conversion contract, eap_doctor integration, bootstrap integration