### PR TITLE
EAP-125 harden web tools against SSRF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,8 @@ EAP_LOG_JSON=
 # Defaults to the current working directory. Set this to a dedicated workspace
 # when exposing read_local_file/write_local_file/list_local_directory to agents.
 EAP_FILE_TOOL_ROOT=
+
+# Built-in web tools SSRF host allowlist (optional).
+# Comma-separated exact hosts/IPs allowed even when they resolve to private or
+# loopback addresses. Leave empty for safe default blocking.
+EAP_WEB_TOOL_HOST_ALLOWLIST=

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,14 @@ Built-in file tools:
   - `read_local_file`, `write_local_file`, and `list_local_directory` reject paths that resolve outside this root.
   - Use a dedicated workspace directory when exposing file tools to an agent.
 
+Built-in web tools:
+- `EAP_WEB_TOOL_HOST_ALLOWLIST` (optional comma-separated exact hosts/IPs)
+  - Defaults to empty.
+  - `scrape_url`, `fetch_json_url`, and `extract_links_from_url` reject hosts that resolve to private, loopback, link-local, reserved, multicast, metadata, or CGNAT addresses.
+  - Redirect targets are rechecked before each request.
+  - Responses are read as streams and fail as soon as `max_bytes` is exceeded.
+  - Add only hosts you intentionally expose to agent tools, for example `127.0.0.1,localhost` for a local-only demo.
+
 Pointer janitor (dashboard):
 - `EAP_POINTER_JANITOR_ENABLED` (default: enabled)
 - `EAP_POINTER_JANITOR_INTERVAL_SECONDS` (default: `300`)
