### PR TITLE
EAP-121: add package regression gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,11 +398,15 @@ jobs:
       - name: Install build tool
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          pip install build pytest
 
       - name: Build package
         run: |
           python -m build
+
+      - name: Installed package compatibility smoke
+        run: |
+          RUN_PACKAGING_SMOKE=1 python -m pytest -q tests/packaging/test_install_smoke.py
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,7 @@ jobs:
       - name: Install build tool
         run: |
           python -m pip install --upgrade pip
-          pip install build pytest
+          pip install -e ".[dev]" build
 
       - name: Build package
         run: |

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -61,7 +61,7 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 | 31 | `EAP-118` | `GEN-74` | `Done` | V1 upgrade handoff artifact + RC dry-run |
 | 32 | `EAP-119` | `GEN-199` | `Done` | Production hardening intake and v1.0.1 blocker plan |
 | 33 | `EAP-120` | `GEN-200` | `Done` | Collapse duplicate package trees and define canonical imports |
-| 34 | `EAP-121` | `GEN-201` | `Todo` | Add import and package compatibility migration tests |
+| 34 | `EAP-121` | `GEN-201` | `Done` | Add import and package compatibility migration tests |
 | 35 | `EAP-122` | `GEN-202` | `Todo` | Replace runtime HTTP server with production ASGI path |
 | 36 | `EAP-123` | `GEN-203` | `Todo` | Fail-closed runtime auth defaults |
 | 37 | `EAP-124` | `GEN-204` | `Todo` | Sandbox local file tools |
@@ -73,4 +73,4 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-120` is complete; `EAP-121` is the first implementation item and the next ordered `Todo`.
+Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-121` is complete; `EAP-122` is the first implementation item and the next ordered `Todo`.

--- a/docs/openclaw_interop.md
+++ b/docs/openclaw_interop.md
@@ -109,10 +109,10 @@ Recommended sequence:
 ## 8) Implemented MCP Bridge (EAP-078)
 
 `EAP-078` is now implemented in-repo with:
-- MCP stdio client bridge at `environment/mcp_client.py`
+- MCP stdio client bridge at `eap/environment/mcp_client.py`
 - built-in bridge tool:
-  - `invoke_mcp_tool` (`environment/tools/mcp_tools.py`)
-  - schema export in `environment.tools` and `eap.environment.tools`
+  - `invoke_mcp_tool` (`eap/environment/tools/mcp_tools.py`)
+  - canonical schema export in `eap.environment.tools`
 - integration test proving runtime execution of a reference MCP tool:
   - `tests/integration/test_mcp_interop.py`
   - mock MCP server fixture: `tests/fixtures/mock_mcp_stdio_server.py`
@@ -288,10 +288,10 @@ Recommended sequence:
 
 `EAP-087` is now implemented in-repo with:
 - typed OpenClaw tools-invoke client:
-  - `environment/openclaw_client.py`
+  - `eap/environment/openclaw_client.py`
 - runtime bridge tool:
-  - `environment/tools/openclaw_tools.py`
-  - schema export in `environment.tools` and `eap.environment.tools`
+  - `eap/environment/tools/openclaw_tools.py`
+  - canonical schema export in `eap.environment.tools`
 - coverage for success, auth failure, and policy-denial mapping:
   - `tests/unit/test_openclaw_client.py`
   - `tests/unit/test_openclaw_tools.py`

--- a/docs/phase13_production_hardening_roadmap.md
+++ b/docs/phase13_production_hardening_roadmap.md
@@ -7,7 +7,7 @@ Intake source: production-hardening review received 2026-04-28
 Current status:
 - [x] `EAP-119` production hardening intake and v1.0.1 blocker plan (`GEN-199`)
 - [x] `EAP-120` collapse duplicate package trees and define canonical imports (`GEN-200`)
-- [ ] `EAP-121` add import and package compatibility migration tests (`GEN-201`)
+- [x] `EAP-121` add import and package compatibility migration tests (`GEN-201`)
 - [ ] `EAP-122` replace runtime HTTP server with production ASGI path (`GEN-202`)
 - [ ] `EAP-123` fail-closed runtime auth defaults (`GEN-203`)
 - [ ] `EAP-124` sandbox local file tools (`GEN-204`)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Built-in Tools
 
-This document describes the built-in tools shipped in `environment.tools`.
+This document describes the built-in tools shipped in `eap.environment.tools`.
 
 ## File tools
 

