### PR TITLE
EAP-127 harden connection lifecycle

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,17 @@ Global defaults:
 - `EAP_OPENAI_API_MODE` (`chat_completions` or `responses`, default: `chat_completions`)
 - `EAP_EXTRA_HEADERS_JSON` (optional JSON object of HTTP headers)
 
+Provider HTTP lifecycle:
+- Provider HTTP calls reuse pooled sessions with bounded retries.
+- Use `OpenClawToolsClient` for reusable OpenClaw `/tools/invoke` sessions; the
+  backwards-compatible helper is a bounded one-shot call.
+- `EAP_TIMEOUT_SECONDS` controls the read timeout; the connect timeout defaults
+  to `min(5s, EAP_TIMEOUT_SECONDS)`.
+- Role-specific timeout variables (`EAP_ARCHITECT_TIMEOUT_SECONDS`,
+  `EAP_AUDITOR_TIMEOUT_SECONDS`) override the global value for those clients.
+- Long-running processes should call `AgentClient.close()` or use
+  `with AgentClient(...) as client:` to release pooled sockets at shutdown.
+
 Role-specific overrides:
 - `EAP_ARCHITECT_BASE_URL`
 - `EAP_ARCHITECT_MODEL`

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -67,10 +67,10 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 | 37 | `EAP-124` | `GEN-204` | `Done` | Sandbox local file tools |
 | 38 | `EAP-125` | `GEN-205` | `Done` | Add SSRF protection and streaming byte caps to web tools |
 | 39 | `EAP-126` | `GEN-206` | `Done` | Add macro cycle detection and execution timeout controls |
-| 40 | `EAP-127` | `GEN-207` | `Todo` | Harden connection pooling and request lifecycle |
+| 40 | `EAP-127` | `GEN-207` | `Done` | Harden connection pooling and request lifecycle |
 | 41 | `EAP-128` | `GEN-208` | `Todo` | Add production-hardening regression gatepack |
 
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-126` is complete; `EAP-127` is the next ordered `Todo`.
+Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-127` is complete; `EAP-128` is the next ordered `Todo`.

--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -40,6 +40,35 @@ Set via `EAP_EXECUTOR_PER_TOOL_LIMITS_JSON`:
 | `backoff_multiplier` | 2.0 | Standard exponential backoff; reduce to 1.5 for tighter latency budgets |
 | `timeout_seconds` | 60 | Per-provider; reduce for local models (10-30), increase for large cloud models (120+) |
 
+## Provider HTTP Lifecycle
+
+Provider calls use a reusable pooled `requests.Session` through
+`BoundedHTTPClient`. OpenClaw integrations can use `OpenClawToolsClient` for
+the same reusable lifecycle; the backwards-compatible one-shot helper remains
+bounded and closes its client after each call.
+
+Defaults:
+
+| Setting | Default | Notes |
+|---|---|---|
+| Connect timeout | `min(5s, timeout_seconds)` | Keeps dead gateways from consuming the full read budget during connection setup |
+| Read timeout | `timeout_seconds` | Comes from `EAP_TIMEOUT_SECONDS` or role-specific timeout env vars |
+| Retry attempts | 2 | Applies to connection/read errors and HTTP `429`, `500`, `502`, `503`, `504` |
+| Retry backoff | 0.25 | Uses urllib3 exponential backoff and honors `Retry-After` |
+| Pool size | 10 connections | Per provider/client instance |
+
+Lifecycle guidance:
+
+- Reuse `AgentClient`, provider, or `OpenClawToolsClient` instances across
+  requests instead of creating one per prompt.
+- Call `AgentClient.close()` or use `with AgentClient(...) as client:` in
+  long-running processes to release pooled sockets during shutdown.
+- For embedded/custom integrations, inject `BoundedHTTPClient` when you need
+  custom pool or retry settings.
+- Built-in web tools intentionally use a short-lived session per invocation so
+  each redirect target can be revalidated for SSRF safety before the next
+  request.
+
 ## Runtime HTTP API
 
 | Environment Variable | Default | Description |

--- a/docs/phase13_production_hardening_roadmap.md
+++ b/docs/phase13_production_hardening_roadmap.md
@@ -13,7 +13,7 @@ Current status:
 - [x] `EAP-124` sandbox local file tools (`GEN-204`)
 - [x] `EAP-125` add SSRF protection and streaming byte caps to web tools (`GEN-205`)
 - [x] `EAP-126` add macro cycle detection and execution timeout controls (`GEN-206`)
-- [ ] `EAP-127` harden connection pooling and request lifecycle (`GEN-207`)
+- [x] `EAP-127` harden connection pooling and request lifecycle (`GEN-207`)
 - [ ] `EAP-128` add production-hardening regression gatepack (`GEN-208`)
 
 ## Objective

--- a/eap/agent/agent_client.py
+++ b/eap/agent/agent_client.py
@@ -46,6 +46,16 @@ class AgentClient:
         )
         self.compiler = MacroCompiler()
 
+    def close(self) -> None:
+        """Release provider-owned network resources."""
+        self.provider.close()
+
+    def __enter__(self) -> "AgentClient":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self.close()
+
     def _headers(self) -> Dict[str, str]:
         if hasattr(self.provider, "_headers"):
             return self.provider._headers()  # type: ignore[attr-defined]

--- a/eap/agent/providers/anthropic_provider.py
+++ b/eap/agent/providers/anthropic_provider.py
@@ -1,17 +1,24 @@
-from typing import Dict, List
-
-import requests
+from typing import Dict, List, Optional
 
 from .base import CompletionRequest, CompletionResponse, LLMProvider
