### PR TITLE
EAP-123 fail closed runtime auth defaults

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,7 @@ Primary endpoints:
 Runtime API includes:
 
 - Uvicorn-backed ASGI request handling
-- scoped bearer-token auth and actor ownership checks
+- fail-closed bearer/scoped-token auth and actor ownership checks
 - operation-level rate limiting and concurrency throttles
 - request body size enforcement with structured JSON errors
 - trace/summary retrieval for external orchestrators (OpenClaw/MCP integrations)

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -63,7 +63,7 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 | 33 | `EAP-120` | `GEN-200` | `Done` | Collapse duplicate package trees and define canonical imports |
 | 34 | `EAP-121` | `GEN-201` | `Done` | Add import and package compatibility migration tests |
 | 35 | `EAP-122` | `GEN-202` | `Done` | Replace runtime HTTP server with production ASGI path |
-| 36 | `EAP-123` | `GEN-203` | `Todo` | Fail-closed runtime auth defaults |
+| 36 | `EAP-123` | `GEN-203` | `Done` | Fail-closed runtime auth defaults |
 | 37 | `EAP-124` | `GEN-204` | `Todo` | Sandbox local file tools |
 | 38 | `EAP-125` | `GEN-205` | `Todo` | Add SSRF protection and streaming byte caps to web tools |
 | 39 | `EAP-126` | `GEN-206` | `Todo` | Add macro cycle detection and execution timeout controls |
@@ -73,4 +73,4 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-122` is complete; `EAP-123` is the next ordered `Todo`.
+Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-123` is complete; `EAP-124` is the next ordered `Todo`.

--- a/docs/phase13_production_hardening_roadmap.md
+++ b/docs/phase13_production_hardening_roadmap.md
@@ -9,7 +9,7 @@ Current status:
 - [x] `EAP-120` collapse duplicate package trees and define canonical imports (`GEN-200`)
 - [x] `EAP-121` add import and package compatibility migration tests (`GEN-201`)
 - [x] `EAP-122` replace runtime HTTP server with production ASGI path (`GEN-202`)
-- [ ] `EAP-123` fail-closed runtime auth defaults (`GEN-203`)
+- [x] `EAP-123` fail-closed runtime auth defaults (`GEN-203`)
 - [ ] `EAP-124` sandbox local file tools (`GEN-204`)
 - [ ] `EAP-125` add SSRF protection and streaming byte caps to web tools (`GEN-205`)
 - [ ] `EAP-126` add macro cycle detection and execution timeout controls (`GEN-206`)

--- a/docs/remote_ops_governance.md
+++ b/docs/remote_ops_governance.md
@@ -161,6 +161,13 @@ Chain-of-custody guidance:
 }
 ```
 
+Runtime auth is fail-closed by default:
+
+- no `--bearer-token` and no `--scoped-auth-config` means runtime requests are denied
+- unauthenticated full-scope access is available only through the explicit `--allow-unauthenticated-local-dev` flag
+- local-dev unauthenticated mode is loopback-only and marks trace metadata with `policy_profile=local_dev`
+- production and self-hosted examples must use bearer/scoped-token configuration
+
 ## Policy Profiles And Templates (EAP-095)
 
 Runtime scoped auth now supports built-in policy profiles with template-based grants.

--- a/docs/self_hosted_control_plane.md
+++ b/docs/self_hosted_control_plane.md
@@ -69,6 +69,7 @@ The smoke validates:
 - Runtime API expects `Authorization: Bearer <token>`.
 - Token source: `EAP_RUNTIME_BEARER_TOKEN` in `deploy/self_hosted/.env`.
 - Requests without valid bearer token return `401 unauthorized`.
+- Missing auth configuration does not grant anonymous access; runtime auth fails closed by default.
 - Runtime also supports scoped tokens via `--scoped-auth-config` for multi-user governance.
 - Scoped auth defaults to `--policy-profile strict` unless overridden.
 - Runtime supports `--guardrails-config` for endpoint rate limits and concurrency ceilings.
@@ -90,6 +91,7 @@ See profile/template matrix and deny-by-default behavior in `docs/remote_ops_gov
 - Use a strong, randomly generated runtime token.
 - Prefer role-scoped tokens for operators instead of sharing one global token.
 - Do not commit `deploy/self_hosted/.env` to source control.