--- a/docs/typing_policy.md
+++ b/docs/typing_policy.md
@@ -8,8 +8,8 @@ Extended in `EAP-109` to include executor runtime path, and in `EAP-110` to incl
 
 Current strict-typed target modules (required in CI):
 
-- `environment.safe_eval`
-- `environment.executor`
+- `eap.environment.safe_eval`
+- `eap.environment.executor`
 - `eap.runtime.auth_scopes`
 - `eap.runtime.guardrails`
 - `eap.runtime.http_api`
@@ -19,7 +19,7 @@ CI gate:
 - Workflow: `.github/workflows/ci.yml`
 - Step: `Type rigor gate (mypy scoped modules)` under required `Lint/Test (py3.11)`
 - Command:
-  - `mypy --follow-imports=skip environment/safe_eval.py environment/executor.py eap/runtime/auth_scopes.py eap/runtime/guardrails.py eap/runtime/http_api.py`
+  - `mypy --follow-imports=skip eap/environment/safe_eval.py eap/environment/executor.py eap/runtime/auth_scopes.py eap/runtime/guardrails.py eap/runtime/http_api.py`
 
 `--follow-imports=skip` keeps enforcement bounded to the scoped modules so legacy typing debt in non-scoped imports does not block this tranche.
 

--- a/tests/contract/test_canonical_import_references.py
+++ b/tests/contract/test_canonical_import_references.py
@@ -1,0 +1,95 @@
+import ast
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEGACY_ROOTS = {"agent", "environment", "protocol"}
+PYTHON_SCAN_ROOTS = [
+    REPO_ROOT / "examples",
+    REPO_ROOT / "scripts",
+    REPO_ROOT / "starter_packs",
+    REPO_ROOT / "tests",
+]
+MARKDOWN_SCAN_ROOTS = [
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "docs",
+    REPO_ROOT / "examples",
+]
+PYTHON_IMPORT_ALLOWLIST = {
+    REPO_ROOT / "tests" / "packaging" / "test_install_smoke.py",
+}
+MARKDOWN_ALLOWLIST = {
+    REPO_ROOT / "docs" / "upgrade_notes_v1.md",
+    REPO_ROOT / "docs" / "v1_contract.md",
+}
+LEGACY_MARKDOWN_PATTERN = re.compile(
+    r"\bfrom\s+(?:agent|environment|protocol)(?:\.|\s+import)|"
+    r"\bimport\s+(?:agent|environment|protocol)(?:\.|\s|$)|"
+    r"`(?:agent|environment|protocol)\."
+)
+LEGACY_PATCH_PATTERN = re.compile(
+    r"\bpatch\(\s*['\"](?:agent|environment|protocol)\."
+)
+
+
+def _python_files() -> list[Path]:
+    paths: list[Path] = []
+    for root in PYTHON_SCAN_ROOTS:
+        paths.extend(root.rglob("*.py"))
+    return sorted(path for path in paths if path not in PYTHON_IMPORT_ALLOWLIST)
+
+
+def _markdown_files() -> list[Path]:
+    paths: list[Path] = []
+    for root in MARKDOWN_SCAN_ROOTS:
+        if root.is_file():
+            paths.append(root)
+        else:
+            paths.extend(root.rglob("*.md"))
+    return sorted(path for path in paths if path not in MARKDOWN_ALLOWLIST)
+
+
+def _legacy_root(module_name: str | None) -> str | None:
+    if not module_name:
+        return None
+    root = module_name.split(".", 1)[0]
+    return root if root in LEGACY_ROOTS else None
+
+
+def test_python_examples_scripts_and_tests_use_canonical_imports() -> None:
+    failures: list[str] = []
+    for path in _python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    root = _legacy_root(alias.name)
+                    if root:
+                        failures.append(f"{path}:{node.lineno} imports legacy namespace {root!r}")
+            elif isinstance(node, ast.ImportFrom):
+                root = _legacy_root(node.module)
+                if root:
+                    failures.append(f"{path}:{node.lineno} imports legacy namespace {root!r}")
+
+    assert not failures, "\n".join(failures)
+
+
+def test_tests_patch_canonical_implementation_modules() -> None:
+    failures: list[str] = []
+    for path in sorted((REPO_ROOT / "tests").rglob("*.py")):
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if LEGACY_PATCH_PATTERN.search(line):
+                failures.append(f"{path}:{line_number} patches a legacy shim path: {line.strip()}")
+
+    assert not failures, "\n".join(failures)
+
+
+def test_markdown_examples_use_canonical_import_references() -> None:
+    failures: list[str] = []
+    for path in _markdown_files():
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if LEGACY_MARKDOWN_PATTERN.search(line):
+                failures.append(f"{path}:{line_number} references a legacy import path: {line.strip()}")
+
+    assert not failures, "\n".join(failures)