+from eap.protocol.http_client import BoundedHTTPClient
 
 
 class AnthropicProvider(LLMProvider):
     """Adapter for Anthropic `/v1/messages` APIs."""
 
-    def __init__(self, endpoint: str, api_key: str, timeout_seconds: int):
+    def __init__(
+        self,
+        endpoint: str,
+        api_key: str,
+        timeout_seconds: int,
+        http_client: Optional[BoundedHTTPClient] = None,
+    ):
         self.endpoint = endpoint
         self.api_key = api_key
         self.timeout_seconds = timeout_seconds
+        self._owns_http_client = http_client is None
+        self._http_client = http_client or BoundedHTTPClient(timeout_seconds=timeout_seconds)
 
     def _headers(self) -> Dict[str, str]:
         return {
@@ -53,15 +60,17 @@ class AnthropicProvider(LLMProvider):
         return ""
 
     def _request(self, request: CompletionRequest) -> CompletionResponse:
-        response = requests.post(
+        response = self._http_client.post(
             self.endpoint,
             json=self._to_payload(request),
             headers=self._headers(),
-            timeout=self.timeout_seconds,
         )
-        response.raise_for_status()
-        raw_json = response.json()
-        return CompletionResponse(text=self._extract_text(raw_json), raw_response=raw_json)
+        try:
+            response.raise_for_status()
+            raw_json = response.json()
+            return CompletionResponse(text=self._extract_text(raw_json), raw_response=raw_json)
+        finally:
+            response.close()
 
     def complete(self, request: CompletionRequest) -> CompletionResponse:
         return self._request(request)
@@ -71,3 +80,7 @@ class AnthropicProvider(LLMProvider):
 
     def stream(self, request: CompletionRequest):
         raise NotImplementedError("Streaming not implemented for AnthropicProvider yet.")
+
+    def close(self) -> None:
+        if self._owns_http_client:
+            self._http_client.close()

--- a/eap/agent/providers/base.py
+++ b/eap/agent/providers/base.py
@@ -38,3 +38,6 @@ class LLMProvider(ABC):
     @abstractmethod
     def stream(self, request: CompletionRequest) -> Iterable[str]:
         """Stream completion tokens/chunks for providers that support streaming."""
+
+    def close(self) -> None:
+        """Release provider-owned network resources."""

--- a/eap/agent/providers/google_provider.py
+++ b/eap/agent/providers/google_provider.py
@@ -1,18 +1,25 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 from urllib.parse import quote
 
-import requests
-
 from .base import CompletionRequest, CompletionResponse, LLMProvider
+from eap.protocol.http_client import BoundedHTTPClient
 
 
 class GoogleProvider(LLMProvider):
     """Adapter for Google Gemini generateContent API."""
 
-    def __init__(self, base_url: str, api_key: str, timeout_seconds: int):
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        timeout_seconds: int,
+        http_client: Optional[BoundedHTTPClient] = None,
+    ):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.timeout_seconds = timeout_seconds
+        self._owns_http_client = http_client is None
+        self._http_client = http_client or BoundedHTTPClient(timeout_seconds=timeout_seconds)
 
     def _endpoint_for_model(self, model: str) -> str:
         return f"{self.base_url}/models/{quote(model, safe='')}:generateContent"
@@ -69,15 +76,17 @@ class GoogleProvider(LLMProvider):
 
     def _request(self, request: CompletionRequest) -> CompletionResponse:
         endpoint = self._endpoint_for_model(request.model)
-        response = requests.post(
+        response = self._http_client.post(
             endpoint,
             params={"key": self.api_key},
             json=self._to_payload(request),
-            timeout=self.timeout_seconds,
         )
-        response.raise_for_status()
-        raw_json = response.json()
-        return CompletionResponse(text=self._extract_text(raw_json), raw_response=raw_json)
+        try:
+            response.raise_for_status()
+            raw_json = response.json()
+            return CompletionResponse(text=self._extract_text(raw_json), raw_response=raw_json)
+        finally:
+            response.close()
 
     def complete(self, request: CompletionRequest) -> CompletionResponse:
         return self._request(request)
@@ -87,3 +96,7 @@ class GoogleProvider(LLMProvider):
 
     def stream(self, request: CompletionRequest):
         raise NotImplementedError("Streaming not implemented for GoogleProvider yet.")
+
+    def close(self) -> None:
+        if self._owns_http_client:
+            self._http_client.close()

--- a/eap/agent/providers/ollama_provider.py
+++ b/eap/agent/providers/ollama_provider.py
@@ -8,9 +8,8 @@ Ollama's OpenAI-compatibility shim.
 import json
 from typing import Dict, Iterable, Optional
 
-import requests
-
 from .base import CompletionRequest, CompletionResponse, LLMProvider
+from eap.protocol.http_client import BoundedHTTPClient
 
 
 DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
@@ -24,10 +23,13 @@ class OllamaProvider(LLMProvider):
         base_url: str = DEFAULT_OLLAMA_BASE_URL,
         timeout_seconds: int = 120,
         extra_headers: Optional[Dict[str, str]] = None,
+        http_client: Optional[BoundedHTTPClient] = None,
     ):
         self.base_url = base_url.rstrip("/")
         self.timeout_seconds = timeout_seconds
         self.extra_headers = dict(extra_headers or {})
+        self._owns_http_client = http_client is None
+        self._http_client = http_client or BoundedHTTPClient(timeout_seconds=timeout_seconds)
 
     def _headers(self) -> Dict[str, str]:
         headers = {"Content-Type": "application/json"}
@@ -44,16 +46,18 @@ class OllamaProvider(LLMProvider):
             "stream": False,
             "options": {"temperature": request.temperature},
         }