+- Do not use `--allow-unauthenticated-local-dev` outside loopback-only local testing.
 - Rotate token by updating `EAP_RUNTIME_BEARER_TOKEN` and restarting the stack:
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -85,10 +85,12 @@ Fix:
 ### Runtime smoke fails with `401 unauthorized`
 Cause:
 - Smoke token does not match the runtime token in compose env.
+- Runtime was started without `--bearer-token` or `--scoped-auth-config`; runtime auth fails closed by default.
 
 Fix:
 - Pass the exact configured token:
   - `python scripts/self_hosted_stack_smoke.py --base-url http://127.0.0.1:8080 --bearer-token "<runtime-token>"`
+- For local-only experiments, `scripts/eap_runtime_service.py` has an explicit `--allow-unauthenticated-local-dev` flag. It only works on loopback hosts and must not be used for self-hosted or remote deployments.
 
 ### Runtime API returns `403 forbidden` with missing scope message
 Cause:

--- a/eap/environment/executor.py
+++ b/eap/environment/executor.py
@@ -96,6 +96,12 @@ class AsyncLocalExecutor:
         }
         if isinstance(source.get("auth_subject"), str) and source["auth_subject"].strip():
             metadata["auth_subject"] = source["auth_subject"].strip()
+        if isinstance(source.get("policy_profile"), str) and source["policy_profile"].strip():
+            metadata["policy_profile"] = source["policy_profile"].strip()
+        if isinstance(source.get("policy_template"), str) and source["policy_template"].strip():
+            metadata["policy_template"] = source["policy_template"].strip()
+        if source.get("local_dev_auth") is True:
+            metadata["local_dev_auth"] = True
         return metadata
 
     async def execute_macro(
@@ -153,6 +159,12 @@ class AsyncLocalExecutor:
                     merged_actor_metadata["actor_scopes"] = normalized_actor_metadata["actor_scopes"]
                 if normalized_actor_metadata.get("auth_subject"):
                     merged_actor_metadata["auth_subject"] = normalized_actor_metadata["auth_subject"]
+                if normalized_actor_metadata.get("policy_profile"):
+                    merged_actor_metadata["policy_profile"] = normalized_actor_metadata["policy_profile"]
+                if normalized_actor_metadata.get("policy_template"):
+                    merged_actor_metadata["policy_template"] = normalized_actor_metadata["policy_template"]
+                if normalized_actor_metadata.get("local_dev_auth"):
+                    merged_actor_metadata["local_dev_auth"] = True
                 merged_actor_metadata["operation"] = operation
                 run_actor_metadata = merged_actor_metadata
 

--- a/eap/runtime/http_api.py
+++ b/eap/runtime/http_api.py
@@ -51,6 +51,7 @@ class ASGISend(Protocol):
         ...
 
 DEFAULT_MAX_REQUEST_BODY_BYTES = 1_000_000
+LOCAL_DEV_AUTH_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 
 def _timestamp_utc() -> str:
@@ -96,12 +97,14 @@ class _RuntimeState:
         required_bearer_token: Optional[str],
         scoped_bearer_tokens: dict[str, ScopedTokenPolicy],
         guardrails: RuntimeGuardrails,
+        allow_unauthenticated_local_dev: bool,
     ) -> None:
         self.executor = executor
         self.state_manager = state_manager
         self.required_bearer_token = required_bearer_token
         self.scoped_bearer_tokens = scoped_bearer_tokens
         self.guardrails = guardrails
+        self.allow_unauthenticated_local_dev = allow_unauthenticated_local_dev
         self._guardrail_lock = threading.Lock()
         self.guardrail_counters: dict[str, int] = {"rate_limited": 0, "throttled": 0}
 
@@ -189,12 +192,13 @@ class _RuntimeASGIApp:
         scoped_policies = self._state.scoped_bearer_tokens
         required = self._state.required_bearer_token
 
-        if not required and not scoped_policies:
+        if self._state.allow_unauthenticated_local_dev and not required and not scoped_policies:
             return {
-                "actor_id": "anonymous",
+                "actor_id": "local-dev-anonymous",
                 "scopes": set(FULL_RUNTIME_SCOPES),
-                "auth_subject": "anonymous",
-                "policy_profile": "trusted",
+                "auth_subject": "unauthenticated_local_dev",
+                "policy_profile": "local_dev",
+                "local_dev_auth": True,
             }
 
         if not token:
@@ -296,6 +300,8 @@ class _RuntimeASGIApp:
         policy_template = auth_context.get("template")
         if policy_template:
             metadata["policy_template"] = policy_template