--- a/tests/integration/test_openai_responses_streaming.py
+++ b/tests/integration/test_openai_responses_streaming.py
@@ -22,7 +22,7 @@ class OpenAIResponsesStreamingIntegrationTest(unittest.TestCase):
         ]
 
         seen = []
-        with patch("agent.providers.openai_provider.requests.post", return_value=stream_response) as post:
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=stream_response) as post:
             final = client.stream_chat("hello", on_token=seen.append, fallback_to_non_stream=False)
 
         self.assertEqual(final, "Hello")
@@ -50,7 +50,7 @@ class OpenAIResponsesStreamingIntegrationTest(unittest.TestCase):
 
         seen = []
         with patch(
-            "agent.providers.openai_provider.requests.post",
+            "eap.agent.providers.openai_provider.requests.post",
             side_effect=[stream_response, completion_response],
         ) as post:
             final = client.stream_chat("hello", on_token=seen.append)

--- a/tests/packaging/test_install_smoke.py
+++ b/tests/packaging/test_install_smoke.py
@@ -37,8 +37,34 @@ class InstallSmokeTest(unittest.TestCase):
         "Set RUN_PACKAGING_SMOKE=1 to run packaging smoke tests.",
     )
     def test_standard_and_editable_installs(self) -> None:
-        self._assert_install_mode([str(PROJECT_ROOT)])
+        with tempfile.TemporaryDirectory(prefix="eap-dist-") as tmpdir:
+            dist_dir = pathlib.Path(tmpdir) / "dist"
+            _run(
+                [
+                    sys.executable,
+                    "-m",
+                    "build",
+                    "--sdist",
+                    "--wheel",
+                    "--outdir",
+                    str(dist_dir),
+                ],
+                cwd=PROJECT_ROOT,
+            )
+            wheel = self._single_artifact(dist_dir, "*.whl")
+            sdist = self._single_artifact(dist_dir, "*.tar.gz")
+
+            self._assert_install_mode([str(wheel)])
+            self._assert_install_mode([str(sdist)])
         self._assert_install_mode(["-e", str(PROJECT_ROOT)])
+
+    def _single_artifact(self, dist_dir: pathlib.Path, pattern: str) -> pathlib.Path:
+        matches = sorted(dist_dir.glob(pattern))
+        if len(matches) != 1:
+            raise AssertionError(
+                f"Expected exactly one artifact for {pattern}, found {[str(path) for path in matches]}"
+            )
+        return matches[0]
 
     def _assert_install_mode(self, install_args: List[str]) -> None:
         with tempfile.TemporaryDirectory(prefix="eap-smoke-") as tmpdir:
@@ -60,12 +86,18 @@ class InstallSmokeTest(unittest.TestCase):
                         "from eap.environment import AsyncLocalExecutor, ToolRegistry; "
                         "from eap.agent import AgentClient; "
                         "from pathlib import Path; "
+                        "import eap.agent.providers.openai_provider as canonical_openai_provider; "
                         "import agent.agent_client as legacy_agent_client; "
                         "import environment.executor as legacy_executor; "
                         "import protocol.state_manager as legacy_state_manager; "
                         "import eap.agent.agent_client as canonical_agent_client; "
                         "import eap.environment.executor as canonical_executor; "
+                        "import eap.environment.tools.web_tools as canonical_web_tools; "
                         "import eap.protocol.state_manager as canonical_state_manager; "
+                        "import eap.protocol.storage.sqlite_store as canonical_sqlite_store; "
+                        "assert canonical_openai_provider.OpenAIProvider; "
+                        "assert canonical_web_tools.scrape_url; "
+                        "assert canonical_sqlite_store.SQLitePointerStore; "
                         "assert legacy_agent_client.AgentClient is canonical_agent_client.AgentClient; "
                         "assert legacy_executor.AsyncLocalExecutor is canonical_executor.AsyncLocalExecutor; "
                         "assert legacy_state_manager.StateManager is canonical_state_manager.StateManager; "

