### PR TITLE
EAP-126 add macro cycle and timeout controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,12 @@ EAP_LOG_FORMAT=json
 # Legacy override (optional): 1/true/yes enables JSON, 0/false/no disables JSON
 EAP_LOG_JSON=
 
+# Executor guardrails
+EAP_EXECUTOR_MAX_CONCURRENCY=8
+# Optional total wall-clock cap for a macro run. Leave empty for no default cap.
+EAP_EXECUTOR_MAX_TOTAL_RUNTIME_SECONDS=
+EAP_EXECUTOR_MAX_REFERENCE_RESOLUTION_DEPTH=32
+
 # Built-in file tools sandbox root (optional).
 # Defaults to the current working directory. Set this to a dedicated workspace
 # when exposing read_local_file/write_local_file/list_local_directory to agents.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > Status: v1.0 Release Candidate. Core APIs and schema are frozen per [`docs/v1_contract.md`](docs/v1_contract.md).
 > See `STABILITY.md` and `ROADMAP.md` for guarantees and planned milestones.
-> Latest stable release: `v1.0.0`
+> Latest stable release: `v1.0.1`
 
 ![Efficient Agent Protocol v1.0.0 explainer](assets/readme/eap_v1_explainer.png)
 

--- a/app.py
+++ b/app.py
@@ -12,7 +12,9 @@ from pydantic import ValidationError
 from eap.protocol import (
     BatchedMacroRequest,
     BranchingRule,
+    ExecutionLimits,
     StateManager,
+    ToolExecutionLimit,
     ToolCall,
     WorkflowEdgeKind,
     WorkflowGraphEdge,
@@ -32,6 +34,24 @@ from eap.agent import AgentClient, WorkflowGraphCompiler
 configure_logging()
 settings = load_settings()
 
+
+def _default_execution_limits_from_settings() -> ExecutionLimits:
+    return ExecutionLimits(
+        max_global_concurrency=settings.executor.max_global_concurrency,
+        max_total_runtime_seconds=settings.executor.max_total_runtime_seconds,
+        max_reference_resolution_depth=settings.executor.max_reference_resolution_depth,
+        global_requests_per_second=settings.executor.global_requests_per_second,
+        global_burst_capacity=settings.executor.global_burst_capacity,
+        per_tool={
+            tool_name: ToolExecutionLimit(
+                max_concurrency=limit.max_concurrency,
+                requests_per_second=limit.requests_per_second,
+                burst_capacity=limit.burst_capacity,
+            )
+            for tool_name, limit in settings.executor.per_tool_limits.items()
+        },
+    )
+
 # --- Page Config ---
 st.set_page_config(page_title="EAP Dashboard", layout="wide", page_icon="⚡")
 
@@ -43,7 +63,11 @@ def get_backend():
     registry.register("read_local_file", read_local_file, READ_FILE_SCHEMA)
     registry.register("analyze_data", analyze_data, ANALYZE_SCHEMA)
     registry.register("scrape_url", scrape_url, SCRAPE_SCHEMA)
-    executor = AsyncLocalExecutor(state_manager, registry)
+    executor = AsyncLocalExecutor(
+        state_manager,
+        registry,
+        default_execution_limits=_default_execution_limits_from_settings(),
+    )
     return state_manager, registry, executor
 
 state_manager, registry, executor = get_backend()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,11 @@ Logging:
 
 Executor concurrency/rate limits:
 - `EAP_EXECUTOR_MAX_CONCURRENCY` (integer > 0, default `8`)
+- `EAP_EXECUTOR_MAX_TOTAL_RUNTIME_SECONDS` (optional float > 0)
+  - Applies a total wall-clock cap to macro execution when used as executor default limits.
+  - Timed-out runs return structured `macro_timeout` error pointers and trace events.
+- `EAP_EXECUTOR_MAX_REFERENCE_RESOLUTION_DEPTH` (integer > 0, default `32`)
+  - Caps nested macro argument reference resolution to avoid unbounded expansion.
 - `EAP_EXECUTOR_GLOBAL_RPS` (optional float > 0)
 - `EAP_EXECUTOR_GLOBAL_BURST` (optional integer > 0, requires `EAP_EXECUTOR_GLOBAL_RPS`)
 - `EAP_EXECUTOR_PER_TOOL_LIMITS_JSON` (optional JSON object)
@@ -118,6 +123,7 @@ For streaming compatibility across providers and gateways, see [`streaming_compa
 - OpenAI API mode must be `chat_completions` or `responses`.
 - Extra header JSON values must be objects with non-empty string keys and values.
 - Executor global concurrency must be a positive integer.
+- Executor total runtime and reference-depth limits must be positive when set.
 - Global burst capacity requires global RPS to be set.
 - Per-tool limits JSON must be an object keyed by non-empty tool names.
 - `EAP_FILE_TOOL_ROOT`, when set, must point to an existing directory.

--- a/docs/custom_tool_authoring.md
+++ b/docs/custom_tool_authoring.md
@@ -139,3 +139,4 @@ Suggested existing suites to copy:
 - `InputValidationError`: runtime arguments violate schema.
 - `KeyError` during dependency resolution: referenced step did not complete successfully.
 - `tool_execution_error`: callable raised an exception after validation.
+- `macro_timeout`: the macro exceeded the configured total runtime limit.

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -66,11 +66,11 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 | 36 | `EAP-123` | `GEN-203` | `Done` | Fail-closed runtime auth defaults |
 | 37 | `EAP-124` | `GEN-204` | `Done` | Sandbox local file tools |
 | 38 | `EAP-125` | `GEN-205` | `Done` | Add SSRF protection and streaming byte caps to web tools |
-| 39 | `EAP-126` | `GEN-206` | `Todo` | Add macro cycle detection and execution timeout controls |
+| 39 | `EAP-126` | `GEN-206` | `Done` | Add macro cycle detection and execution timeout controls |
 | 40 | `EAP-127` | `GEN-207` | `Todo` | Harden connection pooling and request lifecycle |
 | 41 | `EAP-128` | `GEN-208` | `Todo` | Add production-hardening regression gatepack |
 
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-125` is complete; `EAP-126` is the next ordered `Todo`.
+Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-126` is complete; `EAP-127` is the next ordered `Todo`.

--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -15,6 +15,8 @@ EAP uses WAL (Write-Ahead Logging) mode by default for better concurrent read/wr
 | Environment Variable | Default | Description |
 |---|---|---|
 | `EAP_EXECUTOR_MAX_CONCURRENCY` | 8 | Max parallel tool executions |
+| `EAP_EXECUTOR_MAX_TOTAL_RUNTIME_SECONDS` | (unset) | Optional wall-clock cap for an entire macro run |
+| `EAP_EXECUTOR_MAX_REFERENCE_RESOLUTION_DEPTH` | 32 | Max nested depth for macro argument reference resolution |
 | `EAP_EXECUTOR_GLOBAL_RPS` | (unset) | Global requests-per-second rate limit |
 | `EAP_EXECUTOR_GLOBAL_BURST` | (unset) | Burst capacity for rate limiter |
 

--- a/docs/phase13_production_hardening_roadmap.md
+++ b/docs/phase13_production_hardening_roadmap.md
@@ -12,7 +12,7 @@ Current status:
 - [x] `EAP-123` fail-closed runtime auth defaults (`GEN-203`)
 - [x] `EAP-124` sandbox local file tools (`GEN-204`)
 - [x] `EAP-125` add SSRF protection and streaming byte caps to web tools (`GEN-205`)
-- [ ] `EAP-126` add macro cycle detection and execution timeout controls (`GEN-206`)
+- [x] `EAP-126` add macro cycle detection and execution timeout controls (`GEN-206`)
 - [ ] `EAP-127` harden connection pooling and request lifecycle (`GEN-207`)
 - [ ] `EAP-128` add production-hardening regression gatepack (`GEN-208`)
 

--- a/docs/v1_contract.md
+++ b/docs/v1_contract.md
@@ -22,6 +22,8 @@ The `v1.0` contract covers:
   - `WorkflowEdgeKind`
 - Tool error payload envelope (`ToolErrorPayload`) including allowed `error_type`
   values.
+  Current values: `validation_error`, `dependency_error`, `tool_execution_error`,
+  `approval_rejected`, and `macro_timeout`.
 - Frozen runtime settings key surface used by `load_settings()`.
 - SDK HTTP operation path set for TypeScript and Go clients.
 

--- a/docs/v1_contract_lock.json
+++ b/docs/v1_contract_lock.json
@@ -1,5 +1,5 @@
 {
-  "generated_from_package_version": "0.1.9",
+  "generated_from_package_version": "1.0.1",
   "lock_format_version": 1,
   "snapshot": {
     "public_api_exports": {
@@ -91,6 +91,8 @@
       "EAP_EXECUTOR_GLOBAL_BURST",
       "EAP_EXECUTOR_GLOBAL_RPS",
       "EAP_EXECUTOR_MAX_CONCURRENCY",
+      "EAP_EXECUTOR_MAX_REFERENCE_RESOLUTION_DEPTH",
+      "EAP_EXECUTOR_MAX_TOTAL_RUNTIME_SECONDS",
       "EAP_EXECUTOR_PER_TOOL_LIMITS_JSON",
       "EAP_EXTRA_HEADERS_JSON",
       "EAP_MODEL",
@@ -103,7 +105,8 @@
         "validation_error",
         "dependency_error",
         "tool_execution_error",
-        "approval_rejected"
+        "approval_rejected",
+        "macro_timeout"
       ],
       "fields": [
         "details",

--- a/docs/v1_stabilization_checklist.md
+++ b/docs/v1_stabilization_checklist.md
@@ -23,7 +23,7 @@ Ship `v1.0` with a stable contract for core runtime APIs, workflow schema, and u
 ### Workflow and Data Contract Freeze
 
 - [x] Freeze `PersistedWorkflowGraph` required/optional fields and validation rules.
-- [x] Freeze executor error payload contract (`validation_error`, `dependency_error`, `tool_execution_error`).
+- [x] Freeze executor error payload contract (`validation_error`, `dependency_error`, `tool_execution_error`, `approval_rejected`, `macro_timeout`).
 - [x] Freeze pointer lifecycle semantics (TTL and cleanup behavior).
 
 ### Configuration and Operational Defaults

--- a/eap/environment/executor.py
+++ b/eap/environment/executor.py
@@ -391,6 +391,74 @@ class AsyncLocalExecutor:
                 return tool_name_or_hash
             return None
 
+        async def _resolve_step_reference(
+            ref_value: str,
+            argument_key: str,
+            input_pointer_ids: dict[str, str],
+        ) -> object:
+            if ref_value.startswith("$step:"):
+                ref_payload = ref_value[len("$step:"):]
+            else:
+                ref_payload = ref_value[1:]
+            ref_step_id, _, path = ref_payload.partition(".")
+            if ref_step_id not in step_futures:
+                raise KeyError(f"Step reference '{ref_step_id}' failed.")
+
+            pointer_id = await step_futures[ref_step_id]
+            dependency_status = step_status.get(ref_step_id, {}).get("status")
+            if dependency_status != "ok":
+                raise KeyError(
+                    f"Dependency step '{ref_step_id}' did not complete successfully ({dependency_status})."
+                )
+            input_pointer_ids[argument_key] = pointer_id
+            resolved_value: object = self.state_manager.retrieve(pointer_id)
+            if path:
+                for part in path.split("."):
+                    if isinstance(resolved_value, dict):
+                        resolved_value = resolved_value.get(part)
+                    else:
+                        resolved_value = None
+                        break
+            return resolved_value
+
+        async def _resolve_argument_value(
+            value: object,
+            argument_key: str,
+            input_pointer_ids: dict[str, str],
+            depth: int = 0,
+        ) -> object:
+            if depth > execution_limits.max_reference_resolution_depth:
+                raise InputValidationError(
+                    "Macro reference resolution exceeded "
+                    f"max_reference_resolution_depth={execution_limits.max_reference_resolution_depth}."
+                )
+            if isinstance(value, str) and value.startswith("$"):
+                return await _resolve_step_reference(value, argument_key, input_pointer_ids)
+            if isinstance(value, str) and value.startswith("ptr_"):
+                input_pointer_ids[argument_key] = value
+                return self.state_manager.retrieve(value)
+            if isinstance(value, dict):
+                return {
+                    nested_key: await _resolve_argument_value(
+                        nested_value,
+                        f"{argument_key}.{nested_key}",
+                        input_pointer_ids,
+                        depth=depth + 1,
+                    )
+                    for nested_key, nested_value in value.items()
+                }
+            if isinstance(value, list):
+                return [
+                    await _resolve_argument_value(
+                        nested_value,
+                        f"{argument_key}[{idx}]",
+                        input_pointer_ids,
+                        depth=depth + 1,
+                    )
+                    for idx, nested_value in enumerate(value)
+                ]
+            return value
+
         def _pointer_metadata(extra: Optional[dict[str, object]] = None) -> dict[str, object]:
             base: dict[str, object] = {
                 "execution_run_id": run_id,
@@ -665,28 +733,10 @@ class AsyncLocalExecutor:
                         event_type=ExecutionTraceEventType.APPROVED,
                     )
 
-                resolved_args = {}
-                input_pointer_ids = {}
+                resolved_args: dict[str, object] = {}
+                input_pointer_ids: dict[str, str] = {}
                 for key, val in step.arguments.items():
-                    # Forgiving Routing: Handles "$step:id" and "$id"
-                    if isinstance(val, str) and val.startswith("$"):
-                        ref_step_id = val.replace("$step:", "").replace("$", "")
-                        if ref_step_id not in step_futures:
-                            raise KeyError(f"Step reference '{ref_step_id}' failed.")
-
-                        pointer_id = await step_futures[ref_step_id]
-                        dependency_status = step_status.get(ref_step_id, {}).get("status")
-                        if dependency_status != "ok":
-                            raise KeyError(
-                                f"Dependency step '{ref_step_id}' did not complete successfully ({dependency_status})."
-                            )
-                        input_pointer_ids[key] = pointer_id
-                        resolved_args[key] = self.state_manager.retrieve(pointer_id)
-                    elif isinstance(val, str) and val.startswith("ptr_"):
-                        input_pointer_ids[key] = val
-                        resolved_args[key] = self.state_manager.retrieve(val)
-                    else:
-                        resolved_args[key] = val
+                    resolved_args[key] = await _resolve_argument_value(val, key, input_pointer_ids)
 
                 self.registry.validate_arguments(step.tool_name, resolved_args)
                 tool_func = self.registry.get_tool(step.tool_name)
@@ -880,10 +930,73 @@ class AsyncLocalExecutor:
                 await _persist_checkpoint(status="active")
                 return step_pointer
 
+        async def _mark_step_timeout(step: ToolCall) -> PointerPayload:
+            error_payload_model = ToolErrorPayload(
+                error_type="macro_timeout",
+                message=(
+                    "Macro execution exceeded "
+                    f"max_total_runtime_seconds={execution_limits.max_total_runtime_seconds}."
+                ),
+                step_id=step.step_id,
+                tool_name=step.tool_name,
+                details={"max_total_runtime_seconds": execution_limits.max_total_runtime_seconds},
+            )
+            error_payload = error_payload_model.model_dump()
+            _append_trace_event(
+                step_id=step.step_id,
+                tool_name=step.tool_name,
+                event_type=ExecutionTraceEventType.FAILED,
+                attempt=1,
+                error=error_payload_model,
+            )
+            timeout_pointer = _pointer_payload(
+                self.state_manager.store_and_point(
+                    raw_data=error_payload,
+                    summary=f"Step {step.step_id} failed with macro_timeout.",
+                    metadata=_pointer_metadata({"status": "error", "error_type": "macro_timeout"}),
+                )
+            )
+            timeout_pointer_id = _pointer_id(timeout_pointer)
+            step_status[step.step_id] = {"status": "error", "pointer_id": timeout_pointer_id}
+            step_contexts[step.step_id] = {
+                "pointer_id": timeout_pointer_id,
+                "metadata": timeout_pointer.get("metadata"),
+                "raw_data": error_payload,
+                "status": "error",
+            }
+            if not step_futures[step.step_id].done():
+                step_futures[step.step_id].set_result(timeout_pointer_id)
+            return timeout_pointer
+
         tasks: list[asyncio.Task[PointerPayload]] = [
             asyncio.create_task(run_step(step)) for step in macro.steps
         ]
-        results = await asyncio.gather(*tasks)
+        if execution_limits.max_total_runtime_seconds is None:
+            results = await asyncio.gather(*tasks)
+        else:
+            try:
+                results = await asyncio.wait_for(
+                    asyncio.gather(*tasks),
+                    timeout=execution_limits.max_total_runtime_seconds,
+                )
+            except asyncio.TimeoutError:
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                gathered_results = await asyncio.gather(*tasks, return_exceptions=True)
+                results = []
+                for step, task, task_result in zip(macro.steps, tasks, gathered_results):
+                    if isinstance(task_result, dict):
+                        results.append(task_result)
+                    elif step_status.get(step.step_id, {}).get("pointer_id"):
+                        pointer_id_value = step_status[step.step_id].get("pointer_id")
+                        pointer_id = pointer_id_value if isinstance(pointer_id_value, str) else None
+                        results.append(_hydrate_pointer_response(pointer_id, step.step_id))
+                    elif task.cancelled() or isinstance(task_result, BaseException):
+                        results.append(await _mark_step_timeout(step))
+                    else:
+                        results.append(await _mark_step_timeout(step))
+                await _persist_checkpoint(status="active")
         final_result: Optional[PointerPayload] = results[-1] if results else None
 
         run_completed_at = datetime.now(timezone.utc)

--- a/eap/protocol/models.py
+++ b/eap/protocol/models.py
@@ -1,4 +1,5 @@
 # protocol/models.py
+import re
 from collections import defaultdict
 from datetime import datetime, timezone
 from enum import Enum
@@ -24,7 +25,8 @@ class ToolErrorPayload(BaseModel):
     error_type: str = Field(
         ...,
         description=(
-            "validation_error | dependency_error | tool_execution_error | approval_rejected"
+            "validation_error | dependency_error | tool_execution_error | "
+            "approval_rejected | macro_timeout"
         ),
     )
     message: str = Field(..., description="Short human-readable failure reason.")
@@ -178,6 +180,17 @@ class ExecutionLimits(BaseModel):
         default=8,
         ge=1,
         description="Maximum concurrent in-flight tool executions across the whole run.",
+    )
+    max_total_runtime_seconds: Optional[float] = Field(
+        default=None,
+        gt=0.0,
+        description="Optional wall-clock cap for the whole macro run.",
+    )
+    max_reference_resolution_depth: int = Field(
+        default=32,
+        ge=1,
+        le=256,
+        description="Maximum nested depth to inspect and resolve macro step references.",
     )
     global_requests_per_second: Optional[float] = Field(
         default=None,
@@ -422,6 +435,8 @@ class BatchedMacroRequest(BaseModel):
     @model_validator(mode="after")
     def validate_branch_targets(self) -> "BatchedMacroRequest":
         step_ids = {step.step_id for step in self.steps}
+        if len(step_ids) != len(self.steps):
+            raise ValueError("macro step_id values must be unique")
         step_by_id: Dict[str, ToolCall] = {step.step_id: step for step in self.steps}
         for step in self.steps:
             if not step.branching:
@@ -451,7 +466,96 @@ class BatchedMacroRequest(BaseModel):
                     f"approval decision provided for step '{approval_step_id}' "
                     "without approval.required=true"
                 )
+        self._validate_dependency_graph_acyclic()
         return self
+
+    @staticmethod
+    def _extract_argument_step_references(value: Any, *, depth: int = 0, max_depth: int = 32) -> set[str]:
+        if depth > max_depth:
+            raise ValueError(f"macro argument nesting exceeds max reference depth {max_depth}")
+        if isinstance(value, str):
+            if value.startswith("$step:"):
+                ref = value[len("$step:"):]
+                return {ref.split(".", 1)[0]} if ref else set()
+            if value.startswith("$") and not value.startswith("ptr_"):
+                ref = value[1:]
+                return {ref.split(".", 1)[0]} if ref else set()
+            return set()
+        if isinstance(value, dict):
+            refs: set[str] = set()
+            for nested_value in value.values():
+                refs.update(
+                    BatchedMacroRequest._extract_argument_step_references(
+                        nested_value,
+                        depth=depth + 1,
+                        max_depth=max_depth,
+                    )
+                )
+            return refs
+        if isinstance(value, list):
+            refs = set()
+            for nested_value in value:
+                refs.update(
+                    BatchedMacroRequest._extract_argument_step_references(
+                        nested_value,
+                        depth=depth + 1,
+                        max_depth=max_depth,
+                    )
+                )
+            return refs
+        return set()
+
+    @staticmethod
+    def _extract_condition_step_references(condition: str) -> set[str]:
+        return set(re.findall(r"\$step:([A-Za-z0-9_\-]+)(?:\.[A-Za-z0-9_\.]+)?", condition))
+
+    def _validate_dependency_graph_acyclic(self) -> None:
+        step_ids = {step.step_id for step in self.steps}
+        adjacency: Dict[str, set[str]] = {step_id: set() for step_id in step_ids}
+        in_degree: Dict[str, int] = {step_id: 0 for step_id in step_ids}
+
+        def add_edge(source: str, target: str) -> None:
+            if source not in step_ids:
+                raise ValueError(f"step reference '{source}' is not a valid step_id")
+            if target not in step_ids:
+                raise ValueError(f"step reference target '{target}' is not a valid step_id")
+            if target not in adjacency[source]:
+                adjacency[source].add(target)
+                in_degree[target] += 1
+
+        for step in self.steps:
+            for argument_value in step.arguments.values():
+                for dependency_step_id in self._extract_argument_step_references(argument_value):
+                    if dependency_step_id in step_ids:
+                        add_edge(dependency_step_id, step.step_id)
+
+            if not step.branching:
+                continue
+            for condition_dependency in self._extract_condition_step_references(step.branching.condition):
+                if condition_dependency == step.step_id:
+                    continue
+                if condition_dependency in step_ids:
+                    add_edge(condition_dependency, step.step_id)
+            for target_step_id in (
+                step.branching.true_target_step_ids
+                + step.branching.false_target_step_ids
+                + step.branching.fallback_target_step_ids
+            ):
+                add_edge(step.step_id, target_step_id)
+
+        ordered: List[str] = []
+        frontier = sorted(step_id for step_id, degree in in_degree.items() if degree == 0)
+        while frontier:
+            current = frontier.pop(0)
+            ordered.append(current)
+            for target in sorted(adjacency[current]):
+                in_degree[target] -= 1
+                if in_degree[target] == 0:
+                    frontier.append(target)
+            frontier.sort()
+
+        if len(ordered) != len(step_ids):
+            raise ValueError("macro dependency graph contains a cycle")
 
 
 class WorkflowEdgeKind(str, Enum):

--- a/eap/protocol/settings.py
+++ b/eap/protocol/settings.py
@@ -33,6 +33,8 @@ class ToolLimitSettings:
 @dataclass(frozen=True)
 class ExecutorLimitSettings:
     max_global_concurrency: int
+    max_total_runtime_seconds: Optional[float]
+    max_reference_resolution_depth: int
     global_requests_per_second: Optional[float]
     global_burst_capacity: Optional[int]
     per_tool_limits: Dict[str, ToolLimitSettings]
@@ -213,6 +215,20 @@ def _build_executor_limits() -> ExecutorLimitSettings:
     if max_concurrency <= 0:
         raise ValueError("EAP_EXECUTOR_MAX_CONCURRENCY must be > 0")
 
+    max_total_runtime_seconds = _parse_optional_float(
+        os.getenv("EAP_EXECUTOR_MAX_TOTAL_RUNTIME_SECONDS", ""),
+        "EAP_EXECUTOR_MAX_TOTAL_RUNTIME_SECONDS",
+    )
+    if max_total_runtime_seconds is not None and max_total_runtime_seconds <= 0:
+        raise ValueError("EAP_EXECUTOR_MAX_TOTAL_RUNTIME_SECONDS must be > 0")
+
+    max_reference_resolution_depth = _parse_int(
+        os.getenv("EAP_EXECUTOR_MAX_REFERENCE_RESOLUTION_DEPTH", "32"),
+        "EAP_EXECUTOR_MAX_REFERENCE_RESOLUTION_DEPTH",
+    )
+    if max_reference_resolution_depth <= 0:
+        raise ValueError("EAP_EXECUTOR_MAX_REFERENCE_RESOLUTION_DEPTH must be > 0")
+
     global_rps = _parse_optional_float(
         os.getenv("EAP_EXECUTOR_GLOBAL_RPS", ""),
         "EAP_EXECUTOR_GLOBAL_RPS",
@@ -252,6 +268,8 @@ def _build_executor_limits() -> ExecutorLimitSettings:
 
     return ExecutorLimitSettings(
         max_global_concurrency=max_concurrency,
+        max_total_runtime_seconds=max_total_runtime_seconds,
+        max_reference_resolution_depth=max_reference_resolution_depth,
         global_requests_per_second=global_rps,
         global_burst_capacity=global_burst,
         per_tool_limits=per_tool_limits,

--- a/eap/runtime/http_api.py
+++ b/eap/runtime/http_api.py
@@ -366,7 +366,12 @@ class _RuntimeASGIApp:
         try:
             macro = BatchedMacroRequest.model_validate(macro_payload)
         except ValidationError as exc:
-            raise self._error(400, "validation_error", "Invalid macro payload.", details={"errors": exc.errors()})
+            raise self._error(
+                400,
+                "validation_error",
+                "Invalid macro payload.",
+                details={"errors": exc.errors(include_context=False)},
+            )
 
         concurrency_token = self._acquire_concurrency(operation=RUNTIME_OPERATION_MACRO_EXECUTE)
         try:
@@ -426,7 +431,7 @@ class _RuntimeASGIApp:
                     400,
                     "validation_error",
                     "Invalid resume approval payload.",
-                    details={"errors": exc.errors()},
+                    details={"errors": exc.errors(include_context=False)},
                 )
             except Exception as exc:  # pragma: no cover - defensive safeguard
                 raise self._error(500, "execution_error", f"Run resume failed: {str(exc)}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "efficient-agent-protocol"
-version = "1.0.0"
+version = "1.0.1"
 description = "Local-first framework for multi-step tool workflows with pointer-backed state and DAG execution."
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/eap_runtime_service.py
+++ b/scripts/eap_runtime_service.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Sequence
 
 from eap.environment import AsyncLocalExecutor, ToolRegistry
 from eap.environment.tools import ANALYZE_SCHEMA, FETCH_SCHEMA, analyze_data, fetch_user_data
-from eap.protocol import StateManager
+from eap.protocol import ExecutionLimits, StateManager, ToolExecutionLimit, load_settings
 from eap.runtime import EAPRuntimeHTTPServer
 from eap.runtime.guardrails import normalize_concurrency_limits, normalize_rate_limit_rules
 from eap.runtime.policy_profiles import DEFAULT_POLICY_PROFILE, build_scoped_token_policies
@@ -88,6 +88,25 @@ def _register_default_tools(registry: ToolRegistry) -> None:
     # Keep default remote surface narrow for safer out-of-box operation.
     registry.register("fetch_user_data", fetch_user_data, FETCH_SCHEMA)
     registry.register("analyze_data", analyze_data, ANALYZE_SCHEMA)
+
+
+def _load_default_execution_limits() -> ExecutionLimits:
+    settings = load_settings()
+    return ExecutionLimits(
+        max_global_concurrency=settings.executor.max_global_concurrency,
+        max_total_runtime_seconds=settings.executor.max_total_runtime_seconds,
+        max_reference_resolution_depth=settings.executor.max_reference_resolution_depth,
+        global_requests_per_second=settings.executor.global_requests_per_second,
+        global_burst_capacity=settings.executor.global_burst_capacity,
+        per_tool={
+            tool_name: ToolExecutionLimit(
+                max_concurrency=limit.max_concurrency,
+                requests_per_second=limit.requests_per_second,
+                burst_capacity=limit.burst_capacity,
+            )
+            for tool_name, limit in settings.executor.per_tool_limits.items()
+        },
+    )
 
 
 def _load_scoped_auth_config(
@@ -190,7 +209,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     state_manager = StateManager(db_path=str(db_path))
     registry = ToolRegistry()
     _register_default_tools(registry)
-    executor = AsyncLocalExecutor(state_manager, registry)
+    try:
+        default_execution_limits = _load_default_execution_limits()
+    except Exception as exc:
+        print(f"[runtime:error] failed to load executor settings: {exc}")
+        return 1
+    executor = AsyncLocalExecutor(state_manager, registry, default_execution_limits=default_execution_limits)
 
     server = EAPRuntimeHTTPServer(
         executor=executor,

--- a/tests/integration/test_runtime_http_api.py
+++ b/tests/integration/test_runtime_http_api.py
@@ -138,6 +138,26 @@ class RuntimeHttpApiIntegrationTest(unittest.TestCase):
         self.assertEqual(body["error_type"], "validation_error")
         self.assertIn("Invalid macro payload", body["message"])
 
+    def test_execute_macro_rejects_dependency_cycle(self) -> None:
+        response = requests.post(
+            f"{self.server.base_url}/v1/eap/macro/execute",
+            headers={"Authorization": "Bearer secret-token"},
+            json={
+                "macro": {
+                    "steps": [
+                        {"step_id": "a", "tool_name": "echo_text", "arguments": {"text": "$step:b"}},
+                        {"step_id": "b", "tool_name": "echo_text", "arguments": {"text": "$step:a"}},
+                    ]
+                }
+            },
+            timeout=5,
+        )
+        self.assertEqual(response.status_code, 400)
+        body = response.json()
+        self.assertEqual(body["error_type"], "validation_error")
+        self.assertIn("Invalid macro payload", body["message"])
+        self.assertIn("macro dependency graph contains a cycle", str(body["details"]))
+
     def test_execute_macro_rejects_oversized_request_body(self) -> None:
         self.server.stop()
         self.server = EAPRuntimeHTTPServer(

--- a/tests/unit/test_executor_errors.py
+++ b/tests/unit/test_executor_errors.py
@@ -1,13 +1,21 @@
 import asyncio
 import os
 import tempfile
+import time
 import unittest
 
+from pydantic import ValidationError
+
 from eap.environment import AsyncLocalExecutor, ToolRegistry
-from eap.protocol import BatchedMacroRequest, StateManager, ToolCall
+from eap.protocol import BatchedMacroRequest, ExecutionLimits, StateManager, ToolCall
 
 
 def echo_tool(x: str) -> str:
+    return x
+
+
+def slow_tool(x: str, delay_seconds: float = 0.2) -> str:
+    time.sleep(delay_seconds)
     return x
 
 
@@ -15,7 +23,16 @@ ECHO_SCHEMA = {
     "name": "echo_tool",
     "parameters": {
         "type": "object",
-        "properties": {"x": {"type": "string"}},
+        "properties": {"x": {"type": "string"}, "delay_seconds": {"type": "number"}},
+        "required": ["x"],
+    },
+}
+
+SLOW_SCHEMA = {
+    "name": "slow_tool",
+    "parameters": {
+        "type": "object",
+        "properties": {"x": {"type": "string"}, "delay_seconds": {"type": "number"}},
         "required": ["x"],
     },
 }
@@ -29,6 +46,7 @@ class ExecutorErrorContractTest(unittest.TestCase):
         state_manager = StateManager(db_path=db_path)
         registry = ToolRegistry()
         registry.register("echo_tool", echo_tool, ECHO_SCHEMA)
+        registry.register("slow_tool", slow_tool, SLOW_SCHEMA)
         return AsyncLocalExecutor(state_manager, registry)
 
     def test_validation_error_returns_error_pointer(self) -> None:
@@ -48,6 +66,60 @@ class ExecutorErrorContractTest(unittest.TestCase):
         result = asyncio.run(executor.execute_macro(macro))
         self.assertEqual(result["metadata"]["status"], "error")
         self.assertEqual(result["metadata"]["error_type"], "dependency_error")
+
+    def test_direct_dependency_cycle_is_rejected(self) -> None:
+        with self.assertRaises(ValidationError) as ctx:
+            BatchedMacroRequest(
+                steps=[ToolCall(step_id="step_1", tool_name="echo_tool", arguments={"x": "$step:step_1"})]
+            )
+        self.assertIn("macro dependency graph contains a cycle", str(ctx.exception))
+
+    def test_indirect_dependency_cycle_is_rejected(self) -> None:
+        with self.assertRaises(ValidationError) as ctx:
+            BatchedMacroRequest(
+                steps=[
+                    ToolCall(step_id="step_a", tool_name="echo_tool", arguments={"x": "$step:step_b"}),
+                    ToolCall(step_id="step_b", tool_name="echo_tool", arguments={"x": "$step:step_a"}),
+                ]
+            )
+        self.assertIn("macro dependency graph contains a cycle", str(ctx.exception))
+
+    def test_macro_total_timeout_returns_structured_error_pointer(self) -> None:
+        executor = self._build_executor()
+        macro = BatchedMacroRequest(
+            steps=[ToolCall(step_id="slow", tool_name="slow_tool", arguments={"x": "ok", "delay_seconds": 0.2})],
+            execution_limits=ExecutionLimits(max_total_runtime_seconds=0.05),
+        )
+
+        result = asyncio.run(executor.execute_macro(macro))
+
+        self.assertEqual(result["metadata"]["status"], "error")
+        self.assertEqual(result["metadata"]["error_type"], "macro_timeout")
+        self.assertEqual(result["metadata"]["checkpoint_status"], "completed")
+        run_id = result["metadata"]["execution_run_id"]
+        events = executor.state_manager.list_trace_events(run_id)
+        failed_event = next(event for event in events if event.event_type.value == "failed")
+        self.assertEqual(failed_event.error.error_type, "macro_timeout")
+        self.assertIn("max_total_runtime_seconds", failed_event.error.message)
+
+    def test_nested_reference_resolution_depth_is_bounded(self) -> None:
+        executor = self._build_executor()
+        macro = BatchedMacroRequest(
+            steps=[
+                ToolCall(step_id="seed", tool_name="echo_tool", arguments={"x": "ok"}),
+                ToolCall(
+                    step_id="nested",
+                    tool_name="echo_tool",
+                    arguments={"x": {"too": {"deep": "$step:seed"}}},
+                ),
+            ],
+            execution_limits=ExecutionLimits(max_reference_resolution_depth=1),
+        )
+
+        result = asyncio.run(executor.execute_macro(macro))
+
+        self.assertEqual(result["metadata"]["status"], "error")
+        self.assertEqual(result["metadata"]["error_type"], "validation_error")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -16,6 +16,8 @@ class SettingsTest(unittest.TestCase):
             self.assertEqual(settings.architect.extra_headers, {})
             self.assertEqual(settings.auditor.extra_headers, {})
             self.assertEqual(settings.executor.max_global_concurrency, 8)
+            self.assertIsNone(settings.executor.max_total_runtime_seconds)
+            self.assertEqual(settings.executor.max_reference_resolution_depth, 32)
             self.assertEqual(settings.executor.per_tool_limits, {})
 
     def test_role_specific_overrides(self) -> None:
@@ -54,13 +56,25 @@ class SettingsTest(unittest.TestCase):
         with mock.patch.dict(
             os.environ,
             {
-                "EAP_EXECUTOR_PER_TOOL_LIMITS_JSON": '{"tool_a":{"max_concurrency":2,"requests_per_second":5.0,"burst_capacity":3}}'
+                "EAP_EXECUTOR_MAX_TOTAL_RUNTIME_SECONDS": "30",
+                "EAP_EXECUTOR_MAX_REFERENCE_RESOLUTION_DEPTH": "16",
+                "EAP_EXECUTOR_PER_TOOL_LIMITS_JSON": '{"tool_a":{"max_concurrency":2,"requests_per_second":5.0,"burst_capacity":3}}',
             },
             clear=True,
         ):
             settings = load_settings()
+            self.assertEqual(settings.executor.max_total_runtime_seconds, 30.0)
+            self.assertEqual(settings.executor.max_reference_resolution_depth, 16)
             self.assertEqual(settings.executor.per_tool_limits["tool_a"].max_concurrency, 2)
             self.assertEqual(settings.executor.per_tool_limits["tool_a"].requests_per_second, 5.0)
+
+    def test_executor_timeout_limit_validation(self) -> None:
+        with mock.patch.dict(os.environ, {"EAP_EXECUTOR_MAX_TOTAL_RUNTIME_SECONDS": "0"}, clear=True):
+            with self.assertRaises(ValueError):
+                load_settings()
+        with mock.patch.dict(os.environ, {"EAP_EXECUTOR_MAX_REFERENCE_RESOLUTION_DEPTH": "0"}, clear=True):
+            with self.assertRaises(ValueError):
+                load_settings()
 
     def test_invalid_extra_headers_validation(self) -> None:
         with mock.patch.dict(os.environ, {"EAP_EXTRA_HEADERS_JSON": '["bad"]'}, clear=True):


### PR DESCRIPTION
## Summary

- Adds macro dependency graph validation for duplicate step IDs, argument references, branch condition references, and branch targets.
- Adds macro-level wall-clock timeout handling with structured `macro_timeout` error pointers and trace events.
- Adds bounded nested reference resolution with `EAP_EXECUTOR_MAX_REFERENCE_RESOLUTION_DEPTH` and default executor settings for the dashboard/runtime service.
- Updates v1 contract lock and version to `1.0.1` because the public settings/error contract changed intentionally.

Completes GEN-206 / EAP-126.

## Validation

- `ruff check . --select E9,F63,F7,F82`
- `mypy --follow-imports=skip eap/environment/safe_eval.py eap/environment/executor.py eap/runtime/auth_scopes.py eap/runtime/guardrails.py eap/runtime/http_api.py`
- `python -m pytest -q`
- `RUN_PACKAGING_SMOKE=1 python -m pytest -q tests/packaging/test_install_smoke.py`
- `python -m build`
- `pip-audit`
- `git diff --check`

Known non-blocking warning: package build still emits the deferred setuptools `project.license` TOML table deprecation warning.