+        if auth_context.get("local_dev_auth"):
+            metadata["local_dev_auth"] = True
         return metadata
 
     def _check_run_access(self, run_id: str, auth_context: AuthContext, *, allow_any_scope: str) -> None:
@@ -559,6 +565,10 @@ class EAPRuntimeHTTPServer:
     """ASGI-backed runtime endpoints for external orchestrator integration."""
 
     @staticmethod
+    def _is_loopback_host(host: str) -> bool:
+        return host.strip().lower() in LOCAL_DEV_AUTH_LOOPBACK_HOSTS
+
+    @staticmethod
     def _normalize_scoped_bearer_tokens(
         scoped_bearer_tokens: Optional[dict[str, dict[str, object]]],
     ) -> dict[str, ScopedTokenPolicy]:
@@ -610,11 +620,17 @@ class EAPRuntimeHTTPServer:
         rate_limit_rules: Optional[dict[str, dict[str, object]]] = None,
         concurrency_limits: Optional[dict[str, object]] = None,
         max_request_body_bytes: int = DEFAULT_MAX_REQUEST_BODY_BYTES,
+        allow_unauthenticated_local_dev: bool = False,
     ) -> None:
         if port < 0 or port > 65535:
             raise ValueError("port must be between 0 and 65535")
         if max_request_body_bytes <= 0:
             raise ValueError("max_request_body_bytes must be greater than 0")
+        if allow_unauthenticated_local_dev and not self._is_loopback_host(host):
+            raise ValueError(
+                "allow_unauthenticated_local_dev requires a loopback host "
+                "(127.0.0.1, localhost, or ::1)."
+            )
 
         self._host = host
         self._configured_port = port
@@ -631,7 +647,13 @@ class EAPRuntimeHTTPServer:
                 rate_limit_rules=normalized_rate_limits,
                 concurrency_limits=normalized_concurrency_limits,
             ),
+            allow_unauthenticated_local_dev=allow_unauthenticated_local_dev,
         )
