### PR TITLE
EAP-128 add production hardening gatepack

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,7 +93,7 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Complete RC dry-run and go/no-go checklist before v1 cut.
 - Checklist: `docs/phase12_v1_launch_readiness_roadmap.md`
 
-## Phase 13: Production Hardening / v1.0.1 Blockers (Active)
+## Phase 13: Production Hardening / v1.0.1 Blockers (Completed)
 
 - Execute ordered production-hardening queue (`EAP-119` to `EAP-128`) tracked in Linear.
 - Close confirmed P0 risks from the production-hardening brief before strengthening production-readiness claims.
@@ -157,3 +157,4 @@ Post-v1.0.0 work tracked as Linear issues GEN-75 through GEN-81.
 - Phase 11 `EAP-109` strict typing tranche completed for executor runtime path with CI scoped gate expansion (`GEN-65`).
 - Phase 9 `EAP-098` backup/restore workflow completed (state DB + diagnostics snapshot command set, restore verification/rollback flow, and recovery runbook) (`GEN-58`).
 - Phase 9 `EAP-099` soak + chaos reliability gate completed (fault-injection scorecard harness, CI release gate lane, thresholds/baseline, and remediation docs) (`GEN-59`).
+- Phase 13 `EAP-128` production-hardening regression gatepack completed (Phase 13 package, runtime auth/server, sandbox, SSRF, macro safety, and network lifecycle gates) (`GEN-208`).

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -68,9 +68,9 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 | 38 | `EAP-125` | `GEN-205` | `Done` | Add SSRF protection and streaming byte caps to web tools |
 | 39 | `EAP-126` | `GEN-206` | `Done` | Add macro cycle detection and execution timeout controls |
 | 40 | `EAP-127` | `GEN-207` | `Done` | Harden connection pooling and request lifecycle |
-| 41 | `EAP-128` | `GEN-208` | `Todo` | Add production-hardening regression gatepack |
+| 41 | `EAP-128` | `GEN-208` | `Done` | Add production-hardening regression gatepack |
 
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is active. `EAP-127` is complete; `EAP-128` is the next ordered `Todo`.
+Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is complete. Create and approve the next ordered queue before starting new implementation work.

--- a/docs/phase13_production_hardening_roadmap.md
+++ b/docs/phase13_production_hardening_roadmap.md
@@ -1,6 +1,6 @@
 # Phase 13 Production Hardening Roadmap
 
-Status: Active  
+Status: Completed
 Source of truth: Linear project `Efficient Agent Protocol Roadmap`  
 Intake source: production-hardening review received 2026-04-28
 
@@ -14,7 +14,7 @@ Current status:
 - [x] `EAP-125` add SSRF protection and streaming byte caps to web tools (`GEN-205`)
 - [x] `EAP-126` add macro cycle detection and execution timeout controls (`GEN-206`)
 - [x] `EAP-127` harden connection pooling and request lifecycle (`GEN-207`)
-- [ ] `EAP-128` add production-hardening regression gatepack (`GEN-208`)
+- [x] `EAP-128` add production-hardening regression gatepack (`GEN-208`)
 
 ## Objective
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -44,7 +44,7 @@ Compatibility policy:
 Before tagging `v1.0.0`, complete every item below in order:
 
 1. **Stabilization checklist**: verify all boxes in `docs/v1_stabilization_checklist.md` are checked.
-2. **Readiness gatepack**: run `PYTHONPATH=. python scripts/v1_readiness_gatepack.py` and confirm `PASS (9/9)`.
+2. **Readiness gatepack**: run `PYTHONPATH=. python scripts/v1_readiness_gatepack.py` and confirm `PASS (10/10)`.
 3. **CI green**: all workflows on the release branch are green (CI, Security, CodeQL).
 4. **Contract lock**: `docs/v1_contract_lock.json` reflects the intended v1.0 surface.
 5. **Upgrade notes**: `docs/upgrade_notes_v1.md` is complete with breaking changes, migration actions, and rollback guidance.

--- a/docs/upgrade_notes_v1.md
+++ b/docs/upgrade_notes_v1.md
@@ -6,7 +6,7 @@
 
 - Package version bumped from `0.1.9` to `1.0.0`.
 - All stabilization checklist items are complete (see `docs/v1_stabilization_checklist.md`).
-- V1 readiness gatepack passes all 9 gates (`scripts/v1_readiness_gatepack.py`).
+- V1 readiness gatepack passes all 10 gates (`scripts/v1_readiness_gatepack.py`).
 - Release and maintainer runbooks finalized for v1 process.
 - Release Drafter template aligned with `docs/release_notes_template.md` structure.
 - No runtime behavior changes between `0.1.9` and `1.0.0`; this is a stability milestone.
