### PR TITLE
EAP-122 replace runtime server with ASGI

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,8 +108,10 @@ Primary endpoints:
 
 Runtime API includes:
 
+- Uvicorn-backed ASGI request handling
 - scoped bearer-token auth and actor ownership checks
 - operation-level rate limiting and concurrency throttles
+- request body size enforcement with structured JSON errors
 - trace/summary retrieval for external orchestrators (OpenClaw/MCP integrations)
 
 ### Local UI (`app.py`)

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -62,7 +62,7 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 | 32 | `EAP-119` | `GEN-199` | `Done` | Production hardening intake and v1.0.1 blocker plan |
 | 33 | `EAP-120` | `GEN-200` | `Done` | Collapse duplicate package trees and define canonical imports |
 | 34 | `EAP-121` | `GEN-201` | `Done` | Add import and package compatibility migration tests |
-| 35 | `EAP-122` | `GEN-202` | `Todo` | Replace runtime HTTP server with production ASGI path |
+| 35 | `EAP-122` | `GEN-202` | `Done` | Replace runtime HTTP server with production ASGI path |
 | 36 | `EAP-123` | `GEN-203` | `Todo` | Fail-closed runtime auth defaults |
 | 37 | `EAP-124` | `GEN-204` | `Todo` | Sandbox local file tools |
 | 38 | `EAP-125` | `GEN-205` | `Todo` | Add SSRF protection and streaming byte caps to web tools |
@@ -73,4 +73,4 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-121` is complete; `EAP-122` is the first implementation item and the next ordered `Todo`.
+Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-122` is complete; `EAP-123` is the next ordered `Todo`.

--- a/docs/phase13_production_hardening_roadmap.md
+++ b/docs/phase13_production_hardening_roadmap.md
@@ -8,7 +8,7 @@ Current status:
 - [x] `EAP-119` production hardening intake and v1.0.1 blocker plan (`GEN-199`)
 - [x] `EAP-120` collapse duplicate package trees and define canonical imports (`GEN-200`)
 - [x] `EAP-121` add import and package compatibility migration tests (`GEN-201`)
-- [ ] `EAP-122` replace runtime HTTP server with production ASGI path (`GEN-202`)
+- [x] `EAP-122` replace runtime HTTP server with production ASGI path (`GEN-202`)
 - [ ] `EAP-123` fail-closed runtime auth defaults (`GEN-203`)
 - [ ] `EAP-124` sandbox local file tools (`GEN-204`)
 - [ ] `EAP-125` add SSRF protection and streaming byte caps to web tools (`GEN-205`)

--- a/docs/remote_ops_governance.md
+++ b/docs/remote_ops_governance.md
@@ -219,6 +219,7 @@ python scripts/eap_runtime_service.py \
   --db-path /var/lib/eap/agent_state.db \
   --policy-profile strict \
   --guardrails-config /etc/eap/guardrails.json \
