### PR TITLE
EAP-130 clean up package license metadata

### DIFF
--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -70,7 +70,7 @@ Updated: 2026-04-29 (Phase 14 release maintenance intake)
 | 40 | `EAP-127` | `GEN-207` | `Done` | Harden connection pooling and request lifecycle |
 | 41 | `EAP-128` | `GEN-208` | `Done` | Add production-hardening regression gatepack |
 | 42 | `EAP-129` | `GEN-209` | `Done` | Create Phase 14 release maintenance queue |
-| 43 | `EAP-130` | `GEN-210` | `Todo` | Clean up package license metadata |
+| 43 | `EAP-130` | `GEN-210` | `Done` | Clean up package license metadata |
 | 44 | `EAP-131` | `GEN-211` | `Todo` | Resolve GitHub Actions Node runtime warnings |
 | 45 | `EAP-132` | `GEN-212` | `Todo` | Refresh release evidence and docs index |
 | 46 | `EAP-133` | `GEN-213` | `Todo` | Run v1.0.1 release readiness dry-run |
@@ -78,4 +78,4 @@ Updated: 2026-04-29 (Phase 14 release maintenance intake)
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 14 (Release Maintenance / v1.0.1 Readiness) is active. `EAP-129` defines the queue; `EAP-130` is the next ordered `Todo`.
+Current state: Phase 14 (Release Maintenance / v1.0.1 Readiness) is active. `EAP-130` is complete; `EAP-131` is the next ordered `Todo`.

--- a/docs/phase14_release_maintenance_roadmap.md
+++ b/docs/phase14_release_maintenance_roadmap.md
@@ -6,7 +6,7 @@ Intake source: post-Phase 13 completion and post-merge CI annotations from 2026-
 
 Current status:
 - [x] `EAP-129` create Phase 14 release maintenance queue (`GEN-209`)
-- [ ] `EAP-130` clean up package license metadata (`GEN-210`)
+- [x] `EAP-130` clean up package license metadata (`GEN-210`)
 - [ ] `EAP-131` resolve GitHub Actions Node runtime warnings (`GEN-211`)
 - [ ] `EAP-132` refresh release evidence and docs index (`GEN-212`)
 - [ ] `EAP-133` run v1.0.1 release readiness dry-run (`GEN-213`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "efficient-agent-protocol"
 version = "1.0.1"
 description = "Local-first framework for multi-step tool workflows with pointer-backed state and DAG execution."
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.10,<3.14"
 
 dependencies = [

--- a/tests/contract/test_package_metadata_contract.py
+++ b/tests/contract/test_package_metadata_contract.py
@@ -1,4 +1,3 @@
-import tomllib
 from pathlib import Path
 
 
@@ -7,9 +6,8 @@ PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
 
 
 def test_project_license_uses_pep639_spdx_expression() -> None:
-    pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
-    project = pyproject["project"]
+    text = PYPROJECT_PATH.read_text(encoding="utf-8")
 
-    assert project["license"] == "MIT"
-    assert not isinstance(project["license"], dict)
-    assert project["license-files"] == ["LICENSE"]
+    assert 'license = "MIT"' in text
+    assert 'license = {' not in text
+    assert 'license-files = ["LICENSE"]' in text

--- a/tests/contract/test_package_metadata_contract.py
+++ b/tests/contract/test_package_metadata_contract.py
@@ -1,0 +1,15 @@
+import tomllib
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+
+
+def test_project_license_uses_pep639_spdx_expression() -> None:
+    pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    project = pyproject["project"]
+
+    assert project["license"] == "MIT"
+    assert not isinstance(project["license"], dict)
+    assert project["license-files"] == ["LICENSE"]


### PR DESCRIPTION
## Summary
- replace deprecated `project.license` TOML table with PEP 639 SPDX string metadata
- add `license-files = ["LICENSE"]` so built distributions keep the license file
- add a contract test to prevent regressing to the deprecated license table form
- update Phase 14 queue docs so EAP-131 is next after merge

## Validation
- `/tmp/eap-eap125-focus.RgBrSq/bin/python -m pytest tests/contract/test_package_metadata_contract.py tests/contract/test_docs_v1_alignment.py -q`
- `/tmp/eap-eap125-focus.RgBrSq/bin/python -m pytest tests/contract/test_package_metadata_contract.py tests/contract/test_package_namespace_contract.py -q`
- `/tmp/eap-eap125-focus.RgBrSq/bin/python -m ruff check . --select E9,F63,F7,F82`
- `/tmp/eap-eap125-focus.RgBrSq/bin/python -m build --sdist --wheel --outdir /tmp/eap-eap130-dist-final`
- verified build log contains no setuptools license metadata deprecation warning
- verified wheel metadata contains `License-Expression: MIT` and `License-File: LICENSE`
- verified isolated wheel install imports `eap.protocol.StateManager`

## Linear
- GEN-210

## Next ordered item after merge
- EAP-131 / GEN-211: Resolve GitHub Actions Node runtime warnings