--- a/tests/unit/test_agent_client.py
+++ b/tests/unit/test_agent_client.py
@@ -18,7 +18,7 @@ class AgentClientTest(unittest.TestCase):
         mock_response.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
         mock_response.raise_for_status.return_value = None
 
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
             result = client.chat("hello")
 
         self.assertEqual(result, "ok")
@@ -33,7 +33,7 @@ class AgentClientTest(unittest.TestCase):
         mock_response.json.return_value = {"choices": [{"message": {"content": "{\"steps\": []}"}}]}
         mock_response.raise_for_status.return_value = None
 
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
             macro = client.generate_macro("do thing", {"x_hash": {"type": "object"}})
 
         self.assertEqual(macro.steps, [])
@@ -48,7 +48,7 @@ class AgentClientTest(unittest.TestCase):
         mock_response.json.return_value = {"choices": [{"message": {"content": "{\"steps\": []}"}}]}
         mock_response.raise_for_status.return_value = None
 
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
             client.generate_macro(
                 "follow up",
                 {"x_hash": {"type": "object"}},
@@ -70,7 +70,7 @@ class AgentClientTest(unittest.TestCase):
         mock_response.json.return_value = {"output_text": "ok"}
         mock_response.raise_for_status.return_value = None
 
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
             result = client.chat("hello")
 
         self.assertEqual(result, "ok")

--- a/tests/unit/test_ollama_provider.py
+++ b/tests/unit/test_ollama_provider.py
@@ -26,7 +26,7 @@ class OllamaProviderTest(unittest.TestCase):
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"message": {"content": "ollama-ok"}, "done": True}
         mock_resp.raise_for_status.return_value = None
-        with patch("agent.providers.ollama_provider.requests.post", return_value=mock_resp) as post:
+        with patch("eap.agent.providers.ollama_provider.requests.post", return_value=mock_resp) as post:
             response = provider.complete(request)
 
         self.assertEqual(response.text, "ollama-ok")
@@ -42,7 +42,7 @@ class OllamaProviderTest(unittest.TestCase):
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"message": {"content": "tools-ok"}, "done": True}
         mock_resp.raise_for_status.return_value = None
-        with patch("agent.providers.ollama_provider.requests.post", return_value=mock_resp):
+        with patch("eap.agent.providers.ollama_provider.requests.post", return_value=mock_resp):
             response = provider.complete_with_tools(request)
 
         self.assertEqual(response.text, "tools-ok")
@@ -59,7 +59,7 @@ class OllamaProviderTest(unittest.TestCase):
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None
         mock_resp.iter_lines.return_value = iter(lines)
-        with patch("agent.providers.ollama_provider.requests.post", return_value=mock_resp):
+        with patch("eap.agent.providers.ollama_provider.requests.post", return_value=mock_resp):
             tokens = list(provider.stream(request))
 
         self.assertEqual(tokens, ["Hello", " world"])
@@ -75,7 +75,7 @@ class OllamaProviderTest(unittest.TestCase):
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None
         mock_resp.iter_lines.return_value = iter(lines)
-        with patch("agent.providers.ollama_provider.requests.post", return_value=mock_resp):
+        with patch("eap.agent.providers.ollama_provider.requests.post", return_value=mock_resp):
             tokens = list(provider.stream(request))
 
         self.assertEqual(tokens, ["ok"])

--- a/tests/unit/test_openclaw_client.py
+++ b/tests/unit/test_openclaw_client.py
@@ -25,7 +25,7 @@ class OpenClawClientUnitTest(unittest.TestCase):
             status_code=200,
             payload={"ok": True, "tool": "echo_tool", "result": {"text": "hello"}},
         )
-        with patch("environment.openclaw_client.requests.post", return_value=mock_response) as post:
+        with patch("eap.environment.openclaw_client.requests.post", return_value=mock_response) as post:
             result = invoke_openclaw_tools_api(
                 base_url="https://gateway.openclaw.local",
                 api_key="secret-token",
@@ -50,7 +50,7 @@ class OpenClawClientUnitTest(unittest.TestCase):
             status_code=401,
             payload={"error": {"code": "UNAUTHORIZED", "message": "Missing or invalid bearer token."}},
         )
