### PR TITLE
EAP-129 create Phase 14 release maintenance queue

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -100,6 +100,14 @@ This roadmap tracks what is needed to recommend EAP without caveats.
 - Prioritize package ownership, runtime server/auth safety, sandboxed tools, SSRF controls, macro hang protection, and regression gates.
 - Checklist: `docs/phase13_production_hardening_roadmap.md`
 
+## Phase 14: Release Maintenance / v1.0.1 Readiness (Active)
+
+- Execute ordered release-maintenance queue (`EAP-129` to `EAP-133`) tracked in Linear.
+- Remove release noise from package metadata and GitHub Actions runtime warnings.
+- Refresh public release evidence after Phase 13 completion.
+- Run the final `v1.0.1` release readiness dry-run before tagging.
+- Checklist: `docs/phase14_release_maintenance_roadmap.md`
+
 ## Post-v1: Hardening and Ecosystem (Completed)
 
 Post-v1.0.0 work tracked as Linear issues GEN-75 through GEN-81.

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,4 +96,5 @@
 | [phase10_competitiveness_hardening_roadmap.md](phase10_competitiveness_hardening_roadmap.md) | Competitive hardening (completed) |
 | [phase11_typing_rigor_completion_roadmap.md](phase11_typing_rigor_completion_roadmap.md) | Typing rigor completion (completed) |
 | [phase12_v1_launch_readiness_roadmap.md](phase12_v1_launch_readiness_roadmap.md) | V1 launch readiness stabilization (completed) |
-| [phase13_production_hardening_roadmap.md](phase13_production_hardening_roadmap.md) | Production hardening and v1.0.1 blockers (active) |
+| [phase13_production_hardening_roadmap.md](phase13_production_hardening_roadmap.md) | Production hardening and v1.0.1 blockers (completed) |
+| [phase14_release_maintenance_roadmap.md](phase14_release_maintenance_roadmap.md) | Release maintenance and v1.0.1 readiness (active) |

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -24,7 +24,7 @@ This protocol prevents ad-hoc execution and keeps all work in a visible ordered 
 
 ## Current Ordered Queue
 
-Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
+Updated: 2026-04-29 (Phase 14 release maintenance intake)
 
 | Order | EAP ID | Linear | Status | Notes |
 | --- | --- | --- | --- | --- |
@@ -69,8 +69,13 @@ Updated: 2026-04-28 (v1.0.0 baseline plus Phase 13 hardening intake)
 | 39 | `EAP-126` | `GEN-206` | `Done` | Add macro cycle detection and execution timeout controls |
 | 40 | `EAP-127` | `GEN-207` | `Done` | Harden connection pooling and request lifecycle |
 | 41 | `EAP-128` | `GEN-208` | `Done` | Add production-hardening regression gatepack |
+| 42 | `EAP-129` | `GEN-209` | `Done` | Create Phase 14 release maintenance queue |
+| 43 | `EAP-130` | `GEN-210` | `Todo` | Clean up package license metadata |
+| 44 | `EAP-131` | `GEN-211` | `Todo` | Resolve GitHub Actions Node runtime warnings |
+| 45 | `EAP-132` | `GEN-212` | `Todo` | Refresh release evidence and docs index |
+| 46 | `EAP-133` | `GEN-213` | `Todo` | Run v1.0.1 release readiness dry-run |
 
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 13 (Production Hardening / v1.0.1 Blockers) is complete. Create and approve the next ordered queue before starting new implementation work.
+Current state: Phase 14 (Release Maintenance / v1.0.1 Readiness) is active. `EAP-129` defines the queue; `EAP-130` is the next ordered `Todo`.