-        response = requests.post(
+        response = self._http_client.post(
             f"{self.base_url}/api/chat",
             json=payload,
             headers=self._headers(),
-            timeout=self.timeout_seconds,
         )
-        response.raise_for_status()
-        raw_json = response.json()
-        text = raw_json.get("message", {}).get("content", "")
-        return CompletionResponse(text=text, raw_response=raw_json)
+        try:
+            response.raise_for_status()
+            raw_json = response.json()
+            text = raw_json.get("message", {}).get("content", "")
+            return CompletionResponse(text=text, raw_response=raw_json)
+        finally:
+            response.close()
 
     def complete_with_tools(self, request: CompletionRequest) -> CompletionResponse:
         return self.complete(request)
@@ -65,25 +69,31 @@ class OllamaProvider(LLMProvider):
             "stream": True,
             "options": {"temperature": request.temperature},
         }
-        response = requests.post(
+        response = self._http_client.post(
             f"{self.base_url}/api/chat",
             json=payload,
             headers=self._headers(),
-            timeout=self.timeout_seconds,
             stream=True,
         )
-        response.raise_for_status()
-        for raw_line in response.iter_lines():
-            if not raw_line:
-                continue
-            try:
-                chunk = json.loads(raw_line.decode("utf-8"))
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(chunk, dict):
-                continue
-            content = chunk.get("message", {}).get("content")
-            if content:
-                yield str(content)
-            if chunk.get("done", False):
-                break
+        try:
+            response.raise_for_status()
+            for raw_line in response.iter_lines():
+                if not raw_line:
+                    continue
+                try:
+                    chunk = json.loads(raw_line.decode("utf-8"))
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(chunk, dict):
+                    continue
+                content = chunk.get("message", {}).get("content")
+                if content:
+                    yield str(content)
+                if chunk.get("done", False):
+                    break
+        finally:
+            response.close()
+
+    def close(self) -> None:
+        if self._owns_http_client:
+            self._http_client.close()

--- a/eap/agent/providers/openai_provider.py
+++ b/eap/agent/providers/openai_provider.py
@@ -4,6 +4,7 @@ from typing import Dict, Iterable, Optional, Tuple
 import requests
 
 from .base import CompletionRequest, CompletionResponse, LLMProvider
+from eap.protocol.http_client import BoundedHTTPClient
 
 
 class OpenAIProvider(LLMProvider):
@@ -16,12 +17,15 @@ class OpenAIProvider(LLMProvider):
         timeout_seconds: int,
         extra_headers: Optional[Dict[str, str]] = None,
         api_mode: str = "chat_completions",
+        http_client: Optional[BoundedHTTPClient] = None,
     ):
         self.endpoint = endpoint
         self.api_key = api_key
         self.timeout_seconds = timeout_seconds
         self.extra_headers = dict(extra_headers or {})
         self.api_mode = api_mode
+        self._owns_http_client = http_client is None
+        self._http_client = http_client or BoundedHTTPClient(timeout_seconds=timeout_seconds)
 
     def _headers(self) -> Dict[str, str]:
         headers = dict(self.extra_headers)
@@ -44,25 +48,27 @@ class OpenAIProvider(LLMProvider):
             }
             if request.tools:
                 payload["tools"] = request.tools