+        if allow_unauthenticated_local_dev:
+            print(
+                "[runtime:warning] unauthenticated local-dev auth is enabled; "
+                "use only on loopback development hosts."
+            )
         self._app = _RuntimeASGIApp(self._state, max_request_body_bytes=max_request_body_bytes)
         self._config = uvicorn.Config(
             self._app,

--- a/scripts/eap_runtime_service.py
+++ b/scripts/eap_runtime_service.py
@@ -40,6 +40,14 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Optional admin bearer token for /v1/eap/* endpoints.",
     )
     parser.add_argument(
+        "--allow-unauthenticated-local-dev",
+        action="store_true",
+        help=(
+            "Explicit local-development escape hatch. Allows unauthenticated full-scope runtime access "
+            "only when binding to 127.0.0.1, localhost, or ::1. Never use in production."
+        ),
+    )
+    parser.add_argument(
         "--scoped-auth-config",
         default="",
         help=(
@@ -168,7 +176,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"[runtime:error] failed to load --guardrails-config: {exc}")
         return 1
 
-    if not bearer_token and not scoped_tokens:
+    if args.allow_unauthenticated_local_dev and args.host.strip().lower() not in {"127.0.0.1", "localhost", "::1"}:
+        print("[runtime:error] --allow-unauthenticated-local-dev requires --host 127.0.0.1, localhost, or ::1.")
+        return 1
+
+    if not bearer_token and not scoped_tokens and not args.allow_unauthenticated_local_dev:
         print("[runtime:error] provide --bearer-token and/or --scoped-auth-config.")
         return 1
 
@@ -190,6 +202,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         rate_limit_rules=rate_limit_rules or None,
         concurrency_limits=concurrency_limits or None,
         max_request_body_bytes=args.max_request_body_bytes,
+        allow_unauthenticated_local_dev=args.allow_unauthenticated_local_dev,
     ).start()
 
     stop_event = threading.Event()
@@ -205,6 +218,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"[runtime] base_url={server.base_url}")
     print(f"[runtime] db_path={db_path}")
     print(f"[runtime] policy_profile={active_policy_profile}")
+    print(f"[runtime] allow_unauthenticated_local_dev={args.allow_unauthenticated_local_dev}")
+    if args.allow_unauthenticated_local_dev:
+        print("[runtime:warning] unauthenticated local-dev auth is enabled; do not expose this service remotely.")
     print(f"[runtime] scoped_auth_tokens={len(scoped_tokens)}")
     print(f"[runtime] rate_limits={json.dumps(normalized_rate_limits, sort_keys=True, default=lambda o: o.__dict__)}")
     print(f"[runtime] concurrency_limits={json.dumps(normalized_concurrency_limits, sort_keys=True)}")

--- a/tests/contract/test_runtime_auth_scopes.py
+++ b/tests/contract/test_runtime_auth_scopes.py
@@ -25,6 +25,94 @@ ECHO_SCHEMA = {
 }
 
 
+class RuntimeAuthFailClosedContractTest(unittest.TestCase):
+    def setUp(self) -> None:
+        fd, self.db_path = tempfile.mkstemp(prefix="eap-auth-fail-closed-", suffix=".db")
+        os.close(fd)
+
+        self.state_manager = StateManager(db_path=self.db_path)
+        registry = ToolRegistry()
+        registry.register("echo_text", echo_text, ECHO_SCHEMA)
+        self.executor = AsyncLocalExecutor(self.state_manager, registry)
+
+    def tearDown(self) -> None:
+        if hasattr(self, "server"):
+            self.server.stop()
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_runtime_auth_fails_closed_without_config(self) -> None:
+        self.server = EAPRuntimeHTTPServer(
+            executor=self.executor,
+            state_manager=self.state_manager,
+        ).start()
+        time.sleep(0.05)
+
+        response = requests.post(
+            f"{self.server.base_url}/v1/eap/macro/execute",
+            json={
+                "macro": {
+                    "steps": [
+                        {
+                            "step_id": "step_1",
+                            "tool_name": "echo_text",
+                            "arguments": {"text": "hello"},
+                        }
+                    ]
+                }
+            },
+            timeout=5,
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["error_type"], "unauthorized")
+
+    def test_local_dev_auth_escape_hatch_is_explicit_and_marked(self) -> None:
+        self.server = EAPRuntimeHTTPServer(
+            executor=self.executor,
+            state_manager=self.state_manager,
+            allow_unauthenticated_local_dev=True,
+        ).start()
+        time.sleep(0.05)
+
+        response = requests.post(
+            f"{self.server.base_url}/v1/eap/macro/execute",
+            json={
+                "macro": {
+                    "steps": [
+                        {
+                            "step_id": "step_1",
+                            "tool_name": "echo_text",
+                            "arguments": {"text": "hello"},
+                        }
+                    ]
+                }
+            },
+            timeout=5,
+        )
+        self.assertEqual(response.status_code, 200)
+        run_id = response.json()["metadata"]["execution_run_id"]
+
+        run_response = requests.get(
+            f"{self.server.base_url}/v1/eap/runs/{run_id}",
+            timeout=5,
+        )
+        self.assertEqual(run_response.status_code, 200)
+        actor_metadata = run_response.json()["actor_metadata"]
+        self.assertEqual(actor_metadata["actor_id"], "local-dev-anonymous")
+        self.assertEqual(actor_metadata["auth_subject"], "unauthenticated_local_dev")
+        self.assertEqual(actor_metadata["policy_profile"], "local_dev")
+        self.assertTrue(actor_metadata["local_dev_auth"])
+
+    def test_local_dev_auth_escape_hatch_rejects_remote_bind(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires a loopback host"):
+            EAPRuntimeHTTPServer(
+                executor=self.executor,
+                state_manager=self.state_manager,
+                host="0.0.0.0",
+                allow_unauthenticated_local_dev=True,
+            )
+
+
 class RuntimeAuthScopesContractTest(unittest.TestCase):
     def setUp(self) -> None:
         fd, self.db_path = tempfile.mkstemp(prefix="eap-auth-contract-", suffix=".db")


### PR DESCRIPTION
## Summary
- remove anonymous full-scope runtime access when no auth config is provided
- add explicit loopback-only `allow_unauthenticated_local_dev` escape hatch and service flag
- preserve local-dev auth markers in run actor metadata
- update self-hosted/governance/troubleshooting docs and Phase 13 tracking

Completes GEN-203.

## Validation
- ruff check . --select E9,F63,F7,F82
- mypy --follow-imports=skip eap/environment/safe_eval.py eap/environment/executor.py eap/runtime/auth_scopes.py eap/runtime/guardrails.py eap/runtime/http_api.py
- pytest -q
- RUN_PACKAGING_SMOKE=1 pytest -q tests/packaging/test_install_smoke.py
- python -m build
- pip-audit

Note: package build still emits the known non-blocking setuptools `project.license` metadata deprecation warning; cleanup is deferred per roadmap note.