@@ -113,3 +121,4 @@ For streaming compatibility across providers and gateways, see [`streaming_compa
 - Global burst capacity requires global RPS to be set.
 - Per-tool limits JSON must be an object keyed by non-empty tool names.
 - `EAP_FILE_TOOL_ROOT`, when set, must point to an existing directory.
+- `EAP_WEB_TOOL_HOST_ALLOWLIST` is read directly by built-in web tools as comma-separated exact host/IP values.

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -65,7 +65,7 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 | 35 | `EAP-122` | `GEN-202` | `Done` | Replace runtime HTTP server with production ASGI path |
 | 36 | `EAP-123` | `GEN-203` | `Done` | Fail-closed runtime auth defaults |
 | 37 | `EAP-124` | `GEN-204` | `Done` | Sandbox local file tools |
-| 38 | `EAP-125` | `GEN-205` | `Todo` | Add SSRF protection and streaming byte caps to web tools |
+| 38 | `EAP-125` | `GEN-205` | `Done` | Add SSRF protection and streaming byte caps to web tools |
 | 39 | `EAP-126` | `GEN-206` | `Todo` | Add macro cycle detection and execution timeout controls |
 | 40 | `EAP-127` | `GEN-207` | `Todo` | Harden connection pooling and request lifecycle |
 | 41 | `EAP-128` | `GEN-208` | `Todo` | Add production-hardening regression gatepack |
@@ -73,4 +73,4 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-124` is complete; `EAP-125` is the next ordered `Todo`.
+Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-125` is complete; `EAP-126` is the next ordered `Todo`.

--- a/docs/phase13_production_hardening_roadmap.md
+++ b/docs/phase13_production_hardening_roadmap.md
@@ -11,7 +11,7 @@ Current status:
 - [x] `EAP-122` replace runtime HTTP server with production ASGI path (`GEN-202`)
 - [x] `EAP-123` fail-closed runtime auth defaults (`GEN-203`)
 - [x] `EAP-124` sandbox local file tools (`GEN-204`)
-- [ ] `EAP-125` add SSRF protection and streaming byte caps to web tools (`GEN-205`)
+- [x] `EAP-125` add SSRF protection and streaming byte caps to web tools (`GEN-205`)
 - [ ] `EAP-126` add macro cycle detection and execution timeout controls (`GEN-206`)
 - [ ] `EAP-127` harden connection pooling and request lifecycle (`GEN-207`)
 - [ ] `EAP-128` add production-hardening regression gatepack (`GEN-208`)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -60,6 +60,9 @@ File tools run inside a filesystem sandbox:
   - `max_characters` (`integer`, optional, `1..500000`)
 - Notes:
   - URL must be `http` or `https`.
+  - Host DNS resolution must not target private, loopback, link-local, reserved, multicast, metadata, or CGNAT addresses unless explicitly allowlisted by the operator.
+  - Redirect targets are revalidated before fetching.
+  - Response bodies are streamed and fail as soon as `max_bytes` is exceeded.
   - Scripts/styles are removed before text extraction.
   - Schema uses `additionalProperties: false`.
 
@@ -70,6 +73,7 @@ File tools run inside a filesystem sandbox:
   - `timeout_seconds` (`integer`, optional, `1..120`)
   - `max_bytes` (`integer`, optional, `1..10000000`)
 - Notes:
+  - Uses the same SSRF protections, redirect checks, and streaming `max_bytes` enforcement as `scrape_url`.
   - Returns a runtime error when response is not valid JSON.
   - Schema uses `additionalProperties: false`.
 
@@ -83,8 +87,13 @@ File tools run inside a filesystem sandbox:
   - `max_bytes` (`integer`, optional, `1..10000000`)
   - `max_links` (`integer`, optional, `1..5000`)
 - Notes:
+  - Uses the same SSRF protections, redirect checks, and streaming `max_bytes` enforcement as `scrape_url`.
   - Output includes `links`, `link_count`, and `truncated`.
   - Schema uses `additionalProperties: false`.
+
+Operator configuration:
+- `EAP_WEB_TOOL_HOST_ALLOWLIST` can be set to a comma-separated list of exact hosts/IPs that may resolve to otherwise blocked addresses.
+- Leave the allowlist empty for the safe default when exposing web tools to agents.
 
 ## Interop tools
 

--- a/eap/environment/tools/web_tools.py
+++ b/eap/environment/tools/web_tools.py
@@ -1,7 +1,11 @@
 # environment/tools/web_tools.py
+import ipaddress
 import json
 import logging
-from typing import Dict, Optional
+import os
+import socket
+import time
+from typing import Dict, Iterable, Optional, Set
 from urllib.parse import urljoin, urlparse
 
 import requests
@@ -13,12 +17,81 @@ DEFAULT_TIMEOUT_SECONDS = 10
 DEFAULT_MAX_BYTES = 1_000_000
 DEFAULT_MAX_TEXT_CHARACTERS = 100_000
 DEFAULT_MAX_LINKS = 200
+DEFAULT_MAX_REDIRECTS = 5
+_STREAM_CHUNK_SIZE = 64 * 1024
+_CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
 
 
-def _validate_http_url(url: str) -> None:
+def _normalize_host(host: str) -> str:
+    return host.strip().lower().rstrip(".")
+
+
+def _load_host_allowlist(extra_allowlist: Optional[Iterable[str]] = None) -> Set[str]:
+    raw_hosts = os.environ.get("EAP_WEB_TOOL_HOST_ALLOWLIST", "")
+    hosts = {_normalize_host(host) for host in raw_hosts.split(",") if host.strip()}
+    if extra_allowlist:
+        hosts.update(_normalize_host(host) for host in extra_allowlist if host.strip())
+    return hosts
+
+
+def _is_unsafe_ip(address: str) -> bool:
+    parsed = ipaddress.ip_address(address)
+    return (
+        parsed.is_private
+        or parsed.is_loopback
+        or parsed.is_link_local
+        or parsed.is_reserved
+        or parsed.is_multicast
+        or parsed in _CGNAT_NETWORK
+    )
+
+
+def _validate_safe_url(url: str, host_allowlist: Optional[Iterable[str]] = None) -> None:
     parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+    if parsed.scheme not in ("http", "https") or not parsed.netloc or not parsed.hostname:
         raise ValueError(f"Invalid URL '{url}'. URL must include http/https scheme and host.")
+
+    host = _normalize_host(parsed.hostname)
+    allowlist = _load_host_allowlist(host_allowlist)
+    if host in allowlist:
+        return
+
+    try:
+        address_infos = socket.getaddrinfo(host, parsed.port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise ValueError(f"URL host '{host}' could not be resolved safely.") from exc
+
+    resolved_addresses = {info[4][0] for info in address_infos if info and info[4]}
+    if not resolved_addresses:
+        raise ValueError(f"URL host '{host}' did not resolve to any address.")
+
+    for address in resolved_addresses:
+        if address in allowlist:
+            continue
+        try:
+            if _is_unsafe_ip(address):
+                raise ValueError(f"URL host '{host}' resolved to disallowed address '{address}'.")
+        except ValueError:
+            raise
+
+
+def _response_text(response: requests.Response, body_bytes: bytes) -> str:
+    if response.encoding:
+        return body_bytes.decode(response.encoding, errors="replace")
+    return body_bytes.decode("utf-8", errors="replace")
+
+
+def _read_streaming_body(response: requests.Response, max_bytes: int, deadline: float) -> bytes:
+    body = bytearray()
+    for chunk in response.iter_content(chunk_size=_STREAM_CHUNK_SIZE):
+        if time.monotonic() > deadline:
+            raise TimeoutError("Response body streaming exceeded timeout_seconds budget.")
+        if not chunk:
+            continue
+        body.extend(chunk)
+        if len(body) > max_bytes:
+            raise ValueError(f"Response body exceeds max_bytes={max_bytes}.")
+    return bytes(body)
 
 
 def _load_text_response(
@@ -26,22 +99,47 @@ def _load_text_response(
     timeout_seconds: int,
     max_bytes: int,
     headers: Optional[Dict[str, str]] = None,
+    host_allowlist: Optional[Iterable[str]] = None,
 ) -> str:
     if timeout_seconds < 1:
         raise ValueError("'timeout_seconds' must be >= 1.")
     if max_bytes < 1:
         raise ValueError("'max_bytes' must be >= 1.")
 
-    response = requests.get(url, timeout=timeout_seconds, headers=headers)
-    response.raise_for_status()
+    current_url = url
+    request_headers = dict(headers or {})
+    deadline = time.monotonic() + float(timeout_seconds * 2)
 
-    body_bytes = response.content
-    if len(body_bytes) > max_bytes:
-        raise ValueError(f"Response body exceeds max_bytes={max_bytes}.")
+    with requests.Session() as session:
+        for redirect_count in range(DEFAULT_MAX_REDIRECTS + 1):
+            _validate_safe_url(current_url, host_allowlist=host_allowlist)
+            if time.monotonic() > deadline:
+                raise TimeoutError("HTTP request exceeded timeout_seconds budget before completion.")
 
-    if response.encoding:
-        return body_bytes.decode(response.encoding, errors="replace")
-    return body_bytes.decode("utf-8", errors="replace")
+            response = session.get(
+                current_url,
+                timeout=timeout_seconds,
+                headers=request_headers,
+                stream=True,
+                allow_redirects=False,
+            )
+            try:
+                if response.is_redirect or response.is_permanent_redirect:
+                    if redirect_count >= DEFAULT_MAX_REDIRECTS:
+                        raise ValueError(f"Too many redirects fetching URL '{url}'.")
+                    location = response.headers.get("Location")
+                    if not location:
+                        raise ValueError(f"Redirect response for URL '{current_url}' omitted Location header.")
+                    current_url = urljoin(current_url, location)
+                    continue
+
+                response.raise_for_status()
+                body_bytes = _read_streaming_body(response, max_bytes=max_bytes, deadline=deadline)
+                return _response_text(response, body_bytes)
+            finally:
+                response.close()
+
+    raise ValueError(f"Too many redirects fetching URL '{url}'.")
 
 
 def scrape_url(
@@ -49,18 +147,24 @@ def scrape_url(
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
     max_bytes: int = DEFAULT_MAX_BYTES,
     max_characters: int = DEFAULT_MAX_TEXT_CHARACTERS,
+    host_allowlist: Optional[Iterable[str]] = None,
 ) -> str:
     """Fetches and cleans text content from a URL."""
     logger.info(
         "tool invoked",
         extra={"tool_name": "scrape_url"},
     )
-    _validate_http_url(url)
+    _validate_safe_url(url, host_allowlist=host_allowlist)
     if max_characters < 1:
         raise ValueError("'max_characters' must be >= 1.")
 
     try:
-        text_html = _load_text_response(url, timeout_seconds=timeout_seconds, max_bytes=max_bytes)
+        text_html = _load_text_response(
+            url,
+            timeout_seconds=timeout_seconds,
+            max_bytes=max_bytes,
+            host_allowlist=host_allowlist,
+        )
         soup = BeautifulSoup(text_html, "html.parser")
 
         for script_or_style in soup(["script", "style"]):
@@ -83,13 +187,14 @@ def fetch_json_url(
     url: str,
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
     max_bytes: int = DEFAULT_MAX_BYTES,
+    host_allowlist: Optional[Iterable[str]] = None,
 ) -> str:
     """Fetches a URL and returns parsed JSON as pretty-printed text."""
     logger.info(
         "tool invoked",
         extra={"tool_name": "fetch_json_url"},
     )
-    _validate_http_url(url)
+    _validate_safe_url(url, host_allowlist=host_allowlist)
 
     try:
         body_text = _load_text_response(
@@ -97,6 +202,7 @@ def fetch_json_url(
             timeout_seconds=timeout_seconds,
             max_bytes=max_bytes,
             headers={"Accept": "application/json"},
+            host_allowlist=host_allowlist,
         )
         parsed = json.loads(body_text)
         return json.dumps(parsed, indent=2, sort_keys=True)
@@ -115,19 +221,25 @@ def extract_links_from_url(
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
     max_bytes: int = DEFAULT_MAX_BYTES,
     max_links: int = DEFAULT_MAX_LINKS,
+    host_allowlist: Optional[Iterable[str]] = None,
 ) -> str:
     """Extracts normalized links from a webpage and returns JSON metadata."""
     logger.info(
         "tool invoked",
         extra={"tool_name": "extract_links_from_url"},
     )
-    _validate_http_url(url)
+    _validate_safe_url(url, host_allowlist=host_allowlist)
     if max_links < 1:
         raise ValueError("'max_links' must be >= 1.")
 
     try:
         source_domain = urlparse(url).netloc
-        html = _load_text_response(url, timeout_seconds=timeout_seconds, max_bytes=max_bytes)
+        html = _load_text_response(
+            url,
+            timeout_seconds=timeout_seconds,
+            max_bytes=max_bytes,
+            host_allowlist=host_allowlist,
+        )
         soup = BeautifulSoup(html, "html.parser")
 
         links = []

--- a/starter_packs/research_assistant.py
+++ b/starter_packs/research_assistant.py
@@ -45,7 +45,11 @@ def run_research_assistant(
     source_url = f"http://127.0.0.1:{server.server_address[1]}/{html_path.name}"
     state_manager = StateManager(db_path=db_path)
     registry = ToolRegistry()
-    registry.register("scrape_url", scrape_url, SCRAPE_SCHEMA)
+    registry.register(
+        "scrape_url",
+        partial(scrape_url, host_allowlist={"127.0.0.1", "localhost"}),
+        SCRAPE_SCHEMA,
+    )
     registry.register("analyze_data", analyze_data, ANALYZE_SCHEMA)
     executor = AsyncLocalExecutor(state_manager, registry)
 

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,8 +1,9 @@
 import tempfile
 import unittest
 import json
+import requests
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from eap.environment.tools.example_tools import analyze_data, fetch_user_data
 from eap.environment.tools.file_tools import (
@@ -15,6 +16,38 @@ from eap.environment.tools.web_tools import (
     fetch_json_url,
     scrape_url,
 )
+
+
+class _MockStreamResponse:
+    def __init__(
+        self,
+        chunks: list[bytes],
+        *,
+        encoding: str = "utf-8",
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self._chunks = chunks
+        self.encoding = encoding
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.is_redirect = status_code in {301, 302, 303, 307, 308}
+        self.is_permanent_redirect = status_code in {301, 308}
+        self.closed = False
+        self.chunks_read = 0
+
+    def iter_content(self, chunk_size: int = 1) -> object:
+        del chunk_size
+        for chunk in self._chunks:
+            self.chunks_read += 1
+            yield chunk
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class ToolModuleTest(unittest.TestCase):
@@ -109,56 +142,100 @@ class ToolModuleTest(unittest.TestCase):
                 self.assertEqual(read_local_file("env-root.txt"), "configured")
 
     def test_scrape_url_success(self) -> None:
-        response = MagicMock()
-        response.content = b"<html><body><h1>Title</h1><p>Body</p></body></html>"
-        response.encoding = "utf-8"
-        response.raise_for_status.return_value = None
-        with patch("eap.environment.tools.web_tools.requests.get", return_value=response):
-            text = scrape_url("https://example.com")
+        response = _MockStreamResponse([b"<html><body><h1>Title</h1><p>Body</p></body></html>"])
+        with patch("eap.environment.tools.web_tools.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 443))]):
+            with patch("eap.environment.tools.web_tools.requests.Session.get", return_value=response):
+                text = scrape_url("https://example.com")
         self.assertIn("Title", text)
         self.assertIn("Body", text)
 
+    def test_web_tools_reject_private_and_localhost_targets(self) -> None:
+        private_cases = [
+            ("http://10.0.0.1", "10.0.0.1"),
+            ("http://169.254.169.254/latest/meta-data/", "169.254.169.254"),
+            ("http://localhost:11434", "127.0.0.1"),
+            ("http://100.64.0.1", "100.64.0.1"),
+        ]
+        for url, address in private_cases:
+            with self.subTest(url=url):
+                with patch("eap.environment.tools.web_tools.socket.getaddrinfo", return_value=[(2, 1, 6, "", (address, 80))]):
+                    with self.assertRaises(ValueError):
+                        scrape_url(url)
+
+    def test_web_tools_allow_explicit_host_allowlist(self) -> None:
+        response = _MockStreamResponse([b"<html><body>local page</body></html>"])
+        with patch("eap.environment.tools.web_tools.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("127.0.0.1", 80))]):
+            with patch("eap.environment.tools.web_tools.requests.Session.get", return_value=response):
+                text = scrape_url("http://127.0.0.1:8000", host_allowlist={"127.0.0.1"})
+        self.assertIn("local page", text)
+
+    def test_web_tools_allow_env_host_allowlist(self) -> None:
+        response = _MockStreamResponse([b'{"ok": true}'])
+        with patch.dict("os.environ", {"EAP_WEB_TOOL_HOST_ALLOWLIST": "127.0.0.1"}):
+            with patch("eap.environment.tools.web_tools.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("127.0.0.1", 80))]):
+                with patch("eap.environment.tools.web_tools.requests.Session.get", return_value=response):
+                    text = fetch_json_url("http://127.0.0.1:8000/data.json")
+        self.assertIn('"ok": true', text)
+
+    def test_web_tools_recheck_redirect_targets_for_ssrf(self) -> None:
+        redirect = _MockStreamResponse([], status_code=302, headers={"Location": "http://127.0.0.1/admin"})
+        getaddrinfo_results = [
+            [(2, 1, 6, "", ("93.184.216.34", 80))],
+            [(2, 1, 6, "", ("127.0.0.1", 80))],
+        ]
+        with patch("eap.environment.tools.web_tools.socket.getaddrinfo", side_effect=getaddrinfo_results):
+            with patch("eap.environment.tools.web_tools.requests.Session.get", return_value=redirect):
+                with self.assertRaises(RuntimeError):
+                    scrape_url("http://example.com/start")
+
+    def test_web_tools_streaming_byte_cap_stops_early(self) -> None:
+        response = _MockStreamResponse([b"12345", b"67890", b"extra"])
+        with patch("eap.environment.tools.web_tools.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 80))]):
+            with patch("eap.environment.tools.web_tools.requests.Session.get", return_value=response):
+                with self.assertRaises(RuntimeError):
+                    scrape_url("http://example.com/large", max_bytes=7)
+        self.assertEqual(response.chunks_read, 2)
+
     def test_scrape_url_failure_raises_runtime_error(self) -> None:
-        with patch("eap.environment.tools.web_tools.requests.get", side_effect=RuntimeError("network down")):
-            with self.assertRaises(RuntimeError):
-                scrape_url("https://example.com")
+        with patch("eap.environment.tools.web_tools.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 443))]):
+            with patch("eap.environment.tools.web_tools.requests.Session.get", side_effect=RuntimeError("network down")):
+                with self.assertRaises(RuntimeError):
+                    scrape_url("https://example.com")
 
     def test_fetch_json_url_success(self) -> None:
-        response = MagicMock()
-        response.content = b'{"name":"eap","version":1}'
-        response.encoding = "utf-8"
-        response.raise_for_status.return_value = None
-        with patch("eap.environment.tools.web_tools.requests.get", return_value=response):
-            text = fetch_json_url("https://example.com/data.json")
+        response = _MockStreamResponse([b'{"name":"eap","version":1}'])
+        with patch("eap.environment.tools.web_tools.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 443))]):
+            with patch("eap.environment.tools.web_tools.requests.Session.get", return_value=response):
+                text = fetch_json_url("https://example.com/data.json")
         self.assertIn('"name": "eap"', text)
         self.assertIn('"version": 1', text)
 
     def test_fetch_json_url_invalid_json_raises_runtime_error(self) -> None:
-        response = MagicMock()
-        response.content = b"<html>not json</html>"
-        response.encoding = "utf-8"
-        response.raise_for_status.return_value = None
-        with patch("eap.environment.tools.web_tools.requests.get", return_value=response):
-            with self.assertRaises(RuntimeError):
-                fetch_json_url("https://example.com/data.json")
+        response = _MockStreamResponse([b"<html>not json</html>"])
+        with patch("eap.environment.tools.web_tools.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 443))]):
+            with patch("eap.environment.tools.web_tools.requests.Session.get", return_value=response):
+                with self.assertRaises(RuntimeError):
+                    fetch_json_url("https://example.com/data.json")
 
     def test_extract_links_from_url_same_domain_only(self) -> None:
-        response = MagicMock()
-        response.content = (
-            b'<html><body>'
-            b'<a href="/a">A</a>'
-            b'<a href="https://example.com/b">B</a>'
-            b'<a href="https://other.com/c">C</a>'
-            b"</body></html>"
+        response = _MockStreamResponse(
+            [
+                (
+                    b'<html><body>'
+                    b'<a href="/a">A</a>'
+                    b'<a href="https://example.com/b">B</a>'
+                    b'<a href="https://other.com/c">C</a>'
+                    b"</body></html>"
+                )
+            ]
         )
-        response.encoding = "utf-8"
-        response.raise_for_status.return_value = None
-        with patch("eap.environment.tools.web_tools.requests.get", return_value=response):
-            payload = extract_links_from_url(
-                "https://example.com/base",
-                same_domain_only=True,
-                include_text=True,
-            )
+        with patch("eap.environment.tools.web_tools.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 443))]):
+            with patch("eap.environment.tools.web_tools.requests.Session.get", return_value=response):
+                payload = extract_links_from_url(
+                    "https://example.com/base",
+                    same_domain_only=True,
+                    include_text=True,
+                )
 
         parsed = json.loads(payload)
         self.assertEqual(parsed["link_count"], 2)


### PR DESCRIPTION
## Summary
- add DNS-aware SSRF checks for built-in web tools, including private/loopback/link-local/reserved/multicast/CGNAT targets
- manually validate redirects and stream response bodies with early max_bytes enforcement
- document EAP_WEB_TOOL_HOST_ALLOWLIST and bind the local research starter pack through registration-time allowlist configuration
- mark EAP-125 complete in the Phase 13 roadmap and set EAP-126 as the next ordered Todo

Completes GEN-205.

## Local validation
- ruff check . --select E9,F63,F7,F82
- mypy --follow-imports=skip eap/environment/safe_eval.py eap/environment/executor.py eap/runtime/auth_scopes.py eap/runtime/guardrails.py eap/runtime/http_api.py
- pytest -q
- RUN_PACKAGING_SMOKE=1 pytest -q tests/packaging/test_install_smoke.py
- python -m build
- pip-audit

Note: package build still emits the known non-blocking setuptools license metadata deprecation warning; deferred per the existing cleanup note.