### PR TITLE
EAP-132 refresh release evidence and docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It also ships OpenClaw interop paths for gateway/tool integration.
 - It integrates with existing ecosystems instead of forcing a rewrite (`chat_completions`, `responses`, OpenClaw tooling, MCP tools).
 
 See `docs/eap_proof_sheet.md` for reproducible evidence and command-level validation.
+Current patch-release evidence is tracked in `docs/releases/v1.0.1-readiness.md`.
 
 ## What We Closed Recently
 
@@ -282,6 +283,10 @@ Full documentation index: [`docs/README.md`](docs/README.md)
   - `docs/self_hosted_control_plane.md`
   - `docs/remote_ops_governance.md`
   - `docs/migrations.md`
+- Release evidence:
+  - `docs/releases/v1.0.1-readiness.md`
+  - `docs/release.md`
+  - `docs/github_actions_runtime_inventory.md`
 - Interop and starter packs:
   - `docs/openclaw_interop.md`
   - `integrations/openclaw/eap-runtime-plugin/README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@
 | [release.md](release.md) | Release process and versioning |
 | [release_notes_template.md](release_notes_template.md) | Template for release notes |
 | [releases/v0.1.8.md](releases/v0.1.8.md) | Release notes for v0.1.8 |
+| [releases/v1.0.1-readiness.md](releases/v1.0.1-readiness.md) | Current v1.0.1 readiness evidence, blockers, and go/no-go rule |
 
 ## Roadmaps
 

--- a/docs/execution_protocol.md
+++ b/docs/execution_protocol.md
@@ -72,10 +72,10 @@ Updated: 2026-04-29 (Phase 14 release maintenance intake)
 | 42 | `EAP-129` | `GEN-209` | `Done` | Create Phase 14 release maintenance queue |
 | 43 | `EAP-130` | `GEN-210` | `Done` | Clean up package license metadata |
 | 44 | `EAP-131` | `GEN-211` | `Done` | Resolve GitHub Actions Node runtime warnings |
-| 45 | `EAP-132` | `GEN-212` | `Todo` | Refresh release evidence and docs index |
+| 45 | `EAP-132` | `GEN-212` | `Done` | Refresh release evidence and docs index |
 | 46 | `EAP-133` | `GEN-213` | `Todo` | Run v1.0.1 release readiness dry-run |
 
 ## Execution Rule
 
 Do not start a new implementation item unless it is the first non-blocked `Todo` item in this queue.  
-Current state: Phase 14 (Release Maintenance / v1.0.1 Readiness) is active. `EAP-131` is complete; `EAP-132` is the next ordered `Todo`.
+Current state: Phase 14 (Release Maintenance / v1.0.1 Readiness) is active. `EAP-132` is complete; `EAP-133` is the next ordered `Todo`.

--- a/docs/phase14_release_maintenance_roadmap.md
+++ b/docs/phase14_release_maintenance_roadmap.md
@@ -8,7 +8,7 @@ Current status:
 - [x] `EAP-129` create Phase 14 release maintenance queue (`GEN-209`)
 - [x] `EAP-130` clean up package license metadata (`GEN-210`)
 - [x] `EAP-131` resolve GitHub Actions Node runtime warnings (`GEN-211`)
-- [ ] `EAP-132` refresh release evidence and docs index (`GEN-212`)
+- [x] `EAP-132` refresh release evidence and docs index (`GEN-212`)
 - [ ] `EAP-133` run v1.0.1 release readiness dry-run (`GEN-213`)
 
 ## Objective
@@ -33,7 +33,7 @@ The Phase 14 queue targets the visible post-hardening maintenance items:
 | 1 | `EAP-129` | `GEN-209` | P2 | Intake and tracker | Create this roadmap, update `ROADMAP.md` and `docs/execution_protocol.md`, and create Linear issues for Phase 14 | Phase 14 queue is visible in docs and Linear; first executable Todo is clear |
 | 2 | `EAP-130` | `GEN-210` | P2 | Packaging metadata | Replace deprecated license metadata with current supported packaging format | Package build completes without the setuptools license metadata deprecation warning; MIT license metadata remains correct |
 | 3 | `EAP-131` | `GEN-211` | P2 | CI runtime warnings | Inventory and resolve GitHub Actions Node.js runtime deprecation annotations | Node 24-compatible action majors are used where available; Gitleaks runs through the pinned CLI; the remaining Dependency Review upstream blocker is documented in `docs/github_actions_runtime_inventory.md` |
-| 4 | `EAP-132` | `GEN-212` | P2 | Docs and release evidence | Refresh docs index, roadmap status, and v1.0.1 release evidence | Public docs show Phase 13 complete, Phase 14 active, and current release blockers/evidence accurately |
+| 4 | `EAP-132` | `GEN-212` | P2 | Docs and release evidence | Refresh docs index, roadmap status, and v1.0.1 release evidence | `docs/releases/v1.0.1-readiness.md` centralizes current evidence, blockers, and go/no-go criteria and is linked from the docs index and release runbook |
 | 5 | `EAP-133` | `GEN-213` | P2 | Release dry-run | Run final v1.0.1 readiness evidence pass | Unified gatepack, package smoke, and GitHub main workflows are green or blockers are explicitly listed |
 
 ## Dependency Order

--- a/docs/release.md
+++ b/docs/release.md
@@ -39,6 +39,15 @@ Compatibility policy:
    - confirm `docs/v1_contract_lock.json` was updated intentionally
    - confirm `Breaking Changes` and `Upgrade Notes` sections are populated
 
+## Current v1.0.1 Evidence
+
+The active patch-release evidence file is `docs/releases/v1.0.1-readiness.md`.
+Use it as the release decision source for current CI links, completed hardening
+work, known warnings, and remaining blockers before tagging `v1.0.1`.
+
+Do not tag `v1.0.1` until the `EAP-133` final readiness dry-run is complete
+and the go/no-go rule in `docs/releases/v1.0.1-readiness.md` is satisfied.
+
 ## V1.0 Release Checklist
 
 Before tagging `v1.0.0`, complete every item below in order:

--- a/docs/releases/v1.0.1-readiness.md
+++ b/docs/releases/v1.0.1-readiness.md
@@ -1,0 +1,74 @@
+# v1.0.1 Readiness Evidence
+
+Status: Phase 14 readiness refresh complete; final release dry-run pending in `EAP-133` / `GEN-213`  
+Last updated: 2026-04-29  
+Baseline commit: `208523e6497e9f3789ec28f8b7f5f77b1d11d63b`
+
+## Purpose
+
+This document centralizes the evidence needed before cutting the `v1.0.1` patch release. It points to the hardening gates, CI proof, known warnings, and remaining blockers so release decisions do not depend on scattered Linear comments or GitHub run history alone.
+
+## Current Release Decision
+
+`v1.0.1` is not ready to tag until `EAP-133` completes the final release readiness dry-run. The codebase is on the `1.0.1` package baseline, Phase 13 production hardening is complete, and Phase 14 has removed the known package/build and GitHub Actions runtime warning noise.
+
+## Phase Completion Evidence
+
+| Phase / Item | Status | Evidence |
+| --- | --- | --- |
+| Phase 13 production hardening | Complete | `docs/phase13_production_hardening_roadmap.md` and `scripts/production_hardening_gatepack.py` |
+| `EAP-130` package license metadata cleanup | Complete | PR #104, merge commit `2d8cbfceaf8a8b3c2fa304db2853e78d7e9367aa` |
+| `EAP-131` GitHub Actions runtime warning cleanup | Complete | PR #105, merge commit `208523e6497e9f3789ec28f8b7f5f77b1d11d63b`, `docs/github_actions_runtime_inventory.md` |
+| `EAP-132` release evidence/docs refresh | Complete | This document plus docs index/runbook links |
+| `EAP-133` final readiness dry-run | Pending | Must run before tag cut |
+
+## Post-Merge Workflow Evidence
+
+Latest verified `main` baseline: `208523e6497e9f3789ec28f8b7f5f77b1d11d63b`.
+
+| Workflow | Run | Status |
+| --- | --- | --- |
+| CI | https://github.com/GenieWeenie/efficient-agent-protocol/actions/runs/25137140178 | Passed |
+| Security | https://github.com/GenieWeenie/efficient-agent-protocol/actions/runs/25137140143 | Passed |
+| CodeQL | https://github.com/GenieWeenie/efficient-agent-protocol/actions/runs/25137140165 | Passed |
+| Release Drafter | https://github.com/GenieWeenie/efficient-agent-protocol/actions/runs/25137140150 | Passed |
+| OpenClaw Interop | https://github.com/GenieWeenie/efficient-agent-protocol/actions/runs/25137140152 | Passed |
+
+## Required Local Evidence Commands
+
+Run these before the final release dry-run and attach output to `GEN-213`:
+
+```bash
+PYTHONPATH=. python scripts/v1_readiness_gatepack.py
+PYTHONPATH=. python scripts/production_hardening_gatepack.py
+python -m pytest -q tests/contract/test_docs_v1_alignment.py tests/contract/test_release_evidence_contract.py
+python -m build
+```
+
+Expected results:
+
+- `scripts/v1_readiness_gatepack.py` reports all 10 gates passing.
+- `scripts/production_hardening_gatepack.py` reports all Phase 13 hardening gates passing.
+- Release evidence contract tests pass.
+- Package build completes without the setuptools license metadata deprecation warning.
+
+## Known Warnings and Blockers
+
+| Item | Release impact | Status |
+| --- | --- | --- |
+| Package license metadata deprecation | Blocking if it returns | Resolved by `EAP-130`; covered by `tests/contract/test_package_metadata_contract.py` |
+| GitHub Actions Node.js 20 runtime warning noise | Blocking if actionable warnings return | Resolved where upstream Node 24 actions exist; tracked in `docs/github_actions_runtime_inventory.md` |
+| `actions/dependency-review-action@v4` still declares Node 20 | Non-blocking upstream blocker | PR-only, opt-in behind `ENABLE_DEPENDENCY_REVIEW`, forced through Node 24 compatibility path, documented in `docs/github_actions_runtime_inventory.md` |
+| Final `v1.0.1` release dry-run | Blocking | Pending `EAP-133` |
+
+## Release Go/No-Go Rule
+
+Go only when all of these are true:
+
+- `EAP-133` is complete and Linear `GEN-213` is Done.
+- Latest `main` CI, Security, CodeQL, Release Drafter, and OpenClaw Interop workflows are green.
+- `scripts/v1_readiness_gatepack.py` and `scripts/production_hardening_gatepack.py` pass on the release baseline.
+- `python -m build` completes without package metadata warnings.
+- Any remaining workflow warnings are documented upstream blockers, not actionable repo-side fixes.
+
+If any item fails, do not tag `v1.0.1`; create a new Linear issue in the active release-maintenance queue and link the failing evidence.

--- a/tests/contract/test_release_evidence_contract.py
+++ b/tests/contract/test_release_evidence_contract.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC_INDEX = REPO_ROOT / "docs" / "README.md"
+RELEASE_RUNBOOK = REPO_ROOT / "docs" / "release.md"
+READINESS_EVIDENCE = REPO_ROOT / "docs" / "releases" / "v1.0.1-readiness.md"
+PHASE14_ROADMAP = REPO_ROOT / "docs" / "phase14_release_maintenance_roadmap.md"
+EXECUTION_PROTOCOL = REPO_ROOT / "docs" / "execution_protocol.md"
+
+
+def test_v101_readiness_evidence_is_indexed() -> None:
+    index_text = DOC_INDEX.read_text(encoding="utf-8")
+    runbook_text = RELEASE_RUNBOOK.read_text(encoding="utf-8")
+
+    assert "releases/v1.0.1-readiness.md" in index_text
+    assert "releases/v1.0.1-readiness.md" in runbook_text
+
+
+def test_v101_readiness_evidence_lists_required_gates_and_blocker() -> None:
+    text = READINESS_EVIDENCE.read_text(encoding="utf-8")
+
+    required_fragments = (
+        "scripts/v1_readiness_gatepack.py",
+        "scripts/production_hardening_gatepack.py",
+        "python -m build",
+        "docs/github_actions_runtime_inventory.md",
+        "EAP-133",
+        "GEN-213",
+        "actions/dependency-review-action@v4",
+    )
+    for fragment in required_fragments:
+        assert fragment in text
+
+
+def test_phase14_marks_eap132_complete_and_eap133_next() -> None:
+    phase_text = PHASE14_ROADMAP.read_text(encoding="utf-8")
+    execution_text = EXECUTION_PROTOCOL.read_text(encoding="utf-8")
+
+    assert "[x] `EAP-132` refresh release evidence and docs index (`GEN-212`)" in phase_text
+    assert "| 45 | `EAP-132` | `GEN-212` | `Done` |" in execution_text
+    assert "`EAP-133` is the next ordered `Todo`" in execution_text


### PR DESCRIPTION
## Summary
- add current v1.0.1 readiness evidence with CI proof, blockers, and go/no-go criteria
- link the evidence from README, docs index, and release runbook
- mark EAP-132 complete and EAP-133 as next ordered item in the execution docs
- add a release evidence contract test

## Validation
- /tmp/eap-eap125-focus.RgBrSq/bin/python -m pytest -q tests/contract/test_release_evidence_contract.py tests/contract/test_docs_v1_alignment.py tests/contract/test_package_metadata_contract.py
- /tmp/eap-eap125-focus.RgBrSq/bin/python -m ruff check . --select E9,F63,F7,F82
- git diff --check
- /tmp/eap-eap125-focus.RgBrSq/bin/python -m build --sdist --wheel --outdir /tmp/eap-eap132-dist
- verified build log has no setuptools license metadata deprecation warning
