### PR TITLE
EAP-131 resolve GitHub Actions Node runtime warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -134,10 +134,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -163,7 +163,7 @@ jobs:
 
       - name: Upload bootstrap artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bootstrap-smoke
           path: artifacts/bootstrap/
@@ -176,10 +176,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -201,7 +201,7 @@ jobs:
 
       - name: Upload evaluation artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: eval-scorecard
           path: artifacts/eval/
@@ -214,10 +214,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -231,7 +231,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Download evaluation artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: eval-scorecard
           path: artifacts/eval
@@ -246,7 +246,7 @@ jobs:
 
       - name: Upload competitive benchmark artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: competitive-benchmark
           path: artifacts/competitive_benchmarks/
@@ -259,10 +259,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -287,7 +287,7 @@ jobs:
 
       - name: Upload soak + chaos artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: soak-chaos-reliability
           path: artifacts/soak_chaos/
@@ -300,10 +300,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -365,7 +365,7 @@ jobs:
 
       - name: Upload self-hosted artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: self-hosted-smoke
           path: artifacts/self_hosted/
@@ -384,10 +384,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -409,7 +409,7 @@ jobs:
           RUN_PACKAGING_SMOKE=1 python -m pytest -q tests/packaging/test_install_smoke.py
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/openclaw-interop.yml
+++ b/.github/workflows/openclaw-interop.yml
@@ -22,16 +22,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -57,7 +57,7 @@ jobs:
           python -m twine check dist/*
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,13 +18,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+
+      - name: Install gitleaks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: "8.30.1"
+        run: |
+          set -euo pipefail
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -fsSL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}" \
+            -o "/tmp/${archive}"
+          curl -fsSL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" \
+            -o /tmp/gitleaks_checksums.txt
+          (cd /tmp && grep " ${archive}$" gitleaks_checksums.txt | sha256sum -c -)
+          tar -xzf "/tmp/${archive}" -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+
+      - name: Run gitleaks
+        run: gitleaks detect --source . --redact --verbose
 
   dependency-review:
     name: Dependency Review
@@ -35,4 +50,8 @@ jobs:
       pull-requests: read
     steps:
       - name: Dependency review
+        env:
+          # Upstream dependency-review-action@v4 still declares node20 as of 2026-04-29.
+          # Force the runner compatibility path until a node24 major is published.
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         uses: actions/dependency-review-action@v4

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -71,11 +71,11 @@ Updated: 2026-04-29 (Phase 14 release maintenance intake)
 | 41 | `EAP-128` | `GEN-208` | `Done` | Add production-hardening regression gatepack |
 | 42 | `EAP-129` | `GEN-209` | `Done` | Create Phase 14 release maintenance queue |
 | 43 | `EAP-130` | `GEN-210` | `Done` | Clean up package license metadata |
-| 44 | `EAP-131` | `GEN-211` | `Todo` | Resolve GitHub Actions Node runtime warnings |
+| 44 | `EAP-131` | `GEN-211` | `Done` | Resolve GitHub Actions Node runtime warnings |
 | 45 | `EAP-132` | `GEN-212` | `Todo` | Refresh release evidence and docs index |
 | 46 | `EAP-133` | `GEN-213` | `Todo` | Run v1.0.1 release readiness dry-run |
 
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 14 (Release Maintenance / v1.0.1 Readiness) is active. `EAP-130` is complete; `EAP-131` is the next ordered `Todo`.
+Current state: Phase 14 (Release Maintenance / v1.0.1 Readiness) is active. `EAP-131` is complete; `EAP-132` is the next ordered `Todo`.

--- a/docs/github_actions_runtime_inventory.md
+++ b/docs/github_actions_runtime_inventory.md
@@ -1,0 +1,46 @@
+# GitHub Actions Runtime Inventory
+
+Status: Active for `EAP-131` / `GEN-211`  
+Last reviewed: 2026-04-29
+
+## Purpose
+
+Track JavaScript GitHub Actions that can emit Node.js runtime deprecation warnings so release evidence stays clean and explainable.
+
+## Resolution Summary
+
+Most workflow actions now use upstream majors that declare `runs.using: node24`:
+
+| Action family | Previous pin | Current pin | Runtime status |
+| --- | --- | --- | --- |
+| `actions/checkout` | `v4` | `v6` | Node 24 |
+| `actions/setup-python` | `v5` | `v6` | Node 24 |
+| `actions/setup-node` | `v4` | `v6` | Node 24 |
+| `actions/upload-artifact` | `v4` | `v7` | Node 24 |
+| `actions/download-artifact` | `v4` | `v8` | Node 24 |
+| `release-drafter/release-drafter` | `v6` | `v7` | Node 24 |
+| `github/codeql-action/*` | `v4` | `v4` | Node 24 already |
+| `pypa/gh-action-pypi-publish` | `release/v1` | `release/v1` | Composite action, no JavaScript runtime warning |
+
+`gitleaks/gitleaks-action@v2` still declares `runs.using: node20`, so the Security workflow now installs and runs the pinned Gitleaks CLI directly instead of invoking the JavaScript action.
+
+## Remaining Upstream Blocker
+
+`actions/dependency-review-action@v4` still declares `runs.using: node20` as of 2026-04-29, and no Node 24-compatible major is published yet. The job remains PR-only and opt-in behind `vars.ENABLE_DEPENDENCY_REVIEW == 'true'`.
+
+Temporary mitigation:
+
+- The step sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` so GitHub-hosted runners use the Node 24 compatibility path.
+- Keep this documented until `actions/dependency-review-action@v5` or another Node 24-compatible major exists.
+- Do not loosen workflow permissions while carrying this blocker; the job still requests only `contents: read` and `pull-requests: read`.
+
+## Validation
+
+For future release evidence, verify:
+
+```bash
+rg -n "actions/(checkout@v4|setup-python@v5|setup-node@v4|upload-artifact@v4|download-artifact@v4)|gitleaks/gitleaks-action@v2|release-drafter/release-drafter@v6" .github/workflows
+python -m pytest -q tests/contract/test_github_actions_runtime_contract.py
+```
+
+The first command should return no matches. Any remaining GitHub annotation should map to the Dependency Review upstream blocker above.

--- a/docs/phase14_release_maintenance_roadmap.md
+++ b/docs/phase14_release_maintenance_roadmap.md
@@ -7,7 +7,7 @@ Intake source: post-Phase 13 completion and post-merge CI annotations from 2026-
 Current status:
 - [x] `EAP-129` create Phase 14 release maintenance queue (`GEN-209`)
 - [x] `EAP-130` clean up package license metadata (`GEN-210`)
-- [ ] `EAP-131` resolve GitHub Actions Node runtime warnings (`GEN-211`)
+- [x] `EAP-131` resolve GitHub Actions Node runtime warnings (`GEN-211`)
 - [ ] `EAP-132` refresh release evidence and docs index (`GEN-212`)
 - [ ] `EAP-133` run v1.0.1 release readiness dry-run (`GEN-213`)
 
@@ -32,7 +32,7 @@ The Phase 14 queue targets the visible post-hardening maintenance items:
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | `EAP-129` | `GEN-209` | P2 | Intake and tracker | Create this roadmap, update `ROADMAP.md` and `docs/execution_protocol.md`, and create Linear issues for Phase 14 | Phase 14 queue is visible in docs and Linear; first executable Todo is clear |
 | 2 | `EAP-130` | `GEN-210` | P2 | Packaging metadata | Replace deprecated license metadata with current supported packaging format | Package build completes without the setuptools license metadata deprecation warning; MIT license metadata remains correct |
-| 3 | `EAP-131` | `GEN-211` | P2 | CI runtime warnings | Inventory and resolve GitHub Actions Node.js runtime deprecation annotations | CI no longer emits actionable Node.js 20 warnings, or each remaining warning has a documented upstream blocker |
+| 3 | `EAP-131` | `GEN-211` | P2 | CI runtime warnings | Inventory and resolve GitHub Actions Node.js runtime deprecation annotations | Node 24-compatible action majors are used where available; Gitleaks runs through the pinned CLI; the remaining Dependency Review upstream blocker is documented in `docs/github_actions_runtime_inventory.md` |
 | 4 | `EAP-132` | `GEN-212` | P2 | Docs and release evidence | Refresh docs index, roadmap status, and v1.0.1 release evidence | Public docs show Phase 13 complete, Phase 14 active, and current release blockers/evidence accurately |
 | 5 | `EAP-133` | `GEN-213` | P2 | Release dry-run | Run final v1.0.1 readiness evidence pass | Unified gatepack, package smoke, and GitHub main workflows are green or blockers are explicitly listed |
 

--- a/tests/contract/test_github_actions_runtime_contract.py
+++ b/tests/contract/test_github_actions_runtime_contract.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+INVENTORY_PATH = REPO_ROOT / "docs" / "github_actions_runtime_inventory.md"
+
+NODE20_ACTION_PINS = (
+    "actions/checkout@v4",
+    "actions/setup-python@v5",
+    "actions/setup-node@v4",
+    "actions/upload-artifact@v4",
+    "actions/download-artifact@v4",
+    "gitleaks/gitleaks-action@v2",
+    "release-drafter/release-drafter@v6",
+)
+
+EXPECTED_NODE24_PINS = (
+    "actions/checkout@v6",
+    "actions/setup-python@v6",
+    "actions/setup-node@v6",
+    "actions/upload-artifact@v7",
+    "actions/download-artifact@v8",
+    "release-drafter/release-drafter@v7",
+)
+
+
+def _workflow_text() -> str:
+    return "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted(WORKFLOWS_DIR.glob("*.yml"))
+    )
+
+
+def test_workflows_no_longer_use_known_node20_action_pins() -> None:
+    text = _workflow_text()
+
+    for action_pin in NODE20_ACTION_PINS:
+        assert action_pin not in text
+
+
+def test_workflows_use_expected_node24_action_pins() -> None:
+    text = _workflow_text()
+
+    for action_pin in EXPECTED_NODE24_PINS:
+        assert action_pin in text
+
+
+def test_dependency_review_blocker_is_documented_and_mitigated() -> None:
+    workflow_text = _workflow_text()
+    inventory_text = INVENTORY_PATH.read_text(encoding="utf-8")
+
+    assert "actions/dependency-review-action@v4" in workflow_text
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true" in workflow_text
+    assert "actions/dependency-review-action@v4" in inventory_text
+    assert "upstream blocker" in inventory_text.lower()


### PR DESCRIPTION
## Summary
- upgrade first-party GitHub Actions to Node 24-compatible majors
- replace gitleaks/gitleaks-action@v2 with a pinned Gitleaks CLI install plus checksum verification
- document the remaining dependency-review-action@v4 upstream Node 20 blocker and add a contract test

## Validation
- /tmp/eap-eap125-focus.RgBrSq/bin/python -m pytest -q tests/contract/test_github_actions_runtime_contract.py tests/contract/test_workflow_schema_contract.py
- /tmp/eap-eap125-focus.RgBrSq/bin/python -m ruff check . --select E9,F63,F7,F82
- git diff --check
- verified pinned Gitleaks 8.30.1 archive checksum command locally
