### PR TITLE
EAP-124 sandbox local file tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,8 @@ EAP_LOG_LEVEL=INFO
 EAP_LOG_FORMAT=json
 # Legacy override (optional): 1/true/yes enables JSON, 0/false/no disables JSON
 EAP_LOG_JSON=
+
+# Built-in file tools sandbox root (optional).
+# Defaults to the current working directory. Set this to a dedicated workspace
+# when exposing read_local_file/write_local_file/list_local_directory to agents.
+EAP_FILE_TOOL_ROOT=

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,12 @@ Executor concurrency/rate limits:
   - Example:
     - `{"scrape_url":{"max_concurrency":2,"requests_per_second":5.0,"burst_capacity":2}}`
 
+Built-in file tools:
+- `EAP_FILE_TOOL_ROOT` (optional directory path)
+  - Defaults to the current working directory.
+  - `read_local_file`, `write_local_file`, and `list_local_directory` reject paths that resolve outside this root.
+  - Use a dedicated workspace directory when exposing file tools to an agent.
+
 Pointer janitor (dashboard):
 - `EAP_POINTER_JANITOR_ENABLED` (default: enabled)
 - `EAP_POINTER_JANITOR_INTERVAL_SECONDS` (default: `300`)
@@ -106,3 +112,4 @@ For streaming compatibility across providers and gateways, see [`streaming_compa
 - Executor global concurrency must be a positive integer.
 - Global burst capacity requires global RPS to be set.
 - Per-tool limits JSON must be an object keyed by non-empty tool names.
+- `EAP_FILE_TOOL_ROOT`, when set, must point to an existing directory.

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -64,7 +64,7 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 | 34 | `EAP-121` | `GEN-201` | `Done` | Add import and package compatibility migration tests |
 | 35 | `EAP-122` | `GEN-202` | `Done` | Replace runtime HTTP server with production ASGI path |
 | 36 | `EAP-123` | `GEN-203` | `Done` | Fail-closed runtime auth defaults |
-| 37 | `EAP-124` | `GEN-204` | `Todo` | Sandbox local file tools |
+| 37 | `EAP-124` | `GEN-204` | `Done` | Sandbox local file tools |
 | 38 | `EAP-125` | `GEN-205` | `Todo` | Add SSRF protection and streaming byte caps to web tools |
 | 39 | `EAP-126` | `GEN-206` | `Todo` | Add macro cycle detection and execution timeout controls |
 | 40 | `EAP-127` | `GEN-207` | `Todo` | Harden connection pooling and request lifecycle |
@@ -73,4 +73,4 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-123` is complete; `EAP-124` is the next ordered `Todo`.
+Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-124` is complete; `EAP-125` is the next ordered `Todo`.

--- a/docs/phase13_production_hardening_roadmap.md
+++ b/docs/phase13_production_hardening_roadmap.md
@@ -10,7 +10,7 @@ Current status:
 - [x] `EAP-121` add import and package compatibility migration tests (`GEN-201`)
 - [x] `EAP-122` replace runtime HTTP server with production ASGI path (`GEN-202`)
 - [x] `EAP-123` fail-closed runtime auth defaults (`GEN-203`)
-- [ ] `EAP-124` sandbox local file tools (`GEN-204`)
+- [x] `EAP-124` sandbox local file tools (`GEN-204`)
 - [ ] `EAP-125` add SSRF protection and streaming byte caps to web tools (`GEN-205`)
 - [ ] `EAP-126` add macro cycle detection and execution timeout controls (`GEN-206`)
 - [ ] `EAP-127` harden connection pooling and request lifecycle (`GEN-207`)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,12 +4,22 @@ This document describes the built-in tools shipped in `eap.environment.tools`.
 
 ## File tools
 
+File tools run inside a filesystem sandbox:
+
+- Default sandbox root: current working directory.
+- Operator override: set `EAP_FILE_TOOL_ROOT=/path/to/workspace`.
+- Embedded callers can pass `sandbox_root` directly when registering wrapper functions.
+- Relative paths resolve under the sandbox root.
+- Absolute paths are allowed only when they resolve inside the sandbox root.
+- `..` traversal and symlinks that resolve outside the sandbox root are rejected.
+
 ### `read_local_file`
 - Purpose: Read UTF-8 text from a local file.
 - Parameters:
   - `file_path` (`string`, required, `minLength=1`)
   - `max_characters` (`integer`, optional, `1..1000000`)
 - Notes:
+  - Path must resolve inside the file tool sandbox.
   - Rejects directories.
   - Fails when content exceeds `max_characters`.
   - Schema uses `additionalProperties: false`.
@@ -22,6 +32,7 @@ This document describes the built-in tools shipped in `eap.environment.tools`.
   - `mode` (`string`, optional, enum: `overwrite|append`)
   - `create_directories` (`boolean`, optional)
 - Notes:
+  - Path must resolve inside the file tool sandbox.
   - Can create parent directories when `create_directories=true`.
   - Rejects directory paths.
   - Schema uses `additionalProperties: false`.
@@ -34,6 +45,7 @@ This document describes the built-in tools shipped in `eap.environment.tools`.
   - `include_hidden` (`boolean`, optional)
   - `max_entries` (`integer`, optional, `1..1000`)
 - Notes:
+  - Directory and returned entries must resolve inside the file tool sandbox.
   - Output includes `entries`, `entry_count`, and `truncated`.
   - Schema uses `additionalProperties: false`.
 

--- a/eap/environment/tools/file_tools.py
+++ b/eap/environment/tools/file_tools.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 # environment/tools/file_tools.py
 import json
 import logging
 import os
+from pathlib import Path
+from typing import Optional
 
 logger = logging.getLogger("eap.environment.tools.file_tools")
 
 DEFAULT_MAX_READ_CHARACTERS = 200000
 DEFAULT_MAX_LIST_ENTRIES = 200
+FILE_TOOL_ROOT_ENV = "EAP_FILE_TOOL_ROOT"
 
 
 def _validate_non_empty_path(value: str, field_name: str) -> None:
@@ -14,35 +19,106 @@ def _validate_non_empty_path(value: str, field_name: str) -> None:
         raise ValueError(f"'{field_name}' must be a non-empty string.")
 
 
-def _build_entry_record(base_dir: str, full_path: str, is_dir: bool) -> dict:
-    relative = os.path.relpath(full_path, base_dir)
+def _sandbox_root(sandbox_root: Optional[str] = None) -> Path:
+    raw_root = sandbox_root or os.environ.get(FILE_TOOL_ROOT_ENV) or os.getcwd()
+    root = Path(raw_root).expanduser().resolve()
+    if not root.exists():
+        raise FileNotFoundError(f"File tool sandbox root does not exist: {root}")
+    if not root.is_dir():
+        raise NotADirectoryError(f"File tool sandbox root is not a directory: {root}")
+    return root
+
+
+def _resolve_sandbox_path(path_value: str, *, field_name: str, sandbox_root: Optional[str] = None) -> tuple[Path, Path]:
+    _validate_non_empty_path(path_value, field_name)
+    root = _sandbox_root(sandbox_root)
+    requested = Path(path_value).expanduser()
+    candidate = requested if requested.is_absolute() else root / requested
+    resolved = candidate.resolve(strict=False)
+    if resolved != root and root not in resolved.parents:
+        raise PermissionError(
+            f"Path '{path_value}' escapes the configured file tool sandbox root '{root}'."
+        )
+    return root, resolved
+
+
+def _assert_existing_path_in_sandbox(
+    path_value: str,
+    *,
+    field_name: str,
+    sandbox_root: Optional[str] = None,
+) -> tuple[Path, Path]:
+    root, resolved = _resolve_sandbox_path(path_value, field_name=field_name, sandbox_root=sandbox_root)
+    if not resolved.exists():
+        raise FileNotFoundError(f"Path '{path_value}' not found inside file tool sandbox '{root}'.")
+    # Resolve again with strict semantics so existing symlinks cannot escape after the loose pass.
+    strict_resolved = resolved.resolve(strict=True)
+    if strict_resolved != root and root not in strict_resolved.parents:
+        raise PermissionError(
+            f"Path '{path_value}' escapes the configured file tool sandbox root '{root}'."
+        )
+    return root, strict_resolved
+
+
+def _assert_write_target_in_sandbox(file_path: str, *, sandbox_root: Optional[str] = None) -> tuple[Path, Path]:
+    root, resolved = _resolve_sandbox_path(file_path, field_name="file_path", sandbox_root=sandbox_root)
+    parent = resolved.parent
+    if parent.exists():
+        parent_resolved = parent.resolve(strict=True)
+        if parent_resolved != root and root not in parent_resolved.parents:
+            raise PermissionError(
+                f"Parent directory for '{file_path}' escapes the configured file tool sandbox root '{root}'."
+            )
+        if resolved.exists():
+            target_resolved = resolved.resolve(strict=True)
+            if target_resolved != root and root not in target_resolved.parents:
+                raise PermissionError(
+                    f"Path '{file_path}' escapes the configured file tool sandbox root '{root}'."
+                )
+    return root, resolved
+
+
+def _build_entry_record(sandbox_root: Path, base_dir: Path, full_path: Path, is_dir: bool) -> dict:
+    resolved = full_path.resolve(strict=True)
+    if resolved != sandbox_root and sandbox_root not in resolved.parents:
+        raise PermissionError(
+            f"Directory entry '{full_path}' escapes the configured file tool sandbox root '{sandbox_root}'."
+        )
+    relative = os.path.relpath(resolved, base_dir)
     return {
         "path": relative,
         "type": "directory" if is_dir else "file",
-        "size_bytes": None if is_dir else os.path.getsize(full_path),
+        "size_bytes": None if is_dir else resolved.stat().st_size,
     }
 
 
-def read_local_file(file_path: str, max_characters: int = DEFAULT_MAX_READ_CHARACTERS) -> str:
+def read_local_file(
+    file_path: str,
+    max_characters: int = DEFAULT_MAX_READ_CHARACTERS,
+    sandbox_root: Optional[str] = None,
+) -> str:
     """Reads UTF-8 text from a local file with an explicit size guard."""
     logger.info(
         "tool invoked",
         extra={"tool_name": "read_local_file"},
     )
-    _validate_non_empty_path(file_path, "file_path")
     if max_characters < 1:
         raise ValueError("'max_characters' must be >= 1.")
-    if not os.path.exists(file_path):
-        raise FileNotFoundError(f"File '{file_path}' not found.")
-    if os.path.isdir(file_path):
+    root, resolved_path = _assert_existing_path_in_sandbox(
+        file_path,
+        field_name="file_path",
+        sandbox_root=sandbox_root,
+    )
+    if resolved_path.is_dir():
         raise IsADirectoryError(f"Path '{file_path}' is a directory, not a file.")
 
-    with open(file_path, "r", encoding="utf-8") as handle:
+    with resolved_path.open("r", encoding="utf-8") as handle:
         content = handle.read(max_characters + 1)
 
     if len(content) > max_characters:
         raise ValueError(
-            f"File '{file_path}' exceeds max_characters={max_characters}. Increase the limit to read this file."
+            f"File '{file_path}' inside sandbox '{root}' exceeds max_characters={max_characters}. "
+            "Increase the limit to read this file."
         )
     return content
 
@@ -52,34 +128,39 @@ def write_local_file(
     content: str,
     mode: str = "overwrite",
     create_directories: bool = False,
+    sandbox_root: Optional[str] = None,
 ) -> str:
     """Writes or appends UTF-8 text to a local file."""
     logger.info(
         "tool invoked",
         extra={"tool_name": "write_local_file"},
     )
-    _validate_non_empty_path(file_path, "file_path")
     if mode not in ("overwrite", "append"):
         raise ValueError("'mode' must be one of: overwrite, append.")
 
-    absolute_path = os.path.abspath(file_path)
-    parent = os.path.dirname(absolute_path)
-    if parent and not os.path.exists(parent):
+    root, absolute_path = _assert_write_target_in_sandbox(file_path, sandbox_root=sandbox_root)
+    parent = absolute_path.parent
+    if not parent.exists():
         if create_directories:
-            os.makedirs(parent, exist_ok=True)
+            parent.mkdir(parents=True, exist_ok=True)
+            parent_resolved = parent.resolve(strict=True)
+            if parent_resolved != root and root not in parent_resolved.parents:
+                raise PermissionError(
+                    f"Parent directory for '{file_path}' escapes the configured file tool sandbox root '{root}'."
+                )
         else:
             raise FileNotFoundError(
                 f"Parent directory '{parent}' not found. Set create_directories=True to create it."
             )
-    if os.path.isdir(absolute_path):
+    if absolute_path.exists() and absolute_path.is_dir():
         raise IsADirectoryError(f"Path '{file_path}' is a directory, not a file.")
 
     file_mode = "w" if mode == "overwrite" else "a"
-    with open(absolute_path, file_mode, encoding="utf-8") as handle:
+    with absolute_path.open(file_mode, encoding="utf-8") as handle:
         written = handle.write(content)
 
     action = "Wrote" if mode == "overwrite" else "Appended"
-    return f"{action} {written} characters to '{file_path}'."
+    return f"{action} {written} characters to '{file_path}' inside sandbox '{root}'."
 
 
 def list_local_directory(
@@ -87,21 +168,23 @@ def list_local_directory(
     recursive: bool = False,
     include_hidden: bool = False,
     max_entries: int = DEFAULT_MAX_LIST_ENTRIES,
+    sandbox_root: Optional[str] = None,
 ) -> str:
     """Lists local directory entries and returns structured JSON output."""
     logger.info(
         "tool invoked",
         extra={"tool_name": "list_local_directory"},
     )
-    _validate_non_empty_path(directory_path, "directory_path")
     if max_entries < 1:
         raise ValueError("'max_entries' must be >= 1.")
-    if not os.path.exists(directory_path):
-        raise FileNotFoundError(f"Directory '{directory_path}' not found.")
-    if not os.path.isdir(directory_path):
+    sandbox_root_path, base_dir = _assert_existing_path_in_sandbox(
+        directory_path,
+        field_name="directory_path",
+        sandbox_root=sandbox_root,
+    )
+    if not base_dir.is_dir():
         raise NotADirectoryError(f"Path '{directory_path}' is not a directory.")
 
-    base_dir = os.path.abspath(directory_path)
     entries = []
     truncated = False
 
@@ -109,7 +192,8 @@ def list_local_directory(
         return include_hidden or not name.startswith(".")
 
     if recursive:
-        for root, dirnames, filenames in os.walk(base_dir):
+        for current_root, dirnames, filenames in os.walk(base_dir):
+            root_path = Path(current_root)
             if not include_hidden:
                 dirnames[:] = [dirname for dirname in dirnames if _is_visible(dirname)]
 
@@ -117,8 +201,8 @@ def list_local_directory(
                 if len(entries) >= max_entries:
                     truncated = True
                     break
-                full_path = os.path.join(root, dirname)
-                entries.append(_build_entry_record(base_dir, full_path, is_dir=True))
+                full_path = root_path / dirname
+                entries.append(_build_entry_record(sandbox_root_path, base_dir, full_path, is_dir=True))
             if truncated:
                 break
 
@@ -128,8 +212,8 @@ def list_local_directory(
                 if len(entries) >= max_entries:
                     truncated = True
                     break
-                full_path = os.path.join(root, filename)
-                entries.append(_build_entry_record(base_dir, full_path, is_dir=False))
+                full_path = root_path / filename
+                entries.append(_build_entry_record(sandbox_root_path, base_dir, full_path, is_dir=False))
             if truncated:
                 break
     else:
@@ -143,10 +227,11 @@ def list_local_directory(
             if len(entries) >= max_entries:
                 truncated = True
                 break
-            entries.append(_build_entry_record(base_dir, entry.path, is_dir=entry.is_dir()))
+            entries.append(_build_entry_record(sandbox_root_path, base_dir, Path(entry.path), is_dir=entry.is_dir()))
 
     payload = {
-        "directory_path": base_dir,
+        "directory_path": str(base_dir),
+        "sandbox_root": str(sandbox_root_path),
         "recursive": recursive,
         "include_hidden": include_hidden,
         "max_entries": max_entries,

--- a/starter_packs/doc_ops.py
+++ b/starter_packs/doc_ops.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import os
 import tempfile
+from functools import partial
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -18,6 +19,13 @@ from eap.environment.tools import (
     write_local_file,
 )
 from eap.protocol import BatchedMacroRequest, StateManager, ToolCall
+
+
+def _nearest_existing_parent(path: Path) -> Path:
+    for candidate in [path.parent, *path.parents]:
+        if candidate.exists():
+            return candidate.resolve()
+    return Path.cwd().resolve()
 
 
 def run_doc_ops(
@@ -40,9 +48,17 @@ def run_doc_ops(
 
     state_manager = StateManager(db_path=db_path)
     registry = ToolRegistry()
-    registry.register("read_local_file", read_local_file, READ_FILE_SCHEMA)
+    registry.register(
+        "read_local_file",
+        partial(read_local_file, sandbox_root=str(input_path.parent)),
+        READ_FILE_SCHEMA,
+    )
     registry.register("analyze_data", analyze_data, ANALYZE_SCHEMA)
-    registry.register("write_local_file", write_local_file, WRITE_FILE_SCHEMA)
+    registry.register(
+        "write_local_file",
+        partial(write_local_file, sandbox_root=str(_nearest_existing_parent(output_path))),
+        WRITE_FILE_SCHEMA,
+    )
     executor = AsyncLocalExecutor(state_manager, registry)
 
     try:

--- a/starter_packs/local_etl.py
+++ b/starter_packs/local_etl.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import os
 import tempfile
+from functools import partial
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -49,6 +50,13 @@ TRANSFORM_SALES_SCHEMA = {
 }
 
 
+def _nearest_existing_parent(path: Path) -> Path:
+    for candidate in [path.parent, *path.parents]:
+        if candidate.exists():
+            return candidate.resolve()
+    return Path.cwd().resolve()
+
+
 def run_local_etl(
     input_file: str,
     output_file: str,
@@ -68,9 +76,17 @@ def run_local_etl(
 
     state_manager = StateManager(db_path=db_path)
     registry = ToolRegistry()
-    registry.register("read_local_file", read_local_file, READ_FILE_SCHEMA)
+    registry.register(
+        "read_local_file",
+        partial(read_local_file, sandbox_root=str(input_path.parent)),
+        READ_FILE_SCHEMA,
+    )
     registry.register("transform_sales_jsonl", transform_sales_jsonl, TRANSFORM_SALES_SCHEMA)
-    registry.register("write_local_file", write_local_file, WRITE_FILE_SCHEMA)
+    registry.register(
+        "write_local_file",
+        partial(write_local_file, sandbox_root=str(_nearest_existing_parent(output_path))),
+        WRITE_FILE_SCHEMA,
+    )
     executor = AsyncLocalExecutor(state_manager, registry)
 
     try:

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,6 +1,7 @@
 import tempfile
 import unittest
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from eap.environment.tools.example_tools import analyze_data, fetch_user_data
@@ -18,22 +19,22 @@ from eap.environment.tools.web_tools import (
 
 class ToolModuleTest(unittest.TestCase):
     def test_read_local_file_success(self) -> None:
-        with tempfile.NamedTemporaryFile(mode="w", delete=True) as handle:
-            handle.write("hello")
-            handle.flush()
-            content = read_local_file(handle.name)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = Path(tmp_dir) / "notes.txt"
+            file_path.write_text("hello", encoding="utf-8")
+            content = read_local_file("notes.txt", sandbox_root=tmp_dir)
         self.assertEqual(content, "hello")
 
     def test_read_local_file_missing_raises(self) -> None:
-        with self.assertRaises(FileNotFoundError):
-            read_local_file("/tmp/does-not-exist-eap.txt")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertRaises(FileNotFoundError):
+                read_local_file("does-not-exist-eap.txt", sandbox_root=tmp_dir)
 
     def test_write_local_file_overwrite_and_append(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = f"{tmp_dir}/notes.txt"
-            write_result = write_local_file(file_path, "hello")
-            append_result = write_local_file(file_path, " world", mode="append")
-            content = read_local_file(file_path)
+            write_result = write_local_file("notes.txt", "hello", sandbox_root=tmp_dir)
+            append_result = write_local_file("notes.txt", " world", mode="append", sandbox_root=tmp_dir)
+            content = read_local_file("notes.txt", sandbox_root=tmp_dir)
 
         self.assertIn("Wrote 5 characters", write_result)
         self.assertIn("Appended 6 characters", append_result)
@@ -41,17 +42,16 @@ class ToolModuleTest(unittest.TestCase):
 
     def test_write_local_file_missing_parent_raises(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            missing_parent_path = f"{tmp_dir}/missing/notes.txt"
             with self.assertRaises(FileNotFoundError):
-                write_local_file(missing_parent_path, "hello")
+                write_local_file("missing/notes.txt", "hello", sandbox_root=tmp_dir)
 
     def test_list_local_directory_non_recursive_excludes_hidden(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            write_local_file(f"{tmp_dir}/a.txt", "a")
-            write_local_file(f"{tmp_dir}/.hidden.txt", "secret")
-            write_local_file(f"{tmp_dir}/sub/b.txt", "b", create_directories=True)
+            write_local_file("a.txt", "a", sandbox_root=tmp_dir)
+            write_local_file(".hidden.txt", "secret", sandbox_root=tmp_dir)
+            write_local_file("sub/b.txt", "b", create_directories=True, sandbox_root=tmp_dir)
 
-            output_json = list_local_directory(tmp_dir)
+            output_json = list_local_directory(".", sandbox_root=tmp_dir)
 
         self.assertIn('"path": "a.txt"', output_json)
         self.assertIn('"path": "sub"', output_json)
@@ -60,14 +60,53 @@ class ToolModuleTest(unittest.TestCase):
 
     def test_list_local_directory_recursive_and_limit(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            write_local_file(f"{tmp_dir}/a.txt", "a")
-            write_local_file(f"{tmp_dir}/sub/b.txt", "b", create_directories=True)
-            write_local_file(f"{tmp_dir}/sub/c.txt", "c")
+            write_local_file("a.txt", "a", sandbox_root=tmp_dir)
+            write_local_file("sub/b.txt", "b", create_directories=True, sandbox_root=tmp_dir)
+            write_local_file("sub/c.txt", "c", sandbox_root=tmp_dir)
 
-            output_json = list_local_directory(tmp_dir, recursive=True, max_entries=2)
+            output_json = list_local_directory(".", recursive=True, max_entries=2, sandbox_root=tmp_dir)
 
         self.assertIn('"truncated": true', output_json)
         self.assertIn('"entry_count": 2', output_json)
+
+    def test_file_tools_reject_traversal_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with tempfile.TemporaryDirectory() as outside_dir:
+                outside_file = Path(outside_dir) / "secret.txt"
+                outside_file.write_text("secret", encoding="utf-8")
+                traversal = f"../{Path(outside_dir).name}/secret.txt"
+                with self.assertRaises(PermissionError):
+                    read_local_file(traversal, sandbox_root=tmp_dir)
+
+    def test_file_tools_reject_absolute_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with tempfile.NamedTemporaryFile(mode="w", delete=True) as handle:
+                handle.write("secret")
+                handle.flush()
+                with self.assertRaises(PermissionError):
+                    read_local_file(handle.name, sandbox_root=tmp_dir)
+                with self.assertRaises(PermissionError):
+                    write_local_file(handle.name, "overwrite", sandbox_root=tmp_dir)
+
+    def test_file_tools_reject_symlink_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with tempfile.NamedTemporaryFile(mode="w", delete=True) as handle:
+                handle.write("secret")
+                handle.flush()
+                link_path = root / "escaped-link.txt"
+                link_path.symlink_to(handle.name)
+                with self.assertRaises(PermissionError):
+                    read_local_file("escaped-link.txt", sandbox_root=tmp_dir)
+                with self.assertRaises(PermissionError):
+                    list_local_directory(".", sandbox_root=tmp_dir)
+
+    def test_file_tool_root_env_configures_default_sandbox(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = Path(tmp_dir) / "env-root.txt"
+            file_path.write_text("configured", encoding="utf-8")
+            with patch.dict("os.environ", {"EAP_FILE_TOOL_ROOT": tmp_dir}):
+                self.assertEqual(read_local_file("env-root.txt"), "configured")
 
     def test_scrape_url_success(self) -> None:
         response = MagicMock()


### PR DESCRIPTION
## Summary
- add a filesystem sandbox for built-in read/write/list file tools
- default file-tool root to cwd with `EAP_FILE_TOOL_ROOT` operator override
- block traversal, absolute path escapes, and symlink escapes
- preserve starter-pack behavior by registering file tools with explicit roots
- update tool/configuration docs and Phase 13 tracking

Completes GEN-204.

## Validation
- ruff check . --select E9,F63,F7,F82
- mypy --follow-imports=skip eap/environment/safe_eval.py eap/environment/executor.py eap/runtime/auth_scopes.py eap/runtime/guardrails.py eap/runtime/http_api.py
- pytest -q
- RUN_PACKAGING_SMOKE=1 pytest -q tests/packaging/test_install_smoke.py
- python -m build
- pip-audit

Note: package build still emits the known non-blocking setuptools `project.license` metadata deprecation warning; cleanup is deferred per roadmap note.