+  --max-request-body-bytes 1000000 \
   --scoped-auth-config /etc/eap/scoped_auth.json
 ```
 

--- a/docs/self_hosted_control_plane.md
+++ b/docs/self_hosted_control_plane.md
@@ -55,9 +55,10 @@ The smoke validates:
 ## Deployment Topology
 
 - `runtime` container:
-  - Runs `scripts/eap_runtime_service.py`.
+  - Runs `scripts/eap_runtime_service.py`, which starts the Uvicorn-backed ASGI runtime.
   - Requires bearer auth for all `/v1/eap/*` endpoints.
   - Registers a minimal tool set (`fetch_user_data`, `analyze_data`) by default.
+  - Rejects request bodies above the configured `--max-request-body-bytes` limit.
 - `operator-ui` container:
   - Runs `scripts/eap_operator_ui.py`.
   - Read-only dashboard over the shared SQLite state DB.

--- a/eap/runtime/http_api.py
+++ b/eap/runtime/http_api.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+import time
 import types
 import uuid
 from datetime import datetime, timezone
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Optional, Set, Tuple, Type
+from typing import Awaitable, Callable, Optional, Protocol, Set, Type
+from urllib.parse import unquote
 
+import uvicorn
 from pydantic import ValidationError
 
 from eap.environment import AsyncLocalExecutor
@@ -37,6 +39,18 @@ from eap.runtime.guardrails import (
 AuthContext = dict[str, object]
 ScopedTokenPolicy = dict[str, object]
 JsonPayload = dict[str, object]
+ASGIScope = dict[str, object]
+ASGIMessage = dict[str, object]
+class ASGIReceive(Protocol):
+    def __call__(self) -> Awaitable[ASGIMessage]:
+        ...
+
+
+class ASGISend(Protocol):
+    def __call__(self, message: ASGIMessage) -> Awaitable[None]:
+        ...
+
+DEFAULT_MAX_REQUEST_BODY_BYTES = 1_000_000
 
 
 def _timestamp_utc() -> str:
@@ -50,9 +64,9 @@ def _request_id() -> str:
 def _scopes_from_context(ctx: AuthContext) -> Set[str]:
     raw = ctx.get("scopes")
     if isinstance(raw, (set, frozenset)):
-        return set(raw)
+        return {str(scope) for scope in raw}
     if isinstance(raw, list):
-        return {str(s) for s in raw}
+        return {str(scope) for scope in raw}
     return set()
 
 
@@ -61,46 +75,119 @@ def _str_field(ctx: dict[str, object], key: str, default: str = "") -> str:
     return str(val) if val is not None else default
 
 
-class _RuntimeRequestHandler(BaseHTTPRequestHandler):
-    server: _RuntimeHTTPServer
+class _HTTPResponse(Exception):
+    def __init__(
+        self,
+        status_code: int,
+        payload: JsonPayload,
+        headers: Optional[dict[str, str]] = None,
+    ) -> None:
+        super().__init__(str(status_code))
+        self.status_code = status_code
+        self.payload = payload
+        self.headers = headers or {}
 
-    def do_POST(self) -> None:  # noqa: N802
-        parsed_path = self.path.split("?", 1)[0]
-        if parsed_path == "/v1/eap/macro/execute":
-            self._handle_execute_macro()
-            return
-        if parsed_path.startswith("/v1/eap/runs/") and parsed_path.endswith("/resume"):
-            run_id = parsed_path[len("/v1/eap/runs/"):-len("/resume")].strip()
-            self._handle_resume_run(run_id=run_id)
-            return
-        self._send_error(404, "not_found", f"Path '{parsed_path}' is not registered.")
 
-    def do_GET(self) -> None:  # noqa: N802
-        parsed_path = self.path.split("?", 1)[0]
-        if parsed_path.startswith("/v1/eap/runs/"):
-            run_id = parsed_path[len("/v1/eap/runs/"):].strip()
-            self._handle_get_run(run_id=run_id)
-            return
-        if parsed_path.startswith("/v1/eap/pointers/") and parsed_path.endswith("/summary"):
-            pointer_id = parsed_path[len("/v1/eap/pointers/"):-len("/summary")].strip()
-            self._handle_get_pointer_summary(pointer_id=pointer_id)
-            return
-        self._send_error(404, "not_found", f"Path '{parsed_path}' is not registered.")
+class _RuntimeState:
+    def __init__(
+        self,
+        executor: AsyncLocalExecutor,
+        state_manager: StateManager,
+        required_bearer_token: Optional[str],
+        scoped_bearer_tokens: dict[str, ScopedTokenPolicy],
+        guardrails: RuntimeGuardrails,
+    ) -> None:
+        self.executor = executor
+        self.state_manager = state_manager
+        self.required_bearer_token = required_bearer_token
+        self.scoped_bearer_tokens = scoped_bearer_tokens
+        self.guardrails = guardrails
+        self._guardrail_lock = threading.Lock()
+        self.guardrail_counters: dict[str, int] = {"rate_limited": 0, "throttled": 0}
 
-    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
-        return
+    def record_guardrail_event(self, event_type: str, details: JsonPayload) -> None:
+        with self._guardrail_lock:
+            self.guardrail_counters[event_type] = self.guardrail_counters.get(event_type, 0) + 1
+        log_payload: JsonPayload = {
+            "event_type": event_type,
+            "details": details,
+            "counters": dict(self.guardrail_counters),
+            "timestamp_utc": _timestamp_utc(),
+        }
+        print(f"[runtime:guardrail] {json.dumps(log_payload, sort_keys=True)}")
 
-    def _parse_bearer_token(self) -> Optional[str]:
-        auth_header = (self.headers.get("Authorization") or "").strip()
+
+class _RuntimeASGIApp:
+    def __init__(self, state: _RuntimeState, max_request_body_bytes: int) -> None:
+        self._state = state
+        self._max_request_body_bytes = max_request_body_bytes
+
+    async def __call__(self, scope: ASGIScope, receive: ASGIReceive, send: ASGISend) -> None:
+        if scope.get("type") != "http":
+            await self._send_error(send, 500, "server_error", "Unsupported ASGI scope type.")
+            return
+
+        method = str(scope.get("method", "")).upper()
+        path = unquote(str(scope.get("path", ""))).split("?", 1)[0]
+        headers = self._headers_from_scope(scope)
+
+        try:
+            payload = await self._dispatch(method=method, path=path, headers=headers, receive=receive)
+        except _HTTPResponse as response:
+            await self._send_json(send, response.status_code, response.payload, headers=response.headers)
+            return
+        except Exception as exc:  # pragma: no cover - defensive ASGI boundary
+            await self._send_error(send, 500, "server_error", f"Runtime request failed: {str(exc)}")
+            return
+
+        await self._send_json(send, 200, payload)
+
+    async def _dispatch(
+        self,
+        *,
+        method: str,
+        path: str,
+        headers: dict[str, str],
+        receive: ASGIReceive,
+    ) -> JsonPayload:
+        if method == "POST" and path == "/v1/eap/macro/execute":
+            return await self._handle_execute_macro(headers=headers, receive=receive)
+        if method == "POST" and path.startswith("/v1/eap/runs/") and path.endswith("/resume"):
+            run_id = path[len("/v1/eap/runs/"):-len("/resume")].strip()
+            return await self._handle_resume_run(run_id=run_id, headers=headers, receive=receive)
+        if method == "GET" and path.startswith("/v1/eap/runs/"):
+            run_id = path[len("/v1/eap/runs/"):].strip()
+            return self._handle_get_run(run_id=run_id, headers=headers)
+        if method == "GET" and path.startswith("/v1/eap/pointers/") and path.endswith("/summary"):
+            pointer_id = path[len("/v1/eap/pointers/"):-len("/summary")].strip()
+            return self._handle_get_pointer_summary(pointer_id=pointer_id, headers=headers)
+        raise self._error(404, "not_found", f"Path '{path}' is not registered.")
+
+    def _headers_from_scope(self, scope: ASGIScope) -> dict[str, str]:
+        normalized: dict[str, str] = {}
+        raw_headers = scope.get("headers", [])
+        if not isinstance(raw_headers, list):
+            return normalized
+        for item in raw_headers:
+            if not isinstance(item, tuple) or len(item) != 2:
+                continue
+            raw_name, raw_value = item
+            if not isinstance(raw_name, bytes) or not isinstance(raw_value, bytes):
+                continue
+            normalized[raw_name.decode("latin-1").lower()] = raw_value.decode("latin-1")
+        return normalized
+
+    def _parse_bearer_token(self, headers: dict[str, str]) -> Optional[str]:
+        auth_header = headers.get("authorization", "").strip()
         if not auth_header.startswith("Bearer "):
             return None
         token = auth_header[len("Bearer "):].strip()
         return token or None
 
-    def _resolve_auth_context(self) -> Optional[AuthContext]:
-        token = self._parse_bearer_token()
-        scoped_policies = self.server.scoped_bearer_tokens
-        required = self.server.required_bearer_token
+    def _resolve_auth_context(self, headers: dict[str, str]) -> Optional[AuthContext]:
+        token = self._parse_bearer_token(headers)
+        scoped_policies = self._state.scoped_bearer_tokens
+        required = self._state.required_bearer_token
 
         if not required and not scoped_policies:
             return {
@@ -118,9 +205,9 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
             raw_scopes = policy.get("scopes")
             scopes: Set[str]
             if isinstance(raw_scopes, (set, frozenset)):
-                scopes = set(raw_scopes)
+                scopes = {str(scope) for scope in raw_scopes}
             elif isinstance(raw_scopes, list):
-                scopes = {str(s) for s in raw_scopes}
+                scopes = {str(scope) for scope in raw_scopes}
             else:
                 scopes = set()
             return {
@@ -140,28 +227,22 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
             }
         return None
 
-    def _require_auth(self, required_scope: str) -> Optional[AuthContext]:
-        context = self._resolve_auth_context()
+    def _require_auth(self, headers: dict[str, str], required_scope: str) -> AuthContext:
+        context = self._resolve_auth_context(headers)
         if context is None:
-            self._send_error(401, "unauthorized", "Missing or invalid bearer token.")
-            return None
+            raise self._error(401, "unauthorized", "Missing or invalid bearer token.")
 
         scopes = _scopes_from_context(context)
         if required_scope not in scopes and "*" not in scopes:
-            self._send_error(
-                403,
-                "forbidden",
-                f"Missing required scope '{required_scope}'.",
-            )
-            return None
+            raise self._error(403, "forbidden", f"Missing required scope '{required_scope}'.")
         return context
 
-    def _enforce_rate_limit(self, *, operation: str, auth_context: AuthContext) -> bool:
+    def _enforce_rate_limit(self, *, operation: str, auth_context: AuthContext) -> None:
         actor_id = _str_field(auth_context, "actor_id") or _str_field(auth_context, "auth_subject") or "anonymous"
         actor_id = actor_id.strip() or "anonymous"
-        decision = self.server.guardrails.check_rate_limit(operation=operation, actor_id=actor_id)
+        decision = self._state.guardrails.check_rate_limit(operation=operation, actor_id=actor_id)
         if decision.allowed:
-            return True
+            return
 
         details: JsonPayload = {
             "operation": operation,
@@ -170,18 +251,17 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
             "window_seconds": decision.window_seconds,
             "retry_after_seconds": round(decision.retry_after_seconds, 3),
         }
-        self.server.record_guardrail_event("rate_limited", details)
-        self._send_error(
+        self._state.record_guardrail_event("rate_limited", details)
+        raise self._error(
             429,
             "rate_limited",
             f"Rate limit exceeded for '{operation}'.",
             details=details,
             headers={"Retry-After": RuntimeGuardrails.retry_after_header_value(decision.retry_after_seconds)},
         )
-        return False
 
-    def _acquire_concurrency(self, *, operation: str, run_id: Optional[str] = None) -> Optional[ConcurrencyToken]:
-        decision, token = self.server.guardrails.acquire_concurrency(operation=operation, run_id=run_id)
+    def _acquire_concurrency(self, *, operation: str, run_id: Optional[str] = None) -> ConcurrencyToken:
+        decision, token = self._state.guardrails.acquire_concurrency(operation=operation, run_id=run_id)
         if decision.allowed and token is not None:
             return token
 
@@ -193,14 +273,13 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
         }
         if run_id:
             details["run_id"] = run_id
-        self.server.record_guardrail_event("throttled", details)
-        self._send_error(
+        self._state.record_guardrail_event("throttled", details)
+        raise self._error(
             429,
             "throttled",
             f"Concurrency limit exceeded for '{operation}'.",
             details=details,
         )
-        return None
 
     def _to_actor_metadata(self, auth_context: AuthContext, operation: str) -> JsonPayload:
         scopes = _scopes_from_context(auth_context)
@@ -219,202 +298,139 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
             metadata["policy_template"] = policy_template
         return metadata
 
-    def _check_run_access(
-        self,
-        run_id: str,
-        auth_context: AuthContext,
-        *,
-        allow_any_scope: str,
-    ) -> bool:
-        actor_metadata = self.server.state_manager.get_run_actor_metadata(run_id=run_id)
+    def _check_run_access(self, run_id: str, auth_context: AuthContext, *, allow_any_scope: str) -> None:
+        actor_metadata = self._state.state_manager.get_run_actor_metadata(run_id=run_id)
         owner_actor_id = actor_metadata.get("owner_actor_id") or actor_metadata.get("actor_id")
         if not owner_actor_id:
-            return True
+            return
 
         actor_id = auth_context.get("actor_id")
         scopes = _scopes_from_context(auth_context)
         if actor_id == owner_actor_id or allow_any_scope in scopes or "*" in scopes:
-            return True
-        self._send_error(
-            403,
-            "forbidden",
-            f"Actor '{actor_id}' is not allowed to access run '{run_id}'.",
-        )
-        return False
+            return
+        raise self._error(403, "forbidden", f"Actor '{actor_id}' is not allowed to access run '{run_id}'.")
 
-    def _read_json_body(self, required: bool = True) -> Optional[JsonPayload]:
-        content_length_header = self.headers.get("Content-Length")
-        if not content_length_header:
+    async def _read_json_body(self, receive: ASGIReceive, *, required: bool = True) -> JsonPayload:
+        chunks: list[bytes] = []
+        total_bytes = 0
+        more_body = True
+        while more_body:
+            raw_message = await receive()
+            if not isinstance(raw_message, dict):
+                raise self._error(400, "validation_error", "Invalid ASGI request body message.")
+            body = raw_message.get("body", b"")
+            if not isinstance(body, bytes):
+                raise self._error(400, "validation_error", "Invalid request body chunk.")
+            total_bytes += len(body)
+            if total_bytes > self._max_request_body_bytes:
+                raise self._error(
+                    413,
+                    "request_body_too_large",
+                    f"Request body exceeds {self._max_request_body_bytes} bytes.",
+                    details={"max_request_body_bytes": self._max_request_body_bytes},
+                )
+            if body:
+                chunks.append(body)
+            more_body = bool(raw_message.get("more_body", False))
+
+        raw_body = b"".join(chunks)
+        if not raw_body:
             if required:
-                self._send_error(400, "validation_error", "Request body is required.")
-                return None
-            return {}
-        try:
-            content_length = int(content_length_header)
-        except ValueError:
-            self._send_error(400, "validation_error", "Invalid Content-Length header.")
-            return None
-        if content_length <= 0:
-            if required:
-                self._send_error(400, "validation_error", "Request body is required.")
-                return None
+                raise self._error(400, "validation_error", "Request body is required.")
             return {}
 
-        raw_body = self.rfile.read(content_length)
         try:
             payload = json.loads(raw_body.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError):
-            self._send_error(400, "validation_error", "Request body must be valid JSON.")
-            return None
+            raise self._error(400, "validation_error", "Request body must be valid JSON.")
 
         if not isinstance(payload, dict):
-            self._send_error(400, "validation_error", "Request body must be a JSON object.")
-            return None
+            raise self._error(400, "validation_error", "Request body must be a JSON object.")
         return payload
 
-    def _handle_execute_macro(self) -> None:
-        auth_context = self._require_auth(SCOPE_RUNS_EXECUTE)
-        if auth_context is None:
-            return
-        if not self._enforce_rate_limit(
-            operation=RUNTIME_OPERATION_MACRO_EXECUTE,
-            auth_context=auth_context,
-        ):
-            return
-
-        payload = self._read_json_body()
-        if payload is None:
-            return
+    async def _handle_execute_macro(self, *, headers: dict[str, str], receive: ASGIReceive) -> JsonPayload:
+        auth_context = self._require_auth(headers, SCOPE_RUNS_EXECUTE)
+        self._enforce_rate_limit(operation=RUNTIME_OPERATION_MACRO_EXECUTE, auth_context=auth_context)
+        payload = await self._read_json_body(receive)
 
         macro_payload = payload.get("macro")
         if macro_payload is None:
-            self._send_error(400, "validation_error", "Field 'macro' is required.")
-            return
+            raise self._error(400, "validation_error", "Field 'macro' is required.")
 
         try:
             macro = BatchedMacroRequest.model_validate(macro_payload)
         except ValidationError as exc:
-            self._send_error(
-                400,
-                "validation_error",
-                "Invalid macro payload.",
-                details={"errors": exc.errors()},
-            )
-            return
+            raise self._error(400, "validation_error", "Invalid macro payload.", details={"errors": exc.errors()})
 
         concurrency_token = self._acquire_concurrency(operation=RUNTIME_OPERATION_MACRO_EXECUTE)
-        if concurrency_token is None:
-            return
         try:
             try:
-                result = asyncio.run(
-                    self.server.executor.execute_macro(
-                        macro,
-                        actor_metadata=self._to_actor_metadata(auth_context, operation="execute"),
-                    )
+                result = await self._state.executor.execute_macro(
+                    macro,
+                    actor_metadata=self._to_actor_metadata(auth_context, operation="execute"),
                 )
             except Exception as exc:  # pragma: no cover - defensive safeguard
-                self._send_error(
-                    500,
-                    "execution_error",
-                    f"Macro execution failed: {str(exc)}",
-                )
-                return
+                raise self._error(500, "execution_error", f"Macro execution failed: {str(exc)}")
         finally:
-            self.server.guardrails.release_concurrency(concurrency_token)
+            self._state.guardrails.release_concurrency(concurrency_token)
 
         if not result or "pointer_id" not in result:
-            self._send_error(
-                500,
-                "execution_error",
-                "Macro execution did not return a pointer response.",
-            )
-            return
+            raise self._error(500, "execution_error", "Macro execution did not return a pointer response.")
 
-        response_payload: JsonPayload = {
+        return {
             "request_id": _request_id(),
             "timestamp_utc": _timestamp_utc(),
             "pointer_id": result["pointer_id"],
             "summary": result.get("summary", ""),
             "metadata": result.get("metadata"),
         }
-        self._send_json(200, response_payload)
 
-    def _handle_resume_run(self, run_id: str) -> None:
-        auth_context = self._require_auth(SCOPE_RUNS_RESUME)
-        if auth_context is None:
-            return
-        if not self._enforce_rate_limit(
-            operation=RUNTIME_OPERATION_RUN_RESUME,
-            auth_context=auth_context,
-        ):
-            return
+    async def _handle_resume_run(
+        self,
+        *,
+        run_id: str,
+        headers: dict[str, str],
+        receive: ASGIReceive,
+    ) -> JsonPayload:
+        auth_context = self._require_auth(headers, SCOPE_RUNS_RESUME)
+        self._enforce_rate_limit(operation=RUNTIME_OPERATION_RUN_RESUME, auth_context=auth_context)
         if not run_id:
-            self._send_error(400, "validation_error", "run_id is required.")
-            return
-        if not self._check_run_access(
-            run_id=run_id,
-            auth_context=auth_context,
-            allow_any_scope=SCOPE_RUNS_RESUME_ANY,
-        ):
-            return
+            raise self._error(400, "validation_error", "run_id is required.")
+        self._check_run_access(run_id=run_id, auth_context=auth_context, allow_any_scope=SCOPE_RUNS_RESUME_ANY)
 
-        payload = self._read_json_body(required=False)
-        if payload is None:
-            return
+        payload = await self._read_json_body(receive, required=False)
         approvals = payload.get("approvals")
         if approvals is not None and not isinstance(approvals, dict):
-            self._send_error(400, "validation_error", "Field 'approvals' must be a JSON object.")
-            return
+            raise self._error(400, "validation_error", "Field 'approvals' must be a JSON object.")
 
-        concurrency_token = self._acquire_concurrency(
-            operation=RUNTIME_OPERATION_RUN_RESUME,
-            run_id=run_id,
-        )
-        if concurrency_token is None:
-            return
+        concurrency_token = self._acquire_concurrency(operation=RUNTIME_OPERATION_RUN_RESUME, run_id=run_id)
         try:
             try:
-                result = asyncio.run(
-                    self.server.executor.resume_run(
-                        run_id=run_id,
-                        approvals=approvals,
-                        actor_metadata=self._to_actor_metadata(auth_context, operation="resume"),
-                    )
+                result = await self._state.executor.resume_run(
+                    run_id=run_id,
+                    approvals=approvals,
+                    actor_metadata=self._to_actor_metadata(auth_context, operation="resume"),
                 )
             except KeyError:
-                self._send_error(404, "not_found", f"Execution checkpoint for run '{run_id}' not found.")
-                return
+                raise self._error(404, "not_found", f"Execution checkpoint for run '{run_id}' not found.")
             except ValueError as exc:
-                self._send_error(400, "validation_error", str(exc))
-                return
+                raise self._error(400, "validation_error", str(exc))
             except ValidationError as exc:
-                self._send_error(
+                raise self._error(
                     400,
                     "validation_error",
                     "Invalid resume approval payload.",
                     details={"errors": exc.errors()},
                 )
-                return
             except Exception as exc:  # pragma: no cover - defensive safeguard
-                self._send_error(
-                    500,
-                    "execution_error",
-                    f"Run resume failed: {str(exc)}",
-                )
-                return
+                raise self._error(500, "execution_error", f"Run resume failed: {str(exc)}")
         finally:
-            self.server.guardrails.release_concurrency(concurrency_token)
+            self._state.guardrails.release_concurrency(concurrency_token)
 
         if not result or "pointer_id" not in result:
-            self._send_error(
-                500,
-                "execution_error",
-                "Run resume did not return a pointer response.",
-            )
-            return
+            raise self._error(500, "execution_error", "Run resume did not return a pointer response.")
 
-        response_payload: JsonPayload = {
+        return {
             "request_id": _request_id(),
             "timestamp_utc": _timestamp_utc(),
             "run_id": run_id,
@@ -422,41 +438,27 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
             "summary": result.get("summary", ""),
             "metadata": result.get("metadata"),
         }
-        self._send_json(200, response_payload)
 
-    def _handle_get_run(self, run_id: str) -> None:
-        auth_context = self._require_auth(SCOPE_RUNS_READ)
-        if auth_context is None:
-            return
-        if not self._enforce_rate_limit(
-            operation=RUNTIME_OPERATION_RUN_READ,
-            auth_context=auth_context,
-        ):
-            return
+    def _handle_get_run(self, *, run_id: str, headers: dict[str, str]) -> JsonPayload:
+        auth_context = self._require_auth(headers, SCOPE_RUNS_READ)
+        self._enforce_rate_limit(operation=RUNTIME_OPERATION_RUN_READ, auth_context=auth_context)
         if not run_id:
-            self._send_error(400, "validation_error", "run_id is required.")
-            return
-        if not self._check_run_access(
-            run_id=run_id,
-            auth_context=auth_context,
-            allow_any_scope=SCOPE_RUNS_READ_ANY,
-        ):
-            return
+            raise self._error(400, "validation_error", "run_id is required.")
+        self._check_run_access(run_id=run_id, auth_context=auth_context, allow_any_scope=SCOPE_RUNS_READ_ANY)
 
         try:
-            summary = self.server.state_manager.get_execution_summary(run_id)
+            summary = self._state.state_manager.get_execution_summary(run_id)
         except KeyError:
-            self._send_error(404, "not_found", f"Execution summary for run '{run_id}' not found.")
-            return
+            raise self._error(404, "not_found", f"Execution summary for run '{run_id}' not found.")
 
         trace_events: list[dict[str, object]] = [
             event.model_dump(mode="json")
-            for event in self.server.state_manager.list_trace_events(run_id)
+            for event in self._state.state_manager.list_trace_events(run_id)
         ]
-        actor_metadata = self.server.state_manager.get_run_actor_metadata(run_id=run_id)
+        actor_metadata = self._state.state_manager.get_run_actor_metadata(run_id=run_id)
         status = "failed" if summary.get("failed_steps", 0) > 0 else "succeeded"
 
-        response_payload: JsonPayload = {
+        return {
             "request_id": _request_id(),
             "timestamp_utc": _timestamp_utc(),
             "run_id": run_id,
@@ -466,32 +468,23 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
             "trace_event_count": len(trace_events),
             "trace_events": trace_events,
         }
-        self._send_json(200, response_payload)
 
-    def _handle_get_pointer_summary(self, pointer_id: str) -> None:
-        auth_context = self._require_auth(SCOPE_POINTERS_READ)
-        if auth_context is None:
-            return
-        if not self._enforce_rate_limit(
-            operation=RUNTIME_OPERATION_POINTER_SUMMARY,
-            auth_context=auth_context,
-        ):
-            return
+    def _handle_get_pointer_summary(self, *, pointer_id: str, headers: dict[str, str]) -> JsonPayload:
+        auth_context = self._require_auth(headers, SCOPE_POINTERS_READ)
+        self._enforce_rate_limit(operation=RUNTIME_OPERATION_POINTER_SUMMARY, auth_context=auth_context)
         if not pointer_id:
-            self._send_error(400, "validation_error", "pointer_id is required.")
-            return
+            raise self._error(400, "validation_error", "pointer_id is required.")
 
         pointer: Optional[dict[str, object]] = next(
             (
                 item
-                for item in self.server.state_manager.list_pointers(include_expired=True)
+                for item in self._state.state_manager.list_pointers(include_expired=True)
                 if item.get("pointer_id") == pointer_id
             ),
             None,
         )
         if pointer is None:
-            self._send_error(404, "not_found", f"Pointer '{pointer_id}' not found.")
-            return
+            raise self._error(404, "not_found", f"Pointer '{pointer_id}' not found.")
 
         raw_metadata = pointer.get("metadata")
         pointer_metadata: dict[str, object] = raw_metadata if isinstance(raw_metadata, dict) else {}
@@ -499,14 +492,13 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
         if isinstance(run_id, str) and run_id:
             scopes = _scopes_from_context(auth_context)
             if SCOPE_POINTERS_READ_ANY not in scopes and "*" not in scopes:
-                if not self._check_run_access(
+                self._check_run_access(
                     run_id=run_id,
                     auth_context=auth_context,
                     allow_any_scope=SCOPE_RUNS_READ_ANY,
-                ):
-                    return
+                )
 
-        response_payload: JsonPayload = {
+        return {
             "request_id": _request_id(),
             "timestamp_utc": _timestamp_utc(),
             "pointer": {
@@ -519,75 +511,52 @@ class _RuntimeRequestHandler(BaseHTTPRequestHandler):
                 "is_expired": pointer.get("is_expired", False),
             },
         }
-        self._send_json(200, response_payload)
 
-    def _send_json(
-        self,
-        status_code: int,
-        payload: JsonPayload,
-        headers: Optional[dict[str, str]] = None,
-    ) -> None:
-        encoded = json.dumps(payload, sort_keys=True).encode("utf-8")
-        self.send_response(status_code)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(encoded)))
-        if headers:
-            for key, value in headers.items():
-                self.send_header(key, value)
-        self.end_headers()
-        self.wfile.write(encoded)
-
-    def _send_error(
+    def _error(
         self,
         status_code: int,
         error_type: str,
         message: str,
         details: Optional[JsonPayload] = None,
         headers: Optional[dict[str, str]] = None,
-    ) -> None:
-        payload: JsonPayload = {
-            "error_type": error_type,
-            "message": message,
-        }
+    ) -> _HTTPResponse:
+        payload: JsonPayload = {"error_type": error_type, "message": message}
         if details is not None:
             payload["details"] = details
-        self._send_json(status_code, payload, headers=headers)
+        return _HTTPResponse(status_code, payload, headers=headers)
 
-
-class _RuntimeHTTPServer(ThreadingHTTPServer):
-    def __init__(
+    async def _send_error(
         self,
-        server_address: Tuple[str, int],
-        handler_class: Type[_RuntimeRequestHandler],
-        executor: AsyncLocalExecutor,
-        state_manager: StateManager,
-        required_bearer_token: Optional[str],
-        scoped_bearer_tokens: dict[str, ScopedTokenPolicy],
-        guardrails: RuntimeGuardrails,
+        send: ASGISend,
+        status_code: int,
+        error_type: str,
+        message: str,
+        details: Optional[JsonPayload] = None,
+        headers: Optional[dict[str, str]] = None,
     ) -> None:
-        super().__init__(server_address, handler_class)
-        self.executor = executor
-        self.state_manager = state_manager
-        self.required_bearer_token = required_bearer_token
-        self.scoped_bearer_tokens: dict[str, ScopedTokenPolicy] = scoped_bearer_tokens
-        self.guardrails = guardrails
-        self._guardrail_lock = threading.Lock()
-        self.guardrail_counters: dict[str, int] = {"rate_limited": 0, "throttled": 0}
+        await self._send_json(send, status_code, self._error(status_code, error_type, message, details).payload, headers)
 
-    def record_guardrail_event(self, event_type: str, details: JsonPayload) -> None:
-        with self._guardrail_lock:
-            self.guardrail_counters[event_type] = self.guardrail_counters.get(event_type, 0) + 1
-        log_payload: JsonPayload = {
-            "event_type": event_type,
-            "details": details,
-            "counters": dict(self.guardrail_counters),
-            "timestamp_utc": _timestamp_utc(),
-        }
-        print(f"[runtime:guardrail] {json.dumps(log_payload, sort_keys=True)}")
+    async def _send_json(
+        self,
+        send: ASGISend,
+        status_code: int,
+        payload: JsonPayload,
+        headers: Optional[dict[str, str]] = None,
+    ) -> None:
+        encoded = json.dumps(payload, sort_keys=True).encode("utf-8")
+        response_headers = [
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(encoded)).encode("ascii")),
+        ]
+        if headers:
+            for key, value in headers.items():
+                response_headers.append((key.lower().encode("latin-1"), value.encode("latin-1")))
+        await send({"type": "http.response.start", "status": status_code, "headers": response_headers})
+        await send({"type": "http.response.body", "body": encoded})
 
 
 class EAPRuntimeHTTPServer:
-    """Minimal HTTP runtime endpoints for external orchestrator integration."""
+    """ASGI-backed runtime endpoints for external orchestrator integration."""
 
     @staticmethod
     def _normalize_scoped_bearer_tokens(
@@ -616,9 +585,7 @@ class EAPRuntimeHTTPServer:
                 scopes = []
             scopes = [scope for scope in scopes if scope in FULL_RUNTIME_SCOPES or scope == "*"]
 
-            if not actor_id:
-                continue
-            if not scopes:
+            if not actor_id or not scopes:
                 continue
             entry: ScopedTokenPolicy = {
                 "actor_id": actor_id,
@@ -642,14 +609,20 @@ class EAPRuntimeHTTPServer:
         scoped_bearer_tokens: Optional[dict[str, dict[str, object]]] = None,
         rate_limit_rules: Optional[dict[str, dict[str, object]]] = None,
         concurrency_limits: Optional[dict[str, object]] = None,
+        max_request_body_bytes: int = DEFAULT_MAX_REQUEST_BODY_BYTES,
     ) -> None:
+        if port < 0 or port > 65535:
+            raise ValueError("port must be between 0 and 65535")
+        if max_request_body_bytes <= 0:
+            raise ValueError("max_request_body_bytes must be greater than 0")
+
         self._host = host
+        self._configured_port = port
+        self._bound_port: Optional[int] = None
         normalized_scoped_tokens = self._normalize_scoped_bearer_tokens(scoped_bearer_tokens)
         normalized_rate_limits = normalize_rate_limit_rules(rate_limit_rules)
         normalized_concurrency_limits = normalize_concurrency_limits(concurrency_limits)
-        self._httpd = _RuntimeHTTPServer(
-            (host, port),
-            _RuntimeRequestHandler,
+        self._state = _RuntimeState(
             executor=executor,
             state_manager=state_manager,
             required_bearer_token=required_bearer_token,
@@ -659,6 +632,16 @@ class EAPRuntimeHTTPServer:
                 concurrency_limits=normalized_concurrency_limits,
             ),
         )
+        self._app = _RuntimeASGIApp(self._state, max_request_body_bytes=max_request_body_bytes)
+        self._config = uvicorn.Config(
+            self._app,
+            host=host,
+            port=port,
+            log_level="warning",
+            access_log=False,
+            lifespan="off",
+        )
+        self._server = uvicorn.Server(self._config)
         self._thread: Optional[threading.Thread] = None
 
     @property
@@ -667,7 +650,9 @@ class EAPRuntimeHTTPServer:
 
     @property
     def port(self) -> int:
-        return int(self._httpd.server_address[1])
+        if self._bound_port is not None:
+            return self._bound_port
+        return self._configured_port
 
     @property
     def base_url(self) -> str:
@@ -676,15 +661,36 @@ class EAPRuntimeHTTPServer:
     def start(self) -> EAPRuntimeHTTPServer:
         if self._thread and self._thread.is_alive():
             return self
-        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._server.should_exit = False
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
         self._thread.start()
+        self._wait_until_started()
         return self
 
+    def _wait_until_started(self) -> None:
+        deadline = time.monotonic() + 5.0
+        while not self._server.started:
+            if not self._thread or not self._thread.is_alive():
+                raise RuntimeError("EAP runtime ASGI server failed to start.")
+            if time.monotonic() > deadline:
+                raise TimeoutError("Timed out waiting for EAP runtime ASGI server to start.")
+            threading.Event().wait(0.01)
+        self._bound_port = self._resolve_bound_port()
+
+    def _resolve_bound_port(self) -> int:
+        for server in self._server.servers:
+            sockets = getattr(server, "sockets", [])
+            for sock in sockets:
+                address = sock.getsockname()
+                if isinstance(address, tuple) and len(address) >= 2:
+                    return int(address[1])
+        return self._configured_port
+
     def stop(self) -> None:
-        self._httpd.shutdown()
-        self._httpd.server_close()
+        self._server.should_exit = True
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=5)
+        self._thread = None
 
     def __enter__(self) -> EAPRuntimeHTTPServer:
         return self.start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "pydantic==2.6.1",
   "requests==2.33.0",
   "beautifulsoup4==4.12.3",
+  "uvicorn==0.46.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ requests==2.33.0
 
 # Required for HTML parsing in web_tools.py
 beautifulsoup4==4.12.3
+
+# Required for the production ASGI runtime server
+uvicorn==0.46.0

--- a/scripts/eap_runtime_service.py
+++ b/scripts/eap_runtime_service.py
@@ -67,6 +67,12 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "\"per_run_resume_inflight\":1}}"
         ),
     )
+    parser.add_argument(
+        "--max-request-body-bytes",
+        type=int,
+        default=1_000_000,
+        help="Maximum accepted runtime request body size in bytes (default: 1000000).",
+    )
     return parser.parse_args(argv)
 
 
@@ -142,6 +148,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.port <= 0 or args.port > 65535:
         print("[runtime:error] --port must be between 1 and 65535.")
         return 1
+    if args.max_request_body_bytes <= 0:
+        print("[runtime:error] --max-request-body-bytes must be greater than 0.")
+        return 1
     bearer_token = args.bearer_token.strip()
     try:
         scoped_tokens, active_policy_profile = _load_scoped_auth_config(
@@ -180,6 +189,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         scoped_bearer_tokens=scoped_tokens or None,
         rate_limit_rules=rate_limit_rules or None,
         concurrency_limits=concurrency_limits or None,
+        max_request_body_bytes=args.max_request_body_bytes,
     ).start()
 
     stop_event = threading.Event()
@@ -198,6 +208,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"[runtime] scoped_auth_tokens={len(scoped_tokens)}")
     print(f"[runtime] rate_limits={json.dumps(normalized_rate_limits, sort_keys=True, default=lambda o: o.__dict__)}")
     print(f"[runtime] concurrency_limits={json.dumps(normalized_concurrency_limits, sort_keys=True)}")
+    print(f"[runtime] max_request_body_bytes={args.max_request_body_bytes}")
     print("[runtime] tools=fetch_user_data,analyze_data")
 
     try:

--- a/tests/contract/test_runtime_asgi_contract.py
+++ b/tests/contract/test_runtime_asgi_contract.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HTTP_API_PATH = REPO_ROOT / "eap" / "runtime" / "http_api.py"
+
+
+def test_runtime_http_api_uses_asgi_server_boundary() -> None:
+    source = HTTP_API_PATH.read_text(encoding="utf-8")
+
+    assert "uvicorn.Server" in source
+    assert "ThreadingHTTPServer" not in source
+    assert "BaseHTTPRequestHandler" not in source
+    assert "asyncio.run(" not in source
+
+
+def test_runtime_http_api_enforces_request_body_cap() -> None:
+    source = HTTP_API_PATH.read_text(encoding="utf-8")
+
+    assert "DEFAULT_MAX_REQUEST_BODY_BYTES" in source
+    assert "request_body_too_large" in source
+    assert "max_request_body_bytes" in source

--- a/tests/integration/test_runtime_http_api.py
+++ b/tests/integration/test_runtime_http_api.py
@@ -138,6 +138,26 @@ class RuntimeHttpApiIntegrationTest(unittest.TestCase):
         self.assertEqual(body["error_type"], "validation_error")
         self.assertIn("Invalid macro payload", body["message"])
 
+    def test_execute_macro_rejects_oversized_request_body(self) -> None:
+        self.server.stop()
+        self.server = EAPRuntimeHTTPServer(
+            executor=AsyncLocalExecutor(self.state_manager, ToolRegistry()),
+            state_manager=self.state_manager,
+            required_bearer_token="secret-token",
+            max_request_body_bytes=32,
+        ).start()
+
+        response = requests.post(
+            f"{self.server.base_url}/v1/eap/macro/execute",
+            headers={"Authorization": "Bearer secret-token", "Content-Type": "application/json"},
+            data='{"macro":{"steps":[{"step_id":"step_1","tool_name":"echo_text","arguments":{"text":"hello"}}]}}',
+            timeout=5,
+        )
+        self.assertEqual(response.status_code, 413)
+        body = response.json()
+        self.assertEqual(body["error_type"], "request_body_too_large")
+        self.assertEqual(body["details"]["max_request_body_bytes"], 32)
+
     def test_resume_run_with_approval_decision(self) -> None:
         execute_response = requests.post(
             f"{self.server.base_url}/v1/eap/macro/execute",


### PR DESCRIPTION
## Summary
- replace the runtime ThreadingHTTPServer path with a Uvicorn-backed ASGI server
- preserve the existing runtime endpoint contract while executing macros/resumes through async handlers
- add a configurable request body cap with 413 rejection and update service/docs
- add ASGI contract coverage and oversized-body integration coverage

Completes GEN-202.

## Validation
- ruff check . --select E9,F63,F7,F82
- mypy --follow-imports=skip eap/environment/safe_eval.py eap/environment/executor.py eap/runtime/auth_scopes.py eap/runtime/guardrails.py eap/runtime/http_api.py
- pytest -q
- RUN_PACKAGING_SMOKE=1 pytest -q tests/packaging/test_install_smoke.py
- python -m build
- pip-audit
- pytest -q tests/contract/test_runtime_asgi_contract.py tests/integration/test_runtime_http_api.py