@@ -25,7 +25,7 @@ The following are frozen and covered by contract tests (see `docs/v1_contract.md
 
 ## Added
 
-- Unified V1 readiness gatepack (`scripts/v1_readiness_gatepack.py`) — one command to validate all 9 pre-release gates.
+- Unified V1 readiness gatepack (`scripts/v1_readiness_gatepack.py`) — one command to validate all 10 pre-release gates.
 - `docs/v1_readiness_gates.md` — gate-to-evidence mapping.
 - `docs/v1_go_no_go_checklist.md` — release candidate decision criteria.
 - Contract tests for docs/README alignment (`tests/contract/test_docs_v1_alignment.py`).
@@ -110,7 +110,7 @@ python scripts/migrate_state_db.py --db-path agent_state.db --backup
 After upgrading to `1.0.0`, run these commands to validate runtime behavior:
 
 ```bash
-# 1. V1 readiness gatepack (all 9 gates)
+# 1. V1 readiness gatepack (all 10 gates)
 PYTHONPATH=. python scripts/v1_readiness_gatepack.py
 
 # 2. Contract lock validation

--- a/docs/v1_go_no_go_checklist.md
+++ b/docs/v1_go_no_go_checklist.md
@@ -28,7 +28,7 @@ git push -u origin release/v1.0.0-rc1
 ### 2. Run Local Validation
 
 ```bash
-# Full readiness gatepack (9 gates)
+# Full readiness gatepack (10 gates)
 PYTHONPATH=. python scripts/v1_readiness_gatepack.py
 
 # Contract lock check
@@ -77,7 +77,7 @@ Document the following for each RC:
 
 | Evidence | Location |
 | --- | --- |
-| Gatepack output (9/9 PASS) | Terminal output or CI log |
+| Gatepack output (10/10 PASS) | Terminal output or CI log |
 | CI release workflow run URL | GitHub Actions |
 | TestPyPI package URL | `https://test.pypi.org/project/efficient-agent-protocol/1.0.0rc1/` |
 | Install smoke test result | Terminal output |
@@ -89,7 +89,7 @@ Document the following for each RC:
 
 ### Must-Pass (blocking)
 
-- [ ] All 9 readiness gates pass (`scripts/v1_readiness_gatepack.py` reports `PASS 9/9`).
+- [ ] All 10 readiness gates pass (`scripts/v1_readiness_gatepack.py` reports `PASS 10/10`).
 - [ ] `docs/v1_stabilization_checklist.md` — all stabilization items checked.
 - [ ] CI green on `main`: lint/test (py3.10, 3.11), coverage gates, contract gate, upgrade migration, eval scorecard, competitive benchmark, soak+chaos, security scans.
 - [ ] RC release workflow succeeds (build + TestPyPI publish).

--- a/docs/v1_readiness_gates.md
+++ b/docs/v1_readiness_gates.md
@@ -20,6 +20,7 @@ PYTHONPATH=. python scripts/v1_readiness_gatepack.py
 | 7 | Coverage | Line >= 80%, branch >= 65% | `coverage.json` |
 | 8 | Dependency security | `pip-audit` reports zero vulnerabilities | pip-audit output |
 | 9 | Threshold files | All baseline/threshold JSON files present | file existence check |
+| 10 | Production hardening regressions | Phase 13 P0/P1 risk classes have direct regression coverage | `scripts/production_hardening_gatepack.py` output |
 
 ## Gate Details
 
@@ -109,6 +110,16 @@ All CI threshold and baseline files must be present and version-controlled:
 - `docs/competitive_reference_profiles.json`
 - `docs/v1_contract_lock.json`
 
+### 10. Production Hardening Regression Gates
+
+Runs the focused Phase 13 gatepack for package ownership, ASGI runtime
+boundary, fail-closed auth, file sandboxing, SSRF protections, macro cycle and
+timeout controls, and bounded network lifecycle.
+
+```bash
+PYTHONPATH=. python scripts/production_hardening_gatepack.py
+```
+
 ## CI Gates (Automated)
 
 The following are enforced automatically by GitHub Actions CI on every push:
@@ -123,6 +134,7 @@ The following are enforced automatically by GitHub Actions CI on every push:
 | Competitive benchmark | Advantage gates vs reference profiles |
 | Soak + chaos reliability | Failure rate, latency, chaos scenario pass rate |
 | Dependency vulnerability audit | pip-audit scan |
+| Production hardening regression gates | Phase 13 production-risk regression suite |
 | Secret scan (Gitleaks) | No leaked secrets |
 | CodeQL analysis | No high-severity code scanning alerts |
 | Build package | Wheel builds and installs cleanly |

--- a/scripts/production_hardening_gatepack.py
+++ b/scripts/production_hardening_gatepack.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Production-hardening regression gatepack for Phase 13 fixes.
+
+Exit codes:
+    0 - all hardening gates pass
+    1 - one or more hardening gates failed
+
+Run from the repository root with ``PYTHONPATH=.``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@dataclass(frozen=True)
+class HardeningGate:
+    name: str
+    risk_class: str
+    command: list[str]
+    evidence: str
+    known_bad_fixture: str
+    timeout_seconds: int = 90
+
+
+@dataclass(frozen=True)
+class GateResult:
+    name: str
+    risk_class: str
+    passed: bool
+    detail: str
+    command: list[str]
+    evidence: str
+    known_bad_fixture: str
+
+
+HARDENING_GATES = [
+    HardeningGate(
+        name="Package ownership and canonical imports",
+        risk_class="duplicate package trees / ambiguous runtime ownership",
+        command=[
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/contract/test_package_namespace_contract.py",
+            "tests/contract/test_canonical_import_references.py",
+            "-q",
+            "--tb=line",
+        ],
+        evidence="tests/contract/test_package_namespace_contract.py; tests/contract/test_canonical_import_references.py",
+        known_bad_fixture="fails if legacy top-level packages become real implementations or docs/tests drift back to legacy imports",
+    ),
+    HardeningGate(
+        name="Runtime ASGI boundary and fail-closed auth",
+        risk_class="per-request event loop server path / anonymous trusted runtime access",
+        command=[
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/contract/test_runtime_asgi_contract.py",
+            "tests/contract/test_runtime_auth_scopes.py",
+            "tests/integration/test_runtime_http_api.py::RuntimeHttpApiIntegrationTest::test_execute_macro_rejects_missing_auth",
+            "tests/integration/test_runtime_http_api.py::RuntimeHttpApiIntegrationTest::test_execute_macro_rejects_oversized_request_body",
+            "-q",
+            "--tb=line",
+        ],
+        evidence="tests/contract/test_runtime_asgi_contract.py; tests/contract/test_runtime_auth_scopes.py; tests/integration/test_runtime_http_api.py",
+        known_bad_fixture="fails if ThreadingHTTPServer/asyncio.run returns, auth fails open, or request body caps are removed",
+    ),
+    HardeningGate(
+        name="Filesystem sandbox regressions",
+        risk_class="unrestricted local file read/write/list access",
+        command=[
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/unit/test_tools.py::ToolModuleTest::test_file_tools_reject_traversal_escape",
+            "tests/unit/test_tools.py::ToolModuleTest::test_file_tools_reject_absolute_escape",
+            "tests/unit/test_tools.py::ToolModuleTest::test_file_tools_reject_symlink_escape",
+            "tests/unit/test_tools.py::ToolModuleTest::test_file_tool_root_env_configures_default_sandbox",
+            "-q",
+            "--tb=line",
+        ],
+        evidence="tests/unit/test_tools.py",
+        known_bad_fixture="fails if path traversal, absolute escapes, symlink escapes, or sandbox-root configuration regress",
+    ),
+    HardeningGate(
+        name="Web SSRF and streaming byte caps",
+        risk_class="SSRF exposure / post-load response size limiting",
+        command=[
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/unit/test_tools.py::ToolModuleTest::test_web_tools_reject_private_and_localhost_targets",
+            "tests/unit/test_tools.py::ToolModuleTest::test_web_tools_recheck_redirect_targets_for_ssrf",
+            "tests/unit/test_tools.py::ToolModuleTest::test_web_tools_streaming_byte_cap_stops_early",
+            "-q",
+            "--tb=line",
+        ],
+        evidence="tests/unit/test_tools.py",
+        known_bad_fixture="fails if private/link-local/localhost DNS targets, unsafe redirects, or streaming byte caps are no longer enforced",
+    ),
+    HardeningGate(
+        name="Macro cycle and timeout safety",
+        risk_class="macro dependency cycles / unbounded macro execution",
+        command=[
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/unit/test_executor_errors.py::ExecutorErrorContractTest::test_direct_dependency_cycle_is_rejected",
+            "tests/unit/test_executor_errors.py::ExecutorErrorContractTest::test_indirect_dependency_cycle_is_rejected",
+            "tests/unit/test_executor_errors.py::ExecutorErrorContractTest::test_macro_total_timeout_returns_structured_error_pointer",
+            "tests/integration/test_runtime_http_api.py::RuntimeHttpApiIntegrationTest::test_execute_macro_rejects_dependency_cycle",
+            "-q",
+            "--tb=line",
+        ],
+        evidence="tests/unit/test_executor_errors.py; tests/integration/test_runtime_http_api.py",
+        known_bad_fixture="fails if direct/indirect cycles compile or total macro timeouts stop returning structured macro_timeout errors",
+    ),
+    HardeningGate(
+        name="Bounded network lifecycle",
+        risk_class="unbounded HTTP sessions / missing timeout and pool controls",
+        command=[
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/unit/test_http_client.py",
+            "tests/unit/test_openclaw_client.py",
+            "-q",
+            "--tb=line",
+        ],
+        evidence="tests/unit/test_http_client.py; tests/unit/test_openclaw_client.py",
+        known_bad_fixture="fails if critical network clients stop using bounded connect/read timeouts, retries, or owned-session lifecycle cleanup",
+    ),
+]
+
+
+def _run(command: list[str], timeout_seconds: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+    )
+
+
+def _summarize_output(result: subprocess.CompletedProcess[str]) -> str:
+    output = result.stdout.strip() or result.stderr.strip()
+    if not output:
+        return f"exit={result.returncode}"
+    lines = output.splitlines()
+    return lines[-1] if result.returncode == 0 else output[-800:]
+
+
+def run_gatepack() -> dict[str, object]:
+    results: List[GateResult] = []
+    for gate in HARDENING_GATES:
+        try:
+            completed = _run(gate.command, timeout_seconds=gate.timeout_seconds)
+            passed = completed.returncode == 0
+            detail = _summarize_output(completed)
+        except subprocess.TimeoutExpired as exc:
+            passed = False
+            detail = f"Timed out after {exc.timeout}s"
+        results.append(
+            GateResult(
+                name=gate.name,
+                risk_class=gate.risk_class,
+                passed=passed,
+                detail=detail,
+                command=gate.command,
+                evidence=gate.evidence,
+                known_bad_fixture=gate.known_bad_fixture,
+            )
+        )
+
+    all_passed = all(result.passed for result in results)
+    return {
+        "status": "PASS" if all_passed else "FAIL",
+        "gates_total": len(results),
+        "gates_passed": sum(1 for result in results if result.passed),
+        "gates_failed": sum(1 for result in results if not result.passed),
+        "gates": [
+            {
+                "name": result.name,
+                "risk_class": result.risk_class,
+                "passed": result.passed,
+                "detail": result.detail,
+                "command": result.command,
+                "evidence": result.evidence,
+                "known_bad_fixture": result.known_bad_fixture,
+            }
+            for result in results
+        ],
+    }
+
+
+def main() -> int:
+    if "--json-only" in sys.argv:
+        report = run_gatepack()
+        print(json.dumps(report, indent=2))
+        return 0 if report["status"] == "PASS" else 1
+
+    print("=" * 72)
+    print("  Production Hardening Regression Gatepack")
+    print("=" * 72)
+
+    report = run_gatepack()
+    for gate in report["gates"]:
+        icon = "PASS" if gate["passed"] else "FAIL"
+        print(f"\n  [{icon}] {gate['name']}")
+        print(f"         Risk: {gate['risk_class']}")
+        print(f"         {gate['detail']}")
+
+    print("\n" + "=" * 72)
+    print(f"  Result: {report['status']}  ({report['gates_passed']}/{report['gates_total']} gates passed)")
+    print("=" * 72)
+    print(json.dumps(report, indent=2))
+    return 0 if report["status"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/v1_readiness_gatepack.py
+++ b/scripts/v1_readiness_gatepack.py
@@ -211,7 +211,7 @@ def gate_security_audit() -> GateResult:
         timeout=60,
     )
     passed = result.returncode == 0
-    detail = "No vulnerabilities found" if passed else result.stdout.strip()[:300]
+    detail = "No vulnerabilities found" if passed else (result.stdout.strip() or result.stderr.strip())[:300]
     return GateResult(
         name="Dependency security audit",
         passed=passed,
@@ -241,6 +241,27 @@ def gate_threshold_files() -> GateResult:
     )
 
 
+def gate_production_hardening() -> GateResult:
+    """Gate 10: Phase 13 production-hardening regressions stay covered."""
+    result = _run([sys.executable, "scripts/production_hardening_gatepack.py", "--json-only"], timeout=180)
+    passed = result.returncode == 0
+    if passed:
+        try:
+            report = json.loads(result.stdout)
+            detail = f"All {report.get('gates_passed')}/{report.get('gates_total')} hardening gates passed"
+        except (json.JSONDecodeError, AttributeError):
+            lines = result.stdout.strip().splitlines()
+            detail = lines[-1] if lines else "production hardening gatepack passed"
+    else:
+        detail = (result.stdout.strip() or result.stderr.strip())[-800:]
+    return GateResult(
+        name="Production hardening regression gates",
+        passed=passed,
+        detail=detail,
+        evidence="scripts/production_hardening_gatepack.py output",
+    )
+
+
 GATES = [
     gate_v1_contract,
     gate_upgrade_migration,
@@ -251,6 +272,7 @@ GATES = [
     gate_coverage,
     gate_security_audit,
     gate_threshold_files,
+    gate_production_hardening,
 ]
 
 

--- a/tests/unit/test_production_hardening_gatepack.py
+++ b/tests/unit/test_production_hardening_gatepack.py
@@ -1,0 +1,62 @@
+from scripts.production_hardening_gatepack import HARDENING_GATES
+from scripts.v1_readiness_gatepack import GATES, gate_production_hardening
+
+
+REQUIRED_RISK_FRAGMENTS = [
+    "duplicate package trees",
+    "anonymous trusted runtime access",
+    "unrestricted local file",
+    "SSRF exposure",
+    "macro dependency cycles",
+    "unbounded HTTP sessions",
+]
+
+REQUIRED_TEST_TARGETS = [
+    "tests/contract/test_package_namespace_contract.py",
+    "tests/contract/test_canonical_import_references.py",
+    "tests/contract/test_runtime_asgi_contract.py",
+    "tests/contract/test_runtime_auth_scopes.py",
+    "test_execute_macro_rejects_missing_auth",
+    "test_execute_macro_rejects_oversized_request_body",
+    "test_file_tools_reject_traversal_escape",
+    "test_file_tools_reject_absolute_escape",
+    "test_file_tools_reject_symlink_escape",
+    "test_web_tools_reject_private_and_localhost_targets",
+    "test_web_tools_recheck_redirect_targets_for_ssrf",
+    "test_web_tools_streaming_byte_cap_stops_early",
+    "test_direct_dependency_cycle_is_rejected",
+    "test_indirect_dependency_cycle_is_rejected",
+    "test_macro_total_timeout_returns_structured_error_pointer",
+    "test_execute_macro_rejects_dependency_cycle",
+    "tests/unit/test_http_client.py",
+    "tests/unit/test_openclaw_client.py",
+]
+
+
+def _gate_commands() -> str:
+    return "\n".join(" ".join(gate.command) for gate in HARDENING_GATES)
+
+
+def test_hardening_gatepack_covers_all_phase13_risk_classes() -> None:
+    risks = "\n".join(gate.risk_class for gate in HARDENING_GATES)
+
+    for fragment in REQUIRED_RISK_FRAGMENTS:
+        assert fragment in risks
+
+
+def test_hardening_gatepack_targets_direct_regression_tests() -> None:
+    commands = _gate_commands()
+
+    for target in REQUIRED_TEST_TARGETS:
+        assert target in commands
+
+
+def test_hardening_gatepack_documents_known_bad_fixtures() -> None:
+    for gate in HARDENING_GATES:
+        assert gate.known_bad_fixture
+        assert "fails if" in gate.known_bad_fixture
+        assert gate.evidence
+
+
+def test_v1_readiness_gatepack_runs_production_hardening_gate() -> None:
+    assert gate_production_hardening in GATES


### PR DESCRIPTION
## Summary
- add a dedicated production-hardening regression gatepack for Phase 13 risk classes
- wire the hardening gatepack into the unified V1 readiness gatepack as the 10th gate
- update release/readiness docs and roadmap mirrors for EAP-128/GEN-208

## Validation
- /tmp/eap-eap125-focus.RgBrSq/bin/python -m pytest tests/unit/test_production_hardening_gatepack.py tests/contract/test_docs_v1_alignment.py -q
- PYTHONPATH=. /tmp/eap-eap125-focus.RgBrSq/bin/python scripts/production_hardening_gatepack.py --json-only
- /tmp/eap-eap125-focus.RgBrSq/bin/python -m ruff check . --select E9,F63,F7,F82

## Note
- Local unified V1 gatepack reaches and passes the new hardening gate, but this machine's pip-audit subprocess fails while creating its temporary audit venv due local ensurepip SIGABRT. CI runs pip-audit in a clean GitHub runner.