-        with patch("environment.openclaw_client.requests.post", return_value=mock_response):
+        with patch("eap.environment.openclaw_client.requests.post", return_value=mock_response):
             with self.assertRaises(OpenClawToolInvokeError) as context:
                 invoke_openclaw_tools_api(
                     base_url="https://gateway.openclaw.local",
@@ -74,7 +74,7 @@ class OpenClawClientUnitTest(unittest.TestCase):
                 }
             },
         )
-        with patch("environment.openclaw_client.requests.post", return_value=mock_response):
+        with patch("eap.environment.openclaw_client.requests.post", return_value=mock_response):
             with self.assertRaises(OpenClawToolInvokeError) as context:
                 invoke_openclaw_tools_api(
                     base_url="https://gateway.openclaw.local",
@@ -94,7 +94,7 @@ class OpenClawClientUnitTest(unittest.TestCase):
             payload={"error": {"code": "RATE_LIMITED", "message": "Too many requests."}},
             headers={"Retry-After": "17"},
         )
-        with patch("environment.openclaw_client.requests.post", return_value=mock_response):
+        with patch("eap.environment.openclaw_client.requests.post", return_value=mock_response):
             with self.assertRaises(OpenClawToolInvokeError) as context:
                 invoke_openclaw_tools_api(
                     base_url="https://gateway.openclaw.local",

--- a/tests/unit/test_provider_adapters.py
+++ b/tests/unit/test_provider_adapters.py
@@ -28,7 +28,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = {"choices": [{"message": {"content": "openai-ok"}}]}
         mock_response.raise_for_status.return_value = None
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
             response = provider.complete(request)
 
         self.assertEqual(response.text, "openai-ok")
@@ -55,7 +55,7 @@ class ProviderAdaptersTest(unittest.TestCase):
             b'data: {"choices":[{"delta":{"content":"lo"}}]}',
             b"data: [DONE]",
         ]
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
             chunks = list(provider.stream(request))
 
         self.assertEqual(chunks, ["Hel", "lo"])
@@ -79,7 +79,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
         mock_response.raise_for_status.return_value = None
 
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
             provider.complete(request)
 
         kwargs = post.call_args.kwargs
@@ -103,7 +103,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = {"content": [{"type": "text", "text": "anthropic-ok"}]}
         mock_response.raise_for_status.return_value = None
-        with patch("agent.providers.anthropic_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.agent.providers.anthropic_provider.requests.post", return_value=mock_response) as post:
             response = provider.complete(request)
 
         self.assertEqual(response.text, "anthropic-ok")
@@ -126,7 +126,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = {"id": "resp_1", "output_text": "responses-ok"}
         mock_response.raise_for_status.return_value = None
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
             response = provider.complete(request)
 
         self.assertEqual(response.text, "responses-ok")
@@ -150,7 +150,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.status_code = 404
         mock_response.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
             with self.assertRaises(RuntimeError) as context:
                 provider.complete(request)
         self.assertIn("Responses API path is unavailable", str(context.exception))
@@ -176,7 +176,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         }
         mock_response.raise_for_status.return_value = None
 
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
             response = provider.complete(request)
         self.assertEqual(response.text, "hello world")
 
@@ -196,7 +196,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response.json.return_value = {"id": "resp_1", "output": [{"content": [{"type": "ref"}]}]}
         mock_response.raise_for_status.return_value = None
 
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
             with self.assertRaises(KeyError):
                 provider.complete(request)
 
@@ -221,7 +221,7 @@ class ProviderAdaptersTest(unittest.TestCase):
             b'data: {"type":"response.output_text.done","text":"Hello"}',
             b"data: [DONE]",
         ]
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
             chunks = list(provider.stream(request))
 
         self.assertEqual(chunks, ["Hel", "lo"])
@@ -252,7 +252,7 @@ class ProviderAdaptersTest(unittest.TestCase):
             b'data: {"output":[{"content":[{"type":"output_text","text":"B"}]}]}',
             b"data: [DONE]",
         ]
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
             chunks = list(provider.stream(request))
 
         self.assertEqual(chunks, ["A"])
@@ -277,7 +277,7 @@ class ProviderAdaptersTest(unittest.TestCase):
             b'data: {"type":"response.completed","response":{"output_text":"Hello done"}}',
             b"data: [DONE]",
         ]
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
             chunks = list(provider.stream(request))
         self.assertEqual(chunks, ["Hello done"])
 
@@ -296,7 +296,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.status_code = 405
         mock_response.raise_for_status.side_effect = requests.HTTPError("405 Method Not Allowed")
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
             with self.assertRaises(RuntimeError) as context:
                 list(provider.stream(request))
         self.assertIn("Responses API path is unavailable", str(context.exception))