--- a/docs/phase14_release_maintenance_roadmap.md
+++ b/docs/phase14_release_maintenance_roadmap.md
@@ -1,0 +1,49 @@
+# Phase 14 Release Maintenance Roadmap
+
+Status: Active  
+Source of truth: Linear project `Efficient Agent Protocol Roadmap`  
+Intake source: post-Phase 13 completion and post-merge CI annotations from 2026-04-29
+
+Current status:
+- [x] `EAP-129` create Phase 14 release maintenance queue (`GEN-209`)
+- [ ] `EAP-130` clean up package license metadata (`GEN-210`)
+- [ ] `EAP-131` resolve GitHub Actions Node runtime warnings (`GEN-211`)
+- [ ] `EAP-132` refresh release evidence and docs index (`GEN-212`)
+- [ ] `EAP-133` run v1.0.1 release readiness dry-run (`GEN-213`)
+
+## Objective
+
+Close the remaining release-maintenance friction after Phase 13 so the next patch release can be cut from a clean, explainable, and fully evidenced baseline.
+
+This phase is intentionally small. It does not add product features. It removes release noise, updates public release evidence, and verifies that `v1.0.1` is ready to tag.
+
+## Scope
+
+The Phase 14 queue targets the visible post-hardening maintenance items:
+
+- non-blocking setuptools license metadata deprecation warning during package build
+- GitHub Actions Node.js runtime deprecation annotations on CI jobs
+- docs index drift after Phase 13 completion
+- final release evidence for the current `1.0.1` package baseline
+
+## Ordered Implementation Items
+
+| Order | EAP ID | Linear | Priority | Scope | Deliverable | Done Criteria |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | `EAP-129` | `GEN-209` | P2 | Intake and tracker | Create this roadmap, update `ROADMAP.md` and `docs/execution_protocol.md`, and create Linear issues for Phase 14 | Phase 14 queue is visible in docs and Linear; first executable Todo is clear |
+| 2 | `EAP-130` | `GEN-210` | P2 | Packaging metadata | Replace deprecated license metadata with current supported packaging format | Package build completes without the setuptools license metadata deprecation warning; MIT license metadata remains correct |
+| 3 | `EAP-131` | `GEN-211` | P2 | CI runtime warnings | Inventory and resolve GitHub Actions Node.js runtime deprecation annotations | CI no longer emits actionable Node.js 20 warnings, or each remaining warning has a documented upstream blocker |
+| 4 | `EAP-132` | `GEN-212` | P2 | Docs and release evidence | Refresh docs index, roadmap status, and v1.0.1 release evidence | Public docs show Phase 13 complete, Phase 14 active, and current release blockers/evidence accurately |
+| 5 | `EAP-133` | `GEN-213` | P2 | Release dry-run | Run final v1.0.1 readiness evidence pass | Unified gatepack, package smoke, and GitHub main workflows are green or blockers are explicitly listed |
+
+## Dependency Order
+
+1. `EAP-129` must complete first so the new work is visible and tracked.
+2. `EAP-130` removes package-build warning noise before the release dry-run.
+3. `EAP-131` removes or documents CI warning noise before release evidence is refreshed.
+4. `EAP-132` updates public docs and release evidence after the warning cleanup work.
+5. `EAP-133` closes the phase with a go/no-go dry-run for the `v1.0.1` release.
+
+## Execution Constraint
+
+Do not start implementation until this ordered queue is mirrored in Linear and `docs/execution_protocol.md`. After `EAP-129` is merged, `EAP-130` is the first executable `Todo`.


### PR DESCRIPTION
## Summary
- add Phase 14 release maintenance roadmap for v1.0.1 readiness
- mirror EAP-129 through EAP-133 in the execution protocol
- update the roadmap and docs index so Phase 13 is completed and Phase 14 is active

## Linear
- GEN-209
- GEN-210
- GEN-211
- GEN-212
- GEN-213

## Validation
- /tmp/eap-eap125-focus.RgBrSq/bin/python -m pytest tests/contract/test_docs_v1_alignment.py -q
- git diff --check

## Next ordered item after merge
- EAP-130 / GEN-210: Clean up package license metadata