-            response = requests.post(
+            response = self._http_client.post(
                 self.endpoint,
                 json=payload,
                 headers=self._headers(),
-                timeout=self.timeout_seconds,
             )
             try:
-                response.raise_for_status()
-            except requests.HTTPError as exc:
-                if response.status_code in {404, 405, 410, 501}:
-                    raise RuntimeError(
-                        "OpenAI Responses API path is unavailable on this endpoint."
-                    ) from exc
-                raise
-            raw_json = response.json()
-            return CompletionResponse(
-                text=self._extract_responses_text(raw_json),
-                raw_response=raw_json,
-            )
+                try:
+                    response.raise_for_status()
+                except requests.HTTPError as exc:
+                    if response.status_code in {404, 405, 410, 501}:
+                        raise RuntimeError(
+                            "OpenAI Responses API path is unavailable on this endpoint."
+                        ) from exc
+                    raise
+                raw_json = response.json()
+                return CompletionResponse(
+                    text=self._extract_responses_text(raw_json),
+                    raw_response=raw_json,
+                )
+            finally:
+                response.close()
 
         payload = {
             "model": request.model,
@@ -72,18 +78,20 @@ class OpenAIProvider(LLMProvider):
         if request.tools:
             payload["tools"] = request.tools
 
-        response = requests.post(
+        response = self._http_client.post(
             self.endpoint,
             json=payload,
             headers=self._headers(),
-            timeout=self.timeout_seconds,
         )
-        response.raise_for_status()
-        raw_json = response.json()
-        return CompletionResponse(
-            text=raw_json["choices"][0]["message"]["content"],
-            raw_response=raw_json,
-        )
+        try:
+            response.raise_for_status()
+            raw_json = response.json()
+            return CompletionResponse(
+                text=raw_json["choices"][0]["message"]["content"],
+                raw_response=raw_json,
+            )
+        finally:
+            response.close()
 
     @staticmethod
     def _extract_responses_text(raw_json: Dict[str, object]) -> str:
@@ -206,11 +214,10 @@ class OpenAIProvider(LLMProvider):
                 payload["tools"] = request.tools
 
             try:
-                response = requests.post(
+                response = self._http_client.post(
                     self.endpoint,
                     json=payload,
                     headers=self._headers(),
-                    timeout=self.timeout_seconds,
                     stream=True,
                 )
             except requests.ConnectionError as exc:
@@ -225,18 +232,77 @@ class OpenAIProvider(LLMProvider):
                     f"Consider increasing EAP_TIMEOUT_SECONDS (current: {self.timeout_seconds}s)."
                 ) from exc
             try:
-                response.raise_for_status()
-            except requests.HTTPError as exc:
-                if response.status_code in {404, 405, 410, 501}:
-                    raise RuntimeError(
-                        f"OpenAI Responses API path is unavailable on this endpoint ({self.endpoint}). "
-                        f"Switch to chat_completions mode or use a compatible gateway. "
-                        f"See docs/streaming_compatibility.md."
-                    ) from exc
-                raise
+                try:
+                    response.raise_for_status()
+                except requests.HTTPError as exc:
+                    if response.status_code in {404, 405, 410, 501}:
+                        raise RuntimeError(
+                            f"OpenAI Responses API path is unavailable on this endpoint ({self.endpoint}). "
+                            f"Switch to chat_completions mode or use a compatible gateway. "
+                            f"See docs/streaming_compatibility.md."
+                        ) from exc
+                    raise
+                saw_incremental = False
+                emitted_final_fallback = False
+                for raw_line in response.iter_lines():
+                    if not raw_line:
+                        continue
+                    line = raw_line.decode("utf-8")
+                    if not line.startswith("data:"):
+                        continue
+                    data = line[len("data:") :].strip()
+                    if data == "[DONE]":
+                        break
+                    try:
+                        payload_obj = json.loads(data)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(payload_obj, dict):
+                        continue
 
-            saw_incremental = False
-            emitted_final_fallback = False
+                    token, is_incremental = self._extract_responses_stream_token(payload_obj)
+                    if not token:
+                        continue
+                    if is_incremental:
+                        saw_incremental = True
+                        yield token
+                        continue
+                    if saw_incremental or emitted_final_fallback:
+                        continue
+                    emitted_final_fallback = True
+                    yield token
+            finally:
+                response.close()
+            return
+
+        payload = {
+            "model": request.model,
+            "messages": [{"role": msg.role, "content": msg.content} for msg in request.messages],
+            "temperature": request.temperature,
+            "stream": True,
+        }
+        if request.tools:
+            payload["tools"] = request.tools
+
+        try:
+            response = self._http_client.post(
+                self.endpoint,
+                json=payload,
+                headers=self._headers(),
+                stream=True,
+            )
+        except requests.ConnectionError as exc:
+            raise RuntimeError(
+                f"Failed to connect to streaming endpoint ({self.endpoint}). "
+                f"Verify the gateway is running and reachable."
+            ) from exc
+        except requests.Timeout as exc:
+            raise RuntimeError(
+                f"Timeout connecting to streaming endpoint ({self.endpoint}). "
+                f"Consider increasing EAP_TIMEOUT_SECONDS (current: {self.timeout_seconds}s)."
+            ) from exc
+        try:
+            response.raise_for_status()
             for raw_line in response.iter_lines():
                 if not raw_line:
                     continue
@@ -250,67 +316,16 @@ class OpenAIProvider(LLMProvider):
                     payload_obj = json.loads(data)
                 except json.JSONDecodeError:
                     continue
-                if not isinstance(payload_obj, dict):
-                    continue
+                token = (
+                    payload_obj.get("choices", [{}])[0]
+                    .get("delta", {})
+                    .get("content")
+                )
+                if token:
+                    yield str(token)
+        finally:
+            response.close()
 
-                token, is_incremental = self._extract_responses_stream_token(payload_obj)
-                if not token:
-                    continue
-                if is_incremental:
-                    saw_incremental = True
-                    yield token
-                    continue
-                if saw_incremental or emitted_final_fallback:
-                    continue
-                emitted_final_fallback = True
-                yield token
-            return
-
-        payload = {
-            "model": request.model,
-            "messages": [{"role": msg.role, "content": msg.content} for msg in request.messages],
-            "temperature": request.temperature,
-            "stream": True,
-        }
-        if request.tools:
-            payload["tools"] = request.tools
-
-        try:
-            response = requests.post(
-                self.endpoint,
-                json=payload,
-                headers=self._headers(),
-                timeout=self.timeout_seconds,
-                stream=True,
-            )
-        except requests.ConnectionError as exc:
-            raise RuntimeError(
-                f"Failed to connect to streaming endpoint ({self.endpoint}). "
-                f"Verify the gateway is running and reachable."
-            ) from exc
-        except requests.Timeout as exc:
-            raise RuntimeError(
-                f"Timeout connecting to streaming endpoint ({self.endpoint}). "
-                f"Consider increasing EAP_TIMEOUT_SECONDS (current: {self.timeout_seconds}s)."
-            ) from exc
-        response.raise_for_status()
-        for raw_line in response.iter_lines():
-            if not raw_line:
-                continue
-            line = raw_line.decode("utf-8")
-            if not line.startswith("data:"):
-                continue
-            data = line[len("data:") :].strip()
-            if data == "[DONE]":
-                break
-            try:
-                payload_obj = json.loads(data)
-            except json.JSONDecodeError:
-                continue
-            token = (
-                payload_obj.get("choices", [{}])[0]
-                .get("delta", {})
-                .get("content")
-            )
-            if token:
-                yield str(token)
+    def close(self) -> None:
+        if self._owns_http_client:
+            self._http_client.close()

--- a/eap/environment/openclaw_client.py
+++ b/eap/environment/openclaw_client.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Optional
 
 import requests
 
+from eap.protocol.http_client import BoundedHTTPClient
+
 
 @dataclass(frozen=True)
 class OpenClawToolInvokeRequest:
@@ -31,6 +33,49 @@ class OpenClawToolInvokeError(RuntimeError):
         self.error_type = error_type
         self.details = details
         self.retry_after_seconds = retry_after_seconds
+
+
+class OpenClawToolsClient:
+    """Reusable OpenClaw `/tools/invoke` client with pooled bounded HTTP lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        timeout_seconds: int = 30,
+        account_id: Optional[str] = None,
+        channel_id: Optional[str] = None,
+        http_client: Optional[BoundedHTTPClient] = None,
+    ) -> None:
+        self.base_url = base_url
+        self.api_key = api_key
+        self.timeout_seconds = timeout_seconds
+        self.account_id = account_id
+        self.channel_id = channel_id
+        self._owns_http_client = http_client is None
+        self._http_client = http_client or BoundedHTTPClient(timeout_seconds=timeout_seconds)
+
+    def invoke(self, request: OpenClawToolInvokeRequest) -> OpenClawToolInvokeResponse:
+        return invoke_openclaw_tools_api(
+            base_url=self.base_url,
+            api_key=self.api_key,
+            request=request,
+            timeout_seconds=self.timeout_seconds,
+            account_id=self.account_id,
+            channel_id=self.channel_id,
+            http_client=self._http_client,
+        )
+
+    def close(self) -> None:
+        if self._owns_http_client:
+            self._http_client.close()
+
+    def __enter__(self) -> "OpenClawToolsClient":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self.close()
 
 
 def _parse_retry_after_seconds(value: Optional[str]) -> Optional[int]:
@@ -118,6 +163,7 @@ def invoke_openclaw_tools_api(
     timeout_seconds: int = 30,
     account_id: Optional[str] = None,
     channel_id: Optional[str] = None,
+    http_client: Optional[BoundedHTTPClient] = None,
 ) -> OpenClawToolInvokeResponse:
     normalized_base = (base_url or "").strip().rstrip("/")
     if not normalized_base.startswith(("http://", "https://")):
@@ -140,28 +186,35 @@ def invoke_openclaw_tools_api(
     if channel_id and channel_id.strip():
         headers["x-openclaw-channel-id"] = channel_id.strip()
 
-    response = requests.post(
-        endpoint,
-        json={"name": request.name, "arguments": request.arguments},
-        headers=headers,
-        timeout=timeout_seconds,
-    )
-    payload = _read_json_payload(response)
-    if 200 <= response.status_code < 300:
-        return OpenClawToolInvokeResponse(status_code=response.status_code, payload=payload)
+    client = http_client or BoundedHTTPClient(timeout_seconds=timeout_seconds)
+    try:
+        response = client.post(
+            endpoint,
+            json={"name": request.name, "arguments": request.arguments},
+            headers=headers,
+        )
+        try:
+            payload = _read_json_payload(response)
+            if 200 <= response.status_code < 300:
+                return OpenClawToolInvokeResponse(status_code=response.status_code, payload=payload)
 
-    error_code = _extract_error_code(payload)
-    error_type = _map_error_type(response.status_code, error_code)
-    message = _extract_error_message(
-        payload,
-        default=f"OpenClaw /tools/invoke failed with HTTP {response.status_code}.",
-    )
-    details = _extract_error_details(payload, fallback_code=error_code)
-    retry_after_seconds = _parse_retry_after_seconds(response.headers.get("Retry-After"))
-    raise OpenClawToolInvokeError(
-        message=message,
-        status_code=response.status_code,
-        error_type=error_type,
-        details=details,
-        retry_after_seconds=retry_after_seconds,
-    )
+            error_code = _extract_error_code(payload)
+            error_type = _map_error_type(response.status_code, error_code)
+            message = _extract_error_message(
+                payload,
+                default=f"OpenClaw /tools/invoke failed with HTTP {response.status_code}.",
+            )
+            details = _extract_error_details(payload, fallback_code=error_code)
+            retry_after_seconds = _parse_retry_after_seconds(response.headers.get("Retry-After"))
+            raise OpenClawToolInvokeError(
+                message=message,
+                status_code=response.status_code,
+                error_type=error_type,
+                details=details,
+                retry_after_seconds=retry_after_seconds,
+            )
+        finally:
+            response.close()
+    finally:
+        if http_client is None:
+            client.close()

--- a/eap/protocol/http_client.py
+++ b/eap/protocol/http_client.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+DEFAULT_RETRY_STATUS_CODES = (429, 500, 502, 503, 504)
+
+
+class BoundedHTTPClient:
+    """Reusable requests client with pooling, explicit timeouts, and bounded retries."""
+
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float,
+        connect_timeout_seconds: Optional[float] = None,
+        max_retries: int = 2,
+        backoff_factor: float = 0.25,
+        pool_connections: int = 10,
+        pool_maxsize: int = 10,
+        retry_status_codes: Sequence[int] = DEFAULT_RETRY_STATUS_CODES,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be > 0")
+        resolved_connect_timeout = connect_timeout_seconds
+        if resolved_connect_timeout is None:
+            resolved_connect_timeout = min(5.0, float(timeout_seconds))
+        if resolved_connect_timeout <= 0:
+            raise ValueError("connect_timeout_seconds must be > 0")
+        if max_retries < 0:
+            raise ValueError("max_retries must be >= 0")
+        if backoff_factor < 0:
+            raise ValueError("backoff_factor must be >= 0")
+
+        self.timeout = (float(resolved_connect_timeout), float(timeout_seconds))
+        self._owns_session = session is None
+        self._session = session or requests.Session()
+        if session is None:
+            retry = Retry(
+                total=max_retries,
+                connect=max_retries,
+                read=max_retries,
+                status=max_retries,
+                backoff_factor=backoff_factor,
+                status_forcelist=tuple(retry_status_codes),
+                allowed_methods=frozenset({"GET", "POST"}),
+                raise_on_status=False,
+                respect_retry_after_header=True,
+            )
+            adapter = HTTPAdapter(
+                pool_connections=pool_connections,
+                pool_maxsize=pool_maxsize,
+                max_retries=retry,
+            )
+            self._session.mount("http://", adapter)
+            self._session.mount("https://", adapter)
+
+    def post(self, url: str, **kwargs: object) -> requests.Response:
+        if "timeout" not in kwargs or kwargs["timeout"] is None:
+            kwargs["timeout"] = self.timeout
+        return self._session.post(url, **kwargs)
+
+    def close(self) -> None:
+        if self._owns_session:
+            self._session.close()
+
+    def __enter__(self) -> BoundedHTTPClient:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self.close()

--- a/tests/integration/test_openai_responses_streaming.py
+++ b/tests/integration/test_openai_responses_streaming.py
@@ -22,7 +22,7 @@ class OpenAIResponsesStreamingIntegrationTest(unittest.TestCase):
         ]
 
         seen = []
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=stream_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=stream_response) as post:
             final = client.stream_chat("hello", on_token=seen.append, fallback_to_non_stream=False)
 
         self.assertEqual(final, "Hello")
@@ -50,7 +50,7 @@ class OpenAIResponsesStreamingIntegrationTest(unittest.TestCase):
 
         seen = []
         with patch(
-            "eap.agent.providers.openai_provider.requests.post",
+            "eap.protocol.http_client.requests.Session.post",
             side_effect=[stream_response, completion_response],
         ) as post:
             final = client.stream_chat("hello", on_token=seen.append)

--- a/tests/unit/test_agent_client.py
+++ b/tests/unit/test_agent_client.py
@@ -18,12 +18,12 @@ class AgentClientTest(unittest.TestCase):
         mock_response.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
         mock_response.raise_for_status.return_value = None
 
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             result = client.chat("hello")
 
         self.assertEqual(result, "ok")
         kwargs = post.call_args.kwargs
-        self.assertEqual(kwargs["timeout"], 12)
+        self.assertEqual(kwargs["timeout"], (5.0, 12.0))
         self.assertEqual(kwargs["headers"]["Authorization"], "Bearer secret")
         self.assertEqual(kwargs["json"]["temperature"], 0.3)
 
@@ -33,7 +33,7 @@ class AgentClientTest(unittest.TestCase):
         mock_response.json.return_value = {"choices": [{"message": {"content": "{\"steps\": []}"}}]}
         mock_response.raise_for_status.return_value = None
 
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response):
             macro = client.generate_macro("do thing", {"x_hash": {"type": "object"}})
 
         self.assertEqual(macro.steps, [])
@@ -48,7 +48,7 @@ class AgentClientTest(unittest.TestCase):
         mock_response.json.return_value = {"choices": [{"message": {"content": "{\"steps\": []}"}}]}
         mock_response.raise_for_status.return_value = None
 
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             client.generate_macro(
                 "follow up",
                 {"x_hash": {"type": "object"}},
@@ -70,7 +70,7 @@ class AgentClientTest(unittest.TestCase):
         mock_response.json.return_value = {"output_text": "ok"}
         mock_response.raise_for_status.return_value = None
 
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             result = client.chat("hello")
 
         self.assertEqual(result, "ok")

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import MagicMock
+
+from eap.protocol.http_client import BoundedHTTPClient
+
+
+class BoundedHTTPClientTest(unittest.TestCase):
+    def test_uses_explicit_connect_and_read_timeout(self) -> None:
+        session = MagicMock()
+        response = MagicMock()
+        session.post.return_value = response
+        client = BoundedHTTPClient(timeout_seconds=12, session=session)
+
+        result = client.post("https://example.com/v1/test", json={"ok": True})
+
+        self.assertIs(result, response)
+        self.assertEqual(session.post.call_args.kwargs["timeout"], (5.0, 12.0))
+
+    def test_configures_pooling_and_bounded_retries(self) -> None:
+        client = BoundedHTTPClient(timeout_seconds=30, max_retries=3, pool_connections=4, pool_maxsize=6)
+        try:
+            adapter = client._session.get_adapter("https://example.com")  # noqa: SLF001
+            self.assertEqual(adapter.max_retries.total, 3)
+            self.assertEqual(adapter.max_retries.connect, 3)
+            self.assertEqual(adapter.max_retries.read, 3)
+            self.assertEqual(adapter.max_retries.status, 3)
+            self.assertIn(429, adapter.max_retries.status_forcelist)
+            self.assertIn("POST", adapter.max_retries.allowed_methods)
+            self.assertEqual(adapter._pool_connections, 4)  # noqa: SLF001
+            self.assertEqual(adapter._pool_maxsize, 6)  # noqa: SLF001
+        finally:
+            client.close()
+
+    def test_close_only_closes_owned_sessions(self) -> None:
+        injected_session = MagicMock()
+        injected = BoundedHTTPClient(timeout_seconds=10, session=injected_session)
+        injected.close()
+        injected_session.close.assert_not_called()
+
+        owned = BoundedHTTPClient(timeout_seconds=10)
+        owned._session.close = MagicMock()  # type: ignore[method-assign] # noqa: SLF001
+        owned.close()
+        owned._session.close.assert_called_once()  # noqa: SLF001
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_ollama_provider.py
+++ b/tests/unit/test_ollama_provider.py
@@ -26,7 +26,7 @@ class OllamaProviderTest(unittest.TestCase):
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"message": {"content": "ollama-ok"}, "done": True}
         mock_resp.raise_for_status.return_value = None
-        with patch("eap.agent.providers.ollama_provider.requests.post", return_value=mock_resp) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_resp) as post:
             response = provider.complete(request)
 
         self.assertEqual(response.text, "ollama-ok")
@@ -42,7 +42,7 @@ class OllamaProviderTest(unittest.TestCase):
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"message": {"content": "tools-ok"}, "done": True}
         mock_resp.raise_for_status.return_value = None
-        with patch("eap.agent.providers.ollama_provider.requests.post", return_value=mock_resp):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_resp):
             response = provider.complete_with_tools(request)
 
         self.assertEqual(response.text, "tools-ok")
@@ -59,7 +59,7 @@ class OllamaProviderTest(unittest.TestCase):
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None
         mock_resp.iter_lines.return_value = iter(lines)
-        with patch("eap.agent.providers.ollama_provider.requests.post", return_value=mock_resp):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_resp):
             tokens = list(provider.stream(request))
 
         self.assertEqual(tokens, ["Hello", " world"])
@@ -75,7 +75,7 @@ class OllamaProviderTest(unittest.TestCase):
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None
         mock_resp.iter_lines.return_value = iter(lines)
-        with patch("eap.agent.providers.ollama_provider.requests.post", return_value=mock_resp):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_resp):
             tokens = list(provider.stream(request))
 
         self.assertEqual(tokens, ["ok"])

--- a/tests/unit/test_openclaw_client.py
+++ b/tests/unit/test_openclaw_client.py
@@ -1,9 +1,10 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from eap.environment.openclaw_client import (
     OpenClawToolInvokeError,
     OpenClawToolInvokeRequest,
+    OpenClawToolsClient,
     invoke_openclaw_tools_api,
 )
 
@@ -18,6 +19,9 @@ class _MockResponse:
     def json(self):
         return self._payload
 
+    def close(self):
+        pass
+
 
 class OpenClawClientUnitTest(unittest.TestCase):
     def test_invoke_openclaw_tools_api_success(self) -> None:
@@ -25,7 +29,7 @@ class OpenClawClientUnitTest(unittest.TestCase):
             status_code=200,
             payload={"ok": True, "tool": "echo_tool", "result": {"text": "hello"}},
         )
-        with patch("eap.environment.openclaw_client.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             result = invoke_openclaw_tools_api(
                 base_url="https://gateway.openclaw.local",
                 api_key="secret-token",
@@ -38,7 +42,7 @@ class OpenClawClientUnitTest(unittest.TestCase):
         self.assertEqual(result.status_code, 200)
         self.assertTrue(result.payload["ok"])
         kwargs = post.call_args.kwargs
-        self.assertEqual(kwargs["timeout"], 12)
+        self.assertEqual(kwargs["timeout"], (5.0, 12.0))
         self.assertEqual(kwargs["json"]["name"], "echo_tool")
         self.assertEqual(kwargs["json"]["arguments"]["text"], "hello")
         self.assertEqual(kwargs["headers"]["Authorization"], "Bearer secret-token")
@@ -50,7 +54,7 @@ class OpenClawClientUnitTest(unittest.TestCase):
             status_code=401,
             payload={"error": {"code": "UNAUTHORIZED", "message": "Missing or invalid bearer token."}},
         )
-        with patch("eap.environment.openclaw_client.requests.post", return_value=mock_response):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response):
             with self.assertRaises(OpenClawToolInvokeError) as context:
                 invoke_openclaw_tools_api(
                     base_url="https://gateway.openclaw.local",
@@ -74,7 +78,7 @@ class OpenClawClientUnitTest(unittest.TestCase):
                 }
             },
         )
-        with patch("eap.environment.openclaw_client.requests.post", return_value=mock_response):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response):
             with self.assertRaises(OpenClawToolInvokeError) as context:
                 invoke_openclaw_tools_api(
                     base_url="https://gateway.openclaw.local",
@@ -94,7 +98,7 @@ class OpenClawClientUnitTest(unittest.TestCase):
             payload={"error": {"code": "RATE_LIMITED", "message": "Too many requests."}},
             headers={"Retry-After": "17"},
         )
-        with patch("eap.environment.openclaw_client.requests.post", return_value=mock_response):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response):
             with self.assertRaises(OpenClawToolInvokeError) as context:
                 invoke_openclaw_tools_api(
                     base_url="https://gateway.openclaw.local",
@@ -105,6 +109,27 @@ class OpenClawClientUnitTest(unittest.TestCase):
         error = context.exception
         self.assertEqual(error.error_type, "rate_limited")
         self.assertEqual(error.retry_after_seconds, 17)
+
+    def test_openclaw_tools_client_reuses_injected_http_client(self) -> None:
+        mock_http_client = MagicMock()
+        mock_http_client.post.return_value = _MockResponse(
+            status_code=200,
+            payload={"ok": True},
+        )
+        client = OpenClawToolsClient(
+            base_url="https://gateway.openclaw.local",
+            api_key="secret-token",
+            http_client=mock_http_client,
+        )
+
+        first = client.invoke(OpenClawToolInvokeRequest(name="echo_tool", arguments={"text": "a"}))
+        second = client.invoke(OpenClawToolInvokeRequest(name="echo_tool", arguments={"text": "b"}))
+        client.close()
+
+        self.assertTrue(first.payload["ok"])
+        self.assertTrue(second.payload["ok"])
+        self.assertEqual(mock_http_client.post.call_count, 2)
+        mock_http_client.close.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_provider_adapters.py
+++ b/tests/unit/test_provider_adapters.py
@@ -28,7 +28,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = {"choices": [{"message": {"content": "openai-ok"}}]}
         mock_response.raise_for_status.return_value = None
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             response = provider.complete(request)
 
         self.assertEqual(response.text, "openai-ok")
@@ -55,7 +55,7 @@ class ProviderAdaptersTest(unittest.TestCase):
             b'data: {"choices":[{"delta":{"content":"lo"}}]}',
             b"data: [DONE]",
         ]
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             chunks = list(provider.stream(request))
 
         self.assertEqual(chunks, ["Hel", "lo"])
@@ -79,7 +79,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
         mock_response.raise_for_status.return_value = None
 
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             provider.complete(request)
 
         kwargs = post.call_args.kwargs
@@ -103,7 +103,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = {"content": [{"type": "text", "text": "anthropic-ok"}]}
         mock_response.raise_for_status.return_value = None
-        with patch("eap.agent.providers.anthropic_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             response = provider.complete(request)
 
         self.assertEqual(response.text, "anthropic-ok")
@@ -126,7 +126,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = {"id": "resp_1", "output_text": "responses-ok"}
         mock_response.raise_for_status.return_value = None
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             response = provider.complete(request)
 
         self.assertEqual(response.text, "responses-ok")
@@ -150,7 +150,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.status_code = 404
         mock_response.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response):
             with self.assertRaises(RuntimeError) as context:
                 provider.complete(request)
         self.assertIn("Responses API path is unavailable", str(context.exception))
@@ -176,7 +176,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         }
         mock_response.raise_for_status.return_value = None
 
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response):
             response = provider.complete(request)
         self.assertEqual(response.text, "hello world")
 
@@ -196,7 +196,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response.json.return_value = {"id": "resp_1", "output": [{"content": [{"type": "ref"}]}]}
         mock_response.raise_for_status.return_value = None
 
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response):
             with self.assertRaises(KeyError):
                 provider.complete(request)
 
@@ -221,7 +221,7 @@ class ProviderAdaptersTest(unittest.TestCase):
             b'data: {"type":"response.output_text.done","text":"Hello"}',
             b"data: [DONE]",
         ]
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             chunks = list(provider.stream(request))
 
         self.assertEqual(chunks, ["Hel", "lo"])
@@ -252,7 +252,7 @@ class ProviderAdaptersTest(unittest.TestCase):
             b'data: {"output":[{"content":[{"type":"output_text","text":"B"}]}]}',
             b"data: [DONE]",
         ]
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             chunks = list(provider.stream(request))
 
         self.assertEqual(chunks, ["A"])
@@ -277,7 +277,7 @@ class ProviderAdaptersTest(unittest.TestCase):
             b'data: {"type":"response.completed","response":{"output_text":"Hello done"}}',
             b"data: [DONE]",
         ]
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response):
             chunks = list(provider.stream(request))
         self.assertEqual(chunks, ["Hello done"])
 
@@ -296,7 +296,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.status_code = 405
         mock_response.raise_for_status.side_effect = requests.HTTPError("405 Method Not Allowed")
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response):
             with self.assertRaises(RuntimeError) as context:
                 list(provider.stream(request))
         self.assertIn("Responses API path is unavailable", str(context.exception))
@@ -318,7 +318,7 @@ class ProviderAdaptersTest(unittest.TestCase):
         mock_response.iter_lines.return_value = [
             b'data: {"type":"response.error","error":{"code":"policy_denied","message":"Denied by policy"}}'
         ]
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response):
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response):
             with self.assertRaises(RuntimeError) as context:
                 list(provider.stream(request))
         self.assertIn("Denied by policy", str(context.exception))
@@ -343,7 +343,7 @@ class ProviderAdaptersTest(unittest.TestCase):
             b'data: {"choices":[{"delta":{"content":"tool"}}]}',
             b"data: [DONE]",
         ]
-        with patch("eap.agent.providers.openai_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             chunks = list(provider.stream(request))
 
         self.assertEqual(chunks, ["tool"])
@@ -380,7 +380,7 @@ class ProviderAdaptersTest(unittest.TestCase):
             "candidates": [{"content": {"parts": [{"text": "google-ok"}]}}]
         }
         mock_response.raise_for_status.return_value = None
-        with patch("eap.agent.providers.google_provider.requests.post", return_value=mock_response) as post:
+        with patch("eap.protocol.http_client.requests.Session.post", return_value=mock_response) as post:
             response = provider.complete_with_tools(request)
 
         self.assertEqual(response.text, "google-ok")


### PR DESCRIPTION
## Summary

- Adds `BoundedHTTPClient`, a pooled `requests.Session` wrapper with explicit connect/read timeouts and bounded retry behavior.
- Wires OpenAI-compatible, Anthropic, Google, Ollama, and OpenClaw client paths through bounded HTTP lifecycle handling.
- Adds provider/client close and context-manager lifecycle support for long-running processes.
- Documents provider/OpenClaw lifecycle defaults, shutdown expectations, and web-tool one-shot justification.

Completes GEN-207 / EAP-127.

## Validation

- `ruff check . --select E9,F63,F7,F82`
- `mypy --follow-imports=skip eap/environment/safe_eval.py eap/environment/executor.py eap/runtime/auth_scopes.py eap/runtime/guardrails.py eap/runtime/http_api.py`
- `python -m pytest -q`
- `RUN_PACKAGING_SMOKE=1 python -m pytest -q tests/packaging/test_install_smoke.py`
- `python -m build`
- `pip-audit`
- `git diff --check`

Known non-blocking warning: package build still emits the deferred setuptools `project.license` TOML table deprecation warning.