@@ -318,7 +318,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response.iter_lines.return_value = [
             b'data: {"type":"response.error","error":{"code":"policy_denied","message":"Denied by policy"}}'
         ]
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
             with self.assertRaises(RuntimeError) as context:
                 list(provider.stream(request))
         self.assertIn("Denied by policy", str(context.exception))
@@ -343,7 +343,7 @@ class ProviderAdaptersTest(unittest.TestCase):
             b'data: {"choices":[{"delta":{"content":"tool"}}]}',
             b"data: [DONE]",
         ]
-        with patch("agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
             chunks = list(provider.stream(request))
 
         self.assertEqual(chunks, ["tool"])
@@ -380,7 +380,7 @@ class ProviderAdaptersTest(unittest.TestCase):
             "candidates": [{"content": {"parts": [{"text": "google-ok"}]}}]
         }
         mock_response.raise_for_status.return_value = None
-        with patch("agent.providers.google_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.agent.providers.google_provider.requests.post", return_value=mock_response) as post:
             response = provider.complete_with_tools(request)
 
         self.assertEqual(response.text, "google-ok")

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -74,13 +74,13 @@ class ToolModuleTest(unittest.TestCase):
         response.content = b"<html><body><h1>Title</h1><p>Body</p></body></html>"
         response.encoding = "utf-8"
         response.raise_for_status.return_value = None
-        with patch("environment.tools.web_tools.requests.get", return_value=response):
+        with patch("eap.environment.tools.web_tools.requests.get", return_value=response):
             text = scrape_url("https://example.com")
         self.assertIn("Title", text)
         self.assertIn("Body", text)
 
     def test_scrape_url_failure_raises_runtime_error(self) -> None:
-        with patch("environment.tools.web_tools.requests.get", side_effect=RuntimeError("network down")):
+        with patch("eap.environment.tools.web_tools.requests.get", side_effect=RuntimeError("network down")):
             with self.assertRaises(RuntimeError):
                 scrape_url("https://example.com")
 
@@ -89,7 +89,7 @@ class ToolModuleTest(unittest.TestCase):
         response.content = b'{"name":"eap","version":1}'
         response.encoding = "utf-8"
         response.raise_for_status.return_value = None
-        with patch("environment.tools.web_tools.requests.get", return_value=response):
+        with patch("eap.environment.tools.web_tools.requests.get", return_value=response):
             text = fetch_json_url("https://example.com/data.json")
         self.assertIn('"name": "eap"', text)
         self.assertIn('"version": 1', text)
@@ -99,7 +99,7 @@ class ToolModuleTest(unittest.TestCase):
         response.content = b"<html>not json</html>"
         response.encoding = "utf-8"
         response.raise_for_status.return_value = None
-        with patch("environment.tools.web_tools.requests.get", return_value=response):
+        with patch("eap.environment.tools.web_tools.requests.get", return_value=response):
             with self.assertRaises(RuntimeError):
                 fetch_json_url("https://example.com/data.json")
 
@@ -114,7 +114,7 @@ class ToolModuleTest(unittest.TestCase):
         )
         response.encoding = "utf-8"
         response.raise_for_status.return_value = None
-        with patch("environment.tools.web_tools.requests.get", return_value=response):
+        with patch("eap.environment.tools.web_tools.requests.get", return_value=response):
             payload = extract_links_from_url(
                 "https://example.com/base",
                 same_domain_only=True,


### PR DESCRIPTION
## Summary
- add a canonical import reference contract for examples, scripts, tests, and markdown docs
- move remaining test mocks from legacy shim paths to canonical `eap.*` implementation paths
- expand packaging smoke to install built wheel and sdist artifacts, plus editable install compatibility
- wire the packaging compatibility smoke into the CI build job
- update docs and Phase 13 queue state so EAP-122 is next after merge

## Verification
- `ruff check . --select E9,F63,F7,F82`
- `mypy --follow-imports=skip eap/environment/safe_eval.py eap/environment/executor.py eap/runtime/auth_scopes.py eap/runtime/guardrails.py eap/runtime/http_api.py`
- `pytest -q`
- `RUN_PACKAGING_SMOKE=1 pytest -q tests/packaging/test_install_smoke.py`
- `python -m build`
- `pip-audit`

## Linear
- Completes GEN-201 / EAP-121
