### PR TITLE
Phase-14 hardening: close P1 brief items R7-R17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,29 @@ jobs:
         run: |
           ruff check . --select E9,F63,F7,F82
 
+      - name: Lint (Ruff advisory broader rule set, non-blocking)
+        if: matrix.python-version == '3.11'
+        continue-on-error: true
+        run: |
+          # Phase-14 R12: report (but do not yet gate on) the broader
+          # E,F,W,B,UP,SIM,RUF rule families. The next hardening pass
+          # will fix the top offenders and flip this to a blocking gate.
+          ruff check . --select E,F,W,B,UP,SIM,RUF --output-format=concise || true
+
       - name: Type rigor gate (mypy scoped modules)
         if: matrix.python-version == '3.11'
         run: |
           mypy --follow-imports=skip eap/environment/safe_eval.py eap/environment/executor.py eap/runtime/auth_scopes.py eap/runtime/guardrails.py eap/runtime/http_api.py
+
+      - name: Security lint (Bandit, high-severity gate)
+        if: matrix.python-version == '3.11'
+        run: |
+          # Phase-14 R12: bandit security lint, gating only on HIGH-severity
+          # findings to avoid a whole-codebase reformat. Medium/low findings
+          # are still printed for visibility.
+          pip install bandit
+          bandit -r eap/ --severity-level high
+          bandit -r eap/ --exit-zero --severity-level low || true
 
       - name: Run tests
         if: matrix.python-version != '3.11'

--- a/app.py
+++ b/app.py
@@ -35,6 +35,54 @@ configure_logging()
 settings = load_settings()
 
 
+_AUDITOR_REJECT_REASON_FALLBACK = (
+    "Auditor response could not be parsed as a structured decision. "
+    "Defaulting to reject for safety."
+)
+
+
+def parse_auditor_decision(raw_decision: str) -> tuple[str, str]:
+    """Parse the auditor's response into a structured ``(decision, reason)`` tuple.
+
+    The auditor is asked to emit a JSON object of the form
+    ``{"decision": "approve" | "reject", "reason": "..."}``. If the response
+    is missing, malformed, or carries an unknown decision value, this function
+    returns ``("reject", <fallback reason>)`` — the substring path that
+    previously approved any text containing the literal word ``APPROVED`` is
+    intentionally gone.
+    """
+    if not isinstance(raw_decision, str) or not raw_decision.strip():
+        return "reject", _AUDITOR_REJECT_REASON_FALLBACK
+
+    payload: object = None
+    try:
+        payload = json.loads(raw_decision.strip())
+    except json.JSONDecodeError:
+        # Fall back to the first JSON object embedded in the response (the
+        # auditor sometimes emits surrounding prose despite instructions).
+        match = re.search(r"\{.*\}", raw_decision, re.DOTALL)
+        if match:
+            try:
+                payload = json.loads(match.group(0))
+            except json.JSONDecodeError:
+                payload = None
+
+    if not isinstance(payload, dict):
+        return "reject", _AUDITOR_REJECT_REASON_FALLBACK
+
+    decision_raw = payload.get("decision")
+    reason_raw = payload.get("reason")
+    decision = decision_raw.strip().lower() if isinstance(decision_raw, str) else ""
+    reason = reason_raw.strip() if isinstance(reason_raw, str) and reason_raw.strip() else ""
+
+    if decision == "approve":
+        return "approve", reason or "Auditor approved without an explicit reason."
+    if decision == "reject":
+        return "reject", reason or "Auditor rejected without an explicit reason."
+
+    return "reject", _AUDITOR_REJECT_REASON_FALLBACK
+
+
 def _default_execution_limits_from_settings() -> ExecutionLimits:
     return ExecutionLimits(
         max_global_concurrency=settings.executor.max_global_concurrency,
@@ -370,7 +418,12 @@ with tab1:
                         timeout_seconds=settings.auditor.timeout_seconds,
                         openai_api_mode=settings.auditor.openai_api_mode,
                         extra_headers=settings.auditor.extra_headers,
-                        system_prompt="Review for safety. Respond APPROVED or DENIED."
+                        system_prompt=(
+                            "You are the AUDITOR. Review the proposed macro for safety. "
+                            "Respond ONLY with a JSON object of the form "
+                            '{"decision": "approve" | "reject", "reason": "<short rationale>"}. '
+                            "Do not include code fences or any prose."
+                        ),
                     )
                     review_prompt = f"Review: {macro.model_dump_json()}"
                     streamed = {"text": ""}
@@ -380,12 +433,15 @@ with tab1:
                         streamed["text"] += token
                         decision_placeholder.markdown(f"**Decision (streaming):** {streamed['text']}")
 
-                    audit_decision = auditor.stream_chat(review_prompt, on_token=on_audit_token)
-                    decision_placeholder.markdown(f"**Decision:** {audit_decision}")
+                    raw_decision = auditor.stream_chat(review_prompt, on_token=on_audit_token)
+                    audit_decision, audit_reason = parse_auditor_decision(raw_decision)
+                    decision_placeholder.markdown(
+                        f"**Decision:** `{audit_decision}` — {audit_reason}"
+                    )
                     s.update(label=f"🛡️ Audit: {audit_decision}", state="complete")
 
             # EXECUTOR
-            if "APPROVED" in audit_decision.upper():
+            if audit_decision == "approve":
                 with st.status("🚀 Executing DAG...", expanded=True) as s:
                     result = asyncio.run(executor.execute_macro(macro))
                     st.json(result)
@@ -401,11 +457,11 @@ with tab1:
                     )
                     st.rerun() 
             else:
-                st.error("Audit Failed. Execution Blocked.")
+                st.error(f"Audit Failed. Execution Blocked. Reason: {audit_reason}")
                 state_manager.append_turn(
                     session_id=st.session_state.active_session_id,
                     role="assistant",
-                    content="Audit failed. Execution blocked.",
+                    content=f"Audit failed. Execution blocked. Reason: {audit_reason}",
                 )
 
 # --- TAB 2: Data Inspector ---

--- a/deploy/self_hosted/docker-compose.yml
+++ b/deploy/self_hosted/docker-compose.yml
@@ -12,8 +12,12 @@ services:
       - "8080"
       - --db-path
       - /var/lib/eap/agent_state.db
-      - --bearer-token
-      - ${EAP_RUNTIME_BEARER_TOKEN:?Set EAP_RUNTIME_BEARER_TOKEN}
+    environment:
+      # The bearer token is passed via env (not CLI args) so it does not leak
+      # to `ps`/`/proc/<pid>/cmdline` inside the container. For production,
+      # prefer mounting a Docker / Kubernetes secret and pointing
+      # `--bearer-token-file` at the mount path instead.
+      EAP_RUNTIME_BEARER_TOKEN: ${EAP_RUNTIME_BEARER_TOKEN:?Set EAP_RUNTIME_BEARER_TOKEN}
     ports:
       - "${EAP_RUNTIME_PORT:-8080}:8080"
     volumes:
@@ -36,7 +40,11 @@ services:
     ports:
       - "${EAP_OPERATOR_UI_PORT:-8501}:8501"
     volumes:
-      - eap_state:/var/lib/eap
+      # Mount read-only: only the runtime container should write to the
+      # SQLite file. Multi-writer access across container boundaries is
+      # fragile (different fcntl-lock semantics) — for any multi-process /
+      # multi-host deployment, use the Postgres backend instead.
+      - eap_state:/var/lib/eap:ro
     depends_on:
       - runtime
     restart: unless-stopped

--- a/docs/self_hosted_control_plane.md
+++ b/docs/self_hosted_control_plane.md
@@ -67,11 +67,26 @@ The smoke validates:
 ## Auth Model
 
 - Runtime API expects `Authorization: Bearer <token>`.
-- Token source: `EAP_RUNTIME_BEARER_TOKEN` in `deploy/self_hosted/.env`.
+- Token source: `EAP_RUNTIME_BEARER_TOKEN` in `deploy/self_hosted/.env`. The
+  runtime resolves the token in this order:
+  1. `--bearer-token` CLI flag (discouraged — visible to anyone with `ps`
+     access on the host).
+  2. `--bearer-token-file <path>` (recommended for k8s / Docker secret
+     mounts; the file's first line is read).
+  3. `EAP_RUNTIME_BEARER_TOKEN` environment variable (used by the bundled
+     compose stack).
 - Requests without valid bearer token return `401 unauthorized`.
 - Missing auth configuration does not grant anonymous access; runtime auth fails closed by default.
 - Runtime also supports scoped tokens via `--scoped-auth-config` for multi-user governance.
 - Scoped auth defaults to `--policy-profile strict` unless overridden.
+
+> **Production deployment:** the bundled SQLite-backed compose stack is
+> intended for single-host development / lightweight self-hosting only.
+> Multi-process or multi-host deployments must use the Postgres backend —
+> two containers writing to the same SQLite file across container
+> boundaries have different fcntl-lock semantics and will eventually
+> corrupt the file under load. The `operator-ui` container in the bundled
+> compose mounts the volume `:ro` for that reason.
 - Runtime supports `--guardrails-config` for endpoint rate limits and concurrency ceilings.
 
 Scope baseline:

--- a/eap/agent/compiler.py
+++ b/eap/agent/compiler.py
@@ -1,4 +1,5 @@
 # agent/compiler.py
+import hashlib
 import json
 from typing import Any, Dict, Optional, Union
 from eap.protocol.models import (
@@ -48,9 +49,13 @@ class MacroCompiler:
                     if "tool" in step and "tool_name" not in step:
                         step["tool_name"] = step.pop("tool")
 
-                    # Ensure step_id exists
+                    # Ensure step_id exists. Use a deterministic content-hash
+                    # so that the same step JSON yields the same id across
+                    # processes (Python's built-in hash() is salted).
                     if "step_id" not in step:
-                        step["step_id"] = f"auto_step_{hash(str(step)) % 1000}"
+                        canonical = json.dumps(step, sort_keys=True, default=str).encode("utf-8")
+                        digest = hashlib.sha256(canonical).hexdigest()[:12]
+                        step["step_id"] = f"auto_step_{digest}"
 
             # 3. Final Pydantic validation
             return BatchedMacroRequest(**parsed_data)

--- a/eap/environment/tool_registry.py
+++ b/eap/environment/tool_registry.py
@@ -3,7 +3,21 @@ import hashlib
 import json
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
+
+try:  # jsonschema is preferred but optional at runtime; we fall back gracefully.
+    import jsonschema
+    from jsonschema import Draft202012Validator
+    from jsonschema.exceptions import SchemaError as _JSONSchemaError
+    from jsonschema.exceptions import ValidationError as _JSONSchemaValidationError
+
+    _JSONSCHEMA_AVAILABLE = True
+except Exception:  # pragma: no cover - exercised only when dep missing
+    jsonschema = None  # type: ignore[assignment]
+    Draft202012Validator = None  # type: ignore[assignment]
+    _JSONSchemaError = Exception  # type: ignore[assignment]
+    _JSONSchemaValidationError = Exception  # type: ignore[assignment]
+    _JSONSCHEMA_AVAILABLE = False
 
 
 class InputValidationError(ValueError):
@@ -38,6 +52,9 @@ class ToolRegistry:
         self._tools: Dict[str, Callable] = {}
         self._schemas: Dict[str, dict] = {}
         self._hashes: Dict[str, str] = {}
+        # Cache compiled jsonschema validators per tool name to avoid
+        # re-parsing the schema on every call.
+        self._validators: Dict[str, Any] = {}
         if auto_load_plugins:
             self.load_plugins(group=plugin_group, strict=strict_plugin_loading)
 
@@ -52,13 +69,31 @@ class ToolRegistry:
         self._tools[name] = func
         self._schemas[name] = schema
 
-        # Create a deterministic hash of the schema
-        # If the schema changes, the hash changes automatically
+        # Create a deterministic hash of the schema. SHA-256 is used (instead
+        # of MD5) so static-analysis tools like Bandit/CodeQL stop flagging
+        # the call as a weak-cryptography use; the truncated digest is only
+        # for non-cryptographic name disambiguation.
         schema_str = json.dumps(schema, sort_keys=True)
-        schema_hash = hashlib.md5(schema_str.encode()).hexdigest()[:8]
+        schema_hash = hashlib.sha256(schema_str.encode()).hexdigest()[:8]
 
         hashed_name = f"{name}_{schema_hash}"
         self._hashes[name] = hashed_name
+        # Pre-compile a jsonschema validator if the library is present and
+        # the parameters block is a valid JSON schema. Failures here are
+        # silently ignored — validate_arguments will fall back to the
+        # built-in checks when no compiled validator is available.
+        self._validators.pop(name, None)
+        if _JSONSCHEMA_AVAILABLE:
+            params = schema.get("parameters")
+            if isinstance(params, dict):
+                try:
+                    Draft202012Validator.check_schema(params)
+                    self._validators[name] = Draft202012Validator(params)
+                except _JSONSchemaError:
+                    # Schema is structurally invalid for jsonschema; we still
+                    # accept it for backward compatibility but argument
+                    # validation will degrade to the built-in checks.
+                    self._validators.pop(name, None)
 
     def register_tool_definition(self, tool_definition: ToolDefinition) -> None:
         """Registers a validated tool definition object."""
@@ -200,10 +235,20 @@ class ToolRegistry:
 
     def validate_arguments(self, name_or_hash: str, arguments: Dict[str, Any]) -> None:
         """
-        Validate arguments against the registered JSON schema (basic object checks).
-        Raises InputValidationError on invalid payloads.
+        Validate arguments against the registered JSON schema.
+
+        When the optional ``jsonschema`` package is available (the default for
+        modern installs), the registered ``parameters`` block is treated as a
+        Draft 2020-12 JSON Schema. This adds support for ``pattern``,
+        ``oneOf``/``anyOf``/``allOf``, nested ``properties``, ``format``, and
+        the rest of the spec — features the previous hand-rolled implementation
+        silently ignored. When the dependency is missing, we fall back to the
+        legacy built-in checks so existing deployments keep working.
+
+        Raises ``InputValidationError`` on invalid payloads.
         """
         schema = self.get_schema(name_or_hash)
+        original_name = self._resolve_original_name(name_or_hash)
         params = schema.get("parameters", {})
         if params.get("type") not in (None, "object"):
             raise InputValidationError("Input validation failed: top-level parameters type must be object.")
@@ -211,6 +256,28 @@ class ToolRegistry:
         if not isinstance(arguments, dict):
             raise InputValidationError("Input validation failed: arguments payload must be an object.")
 
+        validator = self._validators.get(original_name)
+        if validator is not None:
+            try:
+                validator.validate(arguments)
+            except _JSONSchemaValidationError as exc:
+                location = "/".join(str(part) for part in exc.absolute_path) or "<root>"
+                tool_label = schema.get("name", name_or_hash)
+                raise InputValidationError(
+                    f"Input validation failed for tool '{tool_label}' at '{location}': {exc.message}"
+                ) from exc
+            return
+
+        # ---- Fallback path (jsonschema unavailable or schema not compatible) ----
+        self._validate_arguments_builtin(schema, name_or_hash, arguments, params)
+
+    def _validate_arguments_builtin(
+        self,
+        schema: Dict[str, Any],
+        name_or_hash: str,
+        arguments: Dict[str, Any],
+        params: Dict[str, Any],
+    ) -> None:
         properties = params.get("properties", {})
         required = params.get("required", [])
         additional_properties = params.get("additionalProperties", True)

--- a/eap/protocol/state_manager.py
+++ b/eap/protocol/state_manager.py
@@ -1,12 +1,14 @@
 # protocol/state_manager.py
+import contextlib
 import uuid
 import sys
 import sqlite3
 import json
 import os
+import threading
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from .models import (
     ConversationSession,
@@ -30,13 +32,84 @@ class StateManager:
     ):
         self.db_path = db_path
         self.pointer_store = pointer_store or SQLitePointerStore(db_path=self.db_path)
+        # Single shared SQLite connection per StateManager instance, guarded by
+        # a lock. SQLite serializes writers anyway, so a per-call ``connect()``
+        # is wasted file-system / page-cache churn — it also magnifies the
+        # ``database is locked`` failure mode under the new ASGI runtime which
+        # multiplies concurrency. ``check_same_thread=False`` is safe here
+        # because every access to the connection is funnelled through
+        # ``self._connection()`` which acquires ``self._conn_lock``.
+        self._conn_lock = threading.Lock()
+        # Reuse a single connection for the lifetime of the StateManager.
+        # ``check_same_thread=False`` is safe because every access flows
+        # through ``self._connection()`` which holds ``self._conn_lock``.
+        # Default ``isolation_level=""`` (deferred) is preserved so that the
+        # ``with conn:`` context manager continues to commit/rollback the same
+        # way the previous per-call ``sqlite3.connect`` blocks did. WAL is
+        # tuned once here (PRAGMAs cannot run inside a transaction).
+        self._connection_obj: Optional[sqlite3.Connection] = sqlite3.connect(
+            self.db_path,
+            check_same_thread=False,
+        )
+        self._connection_obj.execute("PRAGMA journal_mode=WAL")
+        self._connection_obj.execute("PRAGMA synchronous=NORMAL")
+        self._closed = False
         self._init_db()
+
+    @contextlib.contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        """Yield the shared SQLite connection under a process-wide lock.
+
+        Mirrors the ``with sqlite3.connect(path) as conn`` semantics by
+        delegating commit / rollback to sqlite3's own connection context
+        manager. Reusing a single connection avoids the per-call
+        ``connect()`` storm that the new ASGI runtime would otherwise
+        produce against a single SQLite file.
+        """
+        with self._conn_lock:
+            if self._closed or self._connection_obj is None:
+                raise RuntimeError("StateManager connection is closed.")
+            conn = self._connection_obj
+            with conn:
+                yield conn
+
+    def close(self) -> None:
+        """Close the shared SQLite connection. Idempotent."""
+        with self._conn_lock:
+            if self._closed:
+                return
+            self._closed = True
+            if self._connection_obj is not None:
+                try:
+                    self._connection_obj.close()
+                finally:
+                    self._connection_obj = None
+        # Close the pointer store backend too if it exposes a close() hook.
+        close_hook = getattr(self.pointer_store, "close", None)
+        if callable(close_hook):
+            try:
+                close_hook()
+            except Exception:
+                pass
+
+    def __enter__(self) -> "StateManager":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def __del__(self) -> None:  # pragma: no cover - best effort cleanup
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def _init_db(self):
         self.pointer_store.initialize()
-        with sqlite3.connect(self.db_path) as conn:
-            conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute("PRAGMA synchronous=NORMAL")
+        # PRAGMA journal_mode=WAL / synchronous=NORMAL are applied once in
+        # __init__ on the shared connection — they cannot run inside a
+        # transaction, which the _connection() context manager opens.
+        with self._connection() as conn:
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS execution_trace_events (
@@ -244,7 +317,7 @@ class StateManager:
 
     def append_trace_event(self, event: ExecutionTraceEvent) -> None:
         payload = event.model_dump(mode="json")
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 INSERT INTO execution_trace_events (
@@ -290,7 +363,7 @@ class StateManager:
                 payload["retry_delay_seconds"],
                 json.dumps(payload["error"]) if payload["error"] is not None else None,
             ))
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.executemany(
                 """
                 INSERT INTO execution_trace_events (
@@ -308,7 +381,7 @@ class StateManager:
         actor_scopes = actor_metadata.get("actor_scopes") or actor_metadata.get("scopes")
         operation = actor_metadata.get("operation")
 
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             rows = conn.execute(
                 """
                 SELECT step_id, tool_name, event_type, timestamp_utc, attempt, resolved_arguments,
@@ -354,7 +427,7 @@ class StateManager:
         total_duration_ms: float,
         final_pointer_id: Optional[str] = None,
     ) -> None:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 INSERT OR REPLACE INTO execution_run_summaries (
@@ -386,7 +459,7 @@ class StateManager:
         actor_metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         updated_at_utc = self._now_utc_iso()
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 INSERT OR REPLACE INTO execution_run_checkpoints (
@@ -408,7 +481,7 @@ class StateManager:
             )
 
     def get_run_checkpoint(self, run_id: str) -> Dict[str, Any]:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             row = conn.execute(
                 """
                 SELECT started_at_utc, updated_at_utc, status, macro_payload,
@@ -446,7 +519,7 @@ class StateManager:
         query += " ORDER BY updated_at_utc DESC LIMIT ?"
         params = params + (limit,)
 
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             rows = conn.execute(query, params).fetchall()
 
         return [
@@ -462,7 +535,7 @@ class StateManager:
         ]
 
     def get_run_actor_metadata(self, run_id: str) -> Dict[str, Any]:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             checkpoint_row = conn.execute(
                 """
                 SELECT actor_metadata_payload
@@ -503,7 +576,7 @@ class StateManager:
         return actor_payload
 
     def get_execution_summary(self, run_id: str) -> Dict[str, Any]:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             row = conn.execute(
                 """
                 SELECT started_at_utc, completed_at_utc, total_steps, succeeded_steps, failed_steps,
@@ -530,7 +603,7 @@ class StateManager:
 
     def store_execution_diagnostics(self, run_id: str, payload: Dict[str, Any]) -> None:
         updated_at_utc = self._now_utc_iso()
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 INSERT OR REPLACE INTO execution_run_diagnostics (
@@ -545,7 +618,7 @@ class StateManager:
             )
 
     def get_execution_diagnostics(self, run_id: str) -> Dict[str, Any]:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             row = conn.execute(
                 """
                 SELECT updated_at_utc, payload_json
@@ -566,7 +639,7 @@ class StateManager:
         }
 
     def list_execution_diagnostics(self, limit: int = 100) -> List[Dict[str, Any]]:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             rows = conn.execute(
                 """
                 SELECT run_id, updated_at_utc, payload_json
@@ -614,7 +687,7 @@ class StateManager:
             metadata=metadata,
         )
         payload = session.model_dump(mode="json")
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 INSERT INTO conversation_sessions (
@@ -635,7 +708,7 @@ class StateManager:
         return payload
 
     def get_session(self, session_id: str) -> Dict[str, Any]:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             row = conn.execute(
                 """
                 SELECT created_at_utc, updated_at_utc, memory_strategy, window_turn_limit, summary_text, metadata
@@ -660,7 +733,7 @@ class StateManager:
         return session.model_dump(mode="json")
 
     def list_sessions(self, limit: int = 50) -> List[Dict[str, Any]]:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             rows = conn.execute(
                 """
                 SELECT session_id, created_at_utc, updated_at_utc, memory_strategy, window_turn_limit, summary_text, metadata
@@ -686,7 +759,7 @@ class StateManager:
         return sessions
 
     def delete_session(self, session_id: str) -> None:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute("DELETE FROM conversation_turns WHERE session_id = ?", (session_id,))
             cursor = conn.execute("DELETE FROM conversation_sessions WHERE session_id = ?", (session_id,))
 
@@ -719,7 +792,7 @@ class StateManager:
             metadata=metadata,
         )
         payload = turn.model_dump(mode="json")
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 INSERT INTO conversation_turns (
@@ -763,7 +836,7 @@ class StateManager:
             query += " LIMIT ?"
             params = (session_id, limit)
 
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             rows = conn.execute(query, params).fetchall()
 
         turns: List[Dict[str, Any]] = []
@@ -800,7 +873,7 @@ class StateManager:
             overflow = max(0, len(turns) - window_limit)
             if overflow > 0:
                 to_delete = [turn["turn_id"] for turn in turns[:overflow]]
-                with sqlite3.connect(self.db_path) as conn:
+                with self._connection() as conn:
                     conn.executemany(
                         "DELETE FROM conversation_turns WHERE turn_id = ?",
                         [(turn_id,) for turn_id in to_delete],
@@ -834,7 +907,7 @@ class StateManager:
                     merged_summary = merged_summary[-max_summary_chars:]
 
                 to_delete = [turn["turn_id"] for turn in old_turns]
-                with sqlite3.connect(self.db_path) as conn:
+                with self._connection() as conn:
                     conn.executemany(
                         "DELETE FROM conversation_turns WHERE turn_id = ?",
                         [(turn_id,) for turn_id in to_delete],
@@ -863,8 +936,37 @@ class StateManager:
 
     def clear_all(self):
         if os.path.exists(self.db_path):
+            # Close the shared connections (StateManager + pointer store) so
+            # the underlying file can be removed cleanly. Re-open afterward
+            # via _reopen_connection() so subsequent calls keep working.
+            close_hook = getattr(self.pointer_store, "close", None)
+            if callable(close_hook):
+                try:
+                    close_hook()
+                except Exception:
+                    pass
+            with self._conn_lock:
+                if self._connection_obj is not None:
+                    try:
+                        self._connection_obj.close()
+                    finally:
+                        self._connection_obj = None
+                self._closed = True
             os.remove(self.db_path)
+            self._reopen_connection()
+            # Re-build the pointer store with a fresh connection too.
+            self.pointer_store = SQLitePointerStore(db_path=self.db_path)
             self._init_db()
+
+    def _reopen_connection(self) -> None:
+        with self._conn_lock:
+            self._connection_obj = sqlite3.connect(
+                self.db_path,
+                check_same_thread=False,
+            )
+            self._connection_obj.execute("PRAGMA journal_mode=WAL")
+            self._connection_obj.execute("PRAGMA synchronous=NORMAL")
+            self._closed = False
 
     def collect_operational_metrics(self, now_utc: Optional[str] = None) -> Dict[str, Any]:
         snapshot_now = self._parse_now_utc(now_utc).isoformat()
@@ -873,7 +975,7 @@ class StateManager:
         active_pointers = len(self.list_pointers(include_expired=False, now_utc=snapshot_now))
         expired_pointers = max(0, total_pointers - active_pointers)
 
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             run_row = conn.execute(
                 """
                 SELECT

--- a/eap/protocol/storage/postgres_store.py
+++ b/eap/protocol/storage/postgres_store.py
@@ -47,12 +47,27 @@ class PsycopgPointerClient(_PostgresPointerClient):
         dsn: str,
         schema: str = "public",
         table_name: str = "eap_state_store",
+        *,
+        min_pool_size: int = 1,
+        max_pool_size: int = 10,
+        use_connection_pool: bool = True,
     ) -> None:
         self.dsn = dsn
         self.schema = self._validate_identifier(schema, "schema")
         self.table_name = self._validate_identifier(table_name, "table_name")
         self.qualified_table = f'"{self.schema}"."{self.table_name}"'
         self._psycopg = self._import_psycopg()
+        # Lazily-initialised psycopg_pool.ConnectionPool. We try to use a pool
+        # when the optional dependency is available — the previous code did a
+        # fresh ``psycopg.connect()`` per call which is wasteful and a real
+        # bottleneck under the new ASGI runtime. ``use_connection_pool=False``
+        # restores the legacy per-call behaviour for tests / specialised
+        # deployments.
+        self._min_pool_size = max(int(min_pool_size), 0)
+        self._max_pool_size = max(int(max_pool_size), self._min_pool_size or 1)
+        self._use_connection_pool = bool(use_connection_pool)
+        self._pool: Optional[Any] = None
+        self._pool_init_attempted = False
 
     @classmethod
     def _validate_identifier(cls, value: str, field_name: str) -> str:
@@ -71,8 +86,41 @@ class PsycopgPointerClient(_PostgresPointerClient):
             ) from exc
         return psycopg
 
+    def _get_or_create_pool(self):
+        """Return the psycopg_pool.ConnectionPool, or ``None`` if unavailable."""
+        if not self._use_connection_pool:
+            return None
+        if self._pool is not None:
+            return self._pool
+        if self._pool_init_attempted:
+            return None
+        self._pool_init_attempted = True
+        try:  # psycopg_pool ships with psycopg[binary] >= 3.1; tolerate absence
+            from psycopg_pool import ConnectionPool  # type: ignore
+        except Exception:  # pragma: no cover - depends on runtime env
+            self._pool = None
+            return None
+        self._pool = ConnectionPool(
+            conninfo=self.dsn,
+            min_size=self._min_pool_size,
+            max_size=self._max_pool_size,
+            open=True,
+        )
+        return self._pool
+
     def _connect(self):
+        pool = self._get_or_create_pool()
+        if pool is not None:
+            return pool.connection()
         return self._psycopg.connect(self.dsn)
+
+    def close(self) -> None:
+        """Close the underlying connection pool, if any. Idempotent."""
+        if self._pool is not None:
+            try:
+                self._pool.close()
+            finally:
+                self._pool = None
 
     @staticmethod
     def _normalize_iso(value: Any) -> Optional[str]:
@@ -265,3 +313,9 @@ class PostgresPointerStore(PointerStoreBackend):
 
     def delete_pointer(self, pointer_id: str) -> bool:
         return self.client.delete_pointer(pointer_id)
+
+    def close(self) -> None:
+        """Close the underlying client / connection pool. Idempotent."""
+        close_hook = getattr(self.client, "close", None)
+        if callable(close_hook):
+            close_hook()

--- a/eap/protocol/storage/sqlite_store.py
+++ b/eap/protocol/storage/sqlite_store.py
@@ -1,20 +1,63 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import sqlite3
-from typing import Any, Dict, List, Optional
+import threading
+from typing import Any, Dict, Iterator, List, Optional
 
 from .base import PointerStoreBackend
 
 
 class SQLitePointerStore(PointerStoreBackend):
-    """SQLite implementation of the pointer store backend contract."""
+    """SQLite implementation of the pointer store backend contract.
+
+    The store keeps a single ``sqlite3.Connection`` open for its lifetime and
+    funnels every call through a lock. The previous implementation opened a
+    fresh connection for each ``store_pointer`` / ``retrieve_pointer`` call,
+    which was wasted IO under low concurrency and a real ``database is
+    locked`` source under the new ASGI runtime.
+    """
 
     def __init__(self, db_path: str = "agent_state.db") -> None:
         self.db_path = db_path
+        self._conn_lock = threading.Lock()
+        self._conn: Optional[sqlite3.Connection] = sqlite3.connect(
+            self.db_path,
+            check_same_thread=False,
+        )
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._closed = False
+
+    @contextlib.contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        with self._conn_lock:
+            if self._closed or self._conn is None:
+                raise RuntimeError("SQLitePointerStore connection is closed.")
+            with self._conn as conn:
+                yield conn
+
+    def close(self) -> None:
+        """Close the shared SQLite connection. Idempotent."""
+        with self._conn_lock:
+            if self._closed:
+                return
+            self._closed = True
+            if self._conn is not None:
+                try:
+                    self._conn.close()
+                finally:
+                    self._conn = None
+
+    def __del__(self) -> None:  # pragma: no cover - best effort cleanup
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def initialize(self) -> None:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS state_store (
@@ -60,7 +103,7 @@ class SQLitePointerStore(PointerStoreBackend):
         ttl_seconds: Optional[int],
         expires_at_utc: Optional[str],
     ) -> None:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 INSERT INTO state_store
@@ -79,7 +122,7 @@ class SQLitePointerStore(PointerStoreBackend):
             )
 
     def retrieve_pointer(self, pointer_id: str) -> Any:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             cursor = conn.execute("SELECT raw_data FROM state_store WHERE pointer_id = ?", (pointer_id,))
             row = cursor.fetchone()
             if not row:
@@ -109,7 +152,7 @@ class SQLitePointerStore(PointerStoreBackend):
             query += " LIMIT ?"
             params.append(limit)
 
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             rows = conn.execute(query, tuple(params)).fetchall()
 
         pointers: List[Dict[str, Any]] = []
@@ -130,6 +173,6 @@ class SQLitePointerStore(PointerStoreBackend):
         return pointers
 
     def delete_pointer(self, pointer_id: str) -> bool:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             cursor = conn.execute("DELETE FROM state_store WHERE pointer_id = ?", (pointer_id,))
             return cursor.rowcount > 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "requests==2.33.0",
   "beautifulsoup4==4.12.3",
   "uvicorn==0.46.0",
+  "jsonschema>=4.0",
 ]
 
 [project.urls]
@@ -32,6 +33,7 @@ dev = [
   "ruff>=0.6.0",
   "pre-commit>=3.7.0",
   "mypy>=1.11.0",
+  "bandit>=1.7.0",
 ]
 storage = [
   "redis>=5.0.0",
@@ -74,3 +76,13 @@ module = [
 ]
 strict = true
 disallow_any_explicit = true
+
+[tool.bandit]
+# Bandit is run in CI as a security gate. We currently only fail the build on
+# HIGH-severity issues; medium/low are reported but tolerated to avoid a
+# wholesale rewrite. Tighten to ``--severity-level low`` once the reported
+# medium-severity findings (notably SQL string formatting in
+# postgres_store.py — already protected by an identifier whitelist) are
+# explicitly suppressed via ``# nosec``.
+exclude_dirs = ["tests", "examples", ".venv", ".venv-bootstrap", "build", "dist"]
+skips = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ beautifulsoup4==4.12.3
 
 # Required for the production ASGI runtime server
 uvicorn==0.46.0
+
+# Required for full JSON Schema validation of tool argument payloads
+jsonschema>=4.0

--- a/scripts/eap_operator_ui.py
+++ b/scripts/eap_operator_ui.py
@@ -62,8 +62,12 @@ def _render_dashboard(db_path: Path, run_limit: int, pointer_limit: int) -> str:
     if not db_path.exists():
         return _format_error_page(f"State DB not found yet: {db_path}")
 
+    # Connect read-only via URI so the dashboard works against a volume that
+    # is mounted ``:ro`` inside the container. ``mode=ro`` prevents SQLite from
+    # trying to create a journal/WAL file.
+    uri = f"file:{db_path}?mode=ro"
     try:
-        with sqlite3.connect(db_path) as conn:
+        with sqlite3.connect(uri, uri=True) as conn:
             total_runs = _fetch_count(conn, "SELECT COUNT(*) FROM execution_run_summaries")
             total_pointers = _fetch_count(conn, "SELECT COUNT(*) FROM state_store")
 

--- a/scripts/eap_runtime_service.py
+++ b/scripts/eap_runtime_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import signal
 import threading
 from pathlib import Path
@@ -37,7 +38,22 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--bearer-token",
         default="",
-        help="Optional admin bearer token for /v1/eap/* endpoints.",
+        help=(
+            "Optional admin bearer token for /v1/eap/* endpoints. "
+            "Avoid using on the command line in production — prefer the "
+            "EAP_RUNTIME_BEARER_TOKEN environment variable or "
+            "--bearer-token-file (e.g. for Kubernetes secret mounts) so the "
+            "secret is not visible in `ps`/`/proc/<pid>/cmdline`."
+        ),
+    )
+    parser.add_argument(
+        "--bearer-token-file",
+        default="",
+        help=(
+            "Path to a file containing the bearer token. The first line of "
+            "the file is read and stripped. Useful for k8s/Docker secret "
+            "mounts. Mutually exclusive with --bearer-token."
+        ),
     )
     parser.add_argument(
         "--allow-unauthenticated-local-dev",
@@ -82,6 +98,43 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Maximum accepted runtime request body size in bytes (default: 1000000).",
     )
     return parser.parse_args(argv)
+
+
+BEARER_TOKEN_ENV_VAR = "EAP_RUNTIME_BEARER_TOKEN"
+
+
+def _resolve_bearer_token(args: argparse.Namespace) -> str:
+    """Resolve the bearer token from (in order) flag, file, env var.
+
+    Passing the token on the command line is supported but discouraged because
+    it is visible to anyone with ``ps``/``/proc`` access on the host. Prefer the
+    ``EAP_RUNTIME_BEARER_TOKEN`` environment variable or ``--bearer-token-file``.
+
+    Raises ``ValueError`` if more than one source is provided or if a referenced
+    file is unreadable/empty.
+    """
+    flag_token = args.bearer_token.strip()
+    file_path = (args.bearer_token_file or "").strip()
+
+    sources_provided = sum(1 for value in (flag_token, file_path) if value)
+    if sources_provided > 1:
+        raise ValueError("--bearer-token and --bearer-token-file are mutually exclusive.")
+
+    if file_path:
+        try:
+            raw = Path(file_path).read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ValueError(f"failed to read --bearer-token-file '{file_path}': {exc}") from exc
+        token = raw.splitlines()[0].strip() if raw else ""
+        if not token:
+            raise ValueError(f"--bearer-token-file '{file_path}' is empty.")
+        return token
+
+    if flag_token:
+        return flag_token
+
+    env_token = os.environ.get(BEARER_TOKEN_ENV_VAR, "").strip()
+    return env_token
 
 
 def _register_default_tools(registry: ToolRegistry) -> None:
@@ -178,7 +231,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.max_request_body_bytes <= 0:
         print("[runtime:error] --max-request-body-bytes must be greater than 0.")
         return 1
-    bearer_token = args.bearer_token.strip()
+    try:
+        bearer_token = _resolve_bearer_token(args)
+    except ValueError as exc:
+        print(f"[runtime:error] {exc}")
+        return 1
     try:
         scoped_tokens, active_policy_profile = _load_scoped_auth_config(
             args.scoped_auth_config,
@@ -256,6 +313,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             pass
     finally:
         server.stop()
+        try:
+            state_manager.close()
+        except Exception as exc:  # pragma: no cover - defensive teardown
+            print(f"[runtime:warning] state_manager.close failed: {exc}")
         print("[runtime] stopped.")
     return 0
 

--- a/tests/unit/test_app_auditor_decision.py
+++ b/tests/unit/test_app_auditor_decision.py
@@ -1,0 +1,99 @@
+"""Regression tests for the app.py auditor decision parser (Phase-14 R8).
+
+Previously, ``app.py`` approved any LLM response that contained the literal
+substring ``APPROVED`` — a malicious or noisy auditor saying "I will never
+approve this..." would fall through to execution. The new parser requires a
+structured JSON ``{"decision": "approve" | "reject", "reason": "..."}``
+response and defaults to ``reject`` for any unparseable / unknown payload.
+
+``app.py`` is a Streamlit module that imports ``streamlit`` at module load
+and immediately calls ``st.set_page_config``. To avoid pulling Streamlit
+into the unit-test environment, we extract just the
+``parse_auditor_decision`` function (and its private constants) out of the
+source via ``ast`` and exec it in an isolated namespace.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+def _extract_parse_auditor_decision():
+    """Pull the parse_auditor_decision function out of app.py without import."""
+    repo_root = Path(__file__).resolve().parents[2]
+    source = (repo_root / "app.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    namespace: dict[str, object] = {"json": json, "re": re}
+    captured = False
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "_AUDITOR_REJECT_REASON_FALLBACK"
+            for t in node.targets
+        ):
+            exec(compile(ast.Module(body=[node], type_ignores=[]), "<app_extract>", "exec"), namespace)  # noqa: S102
+        if isinstance(node, ast.FunctionDef) and node.name == "parse_auditor_decision":
+            exec(compile(ast.Module(body=[node], type_ignores=[]), "<app_extract>", "exec"), namespace)  # noqa: S102
+            captured = True
+            break
+    if not captured:
+        raise RuntimeError("parse_auditor_decision not found in app.py")
+    return namespace["parse_auditor_decision"]
+
+
+parse_auditor_decision = _extract_parse_auditor_decision()
+
+
+class AuditorDecisionParserTest(unittest.TestCase):
+    def test_parses_clean_approve_payload(self) -> None:
+        decision, reason = parse_auditor_decision(
+            '{"decision": "approve", "reason": "Looks safe"}'
+        )
+        self.assertEqual(decision, "approve")
+        self.assertIn("safe", reason.lower())
+
+    def test_parses_clean_reject_payload(self) -> None:
+        decision, reason = parse_auditor_decision(
+            '{"decision": "reject", "reason": "Calls dangerous tool"}'
+        )
+        self.assertEqual(decision, "reject")
+        self.assertIn("dangerous", reason)
+
+    def test_substring_approval_no_longer_executes(self) -> None:
+        """The old ``APPROVED in upper()`` path is gone.
+
+        A malicious response containing the literal word ``APPROVED`` but no
+        structured decision must be treated as a reject.
+        """
+        decision, reason = parse_auditor_decision("APPROVED — but only kidding")
+        self.assertEqual(decision, "reject")
+        self.assertTrue(reason)
+
+    def test_extracts_json_from_surrounding_prose(self) -> None:
+        decision, _reason = parse_auditor_decision(
+            "Here is my review:\n```json\n"
+            '{"decision": "reject", "reason": "Bad"}\n```'
+        )
+        self.assertEqual(decision, "reject")
+
+    def test_unknown_decision_value_rejects(self) -> None:
+        decision, _reason = parse_auditor_decision(
+            '{"decision": "maybe", "reason": "uncertain"}'
+        )
+        self.assertEqual(decision, "reject")
+
+    def test_empty_response_rejects(self) -> None:
+        decision, _reason = parse_auditor_decision("")
+        self.assertEqual(decision, "reject")
+
+    def test_non_string_response_rejects(self) -> None:
+        decision, _reason = parse_auditor_decision(None)
+        self.assertEqual(decision, "reject")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -27,6 +27,31 @@ class CompilerTest(unittest.TestCase):
         macro = MacroCompiler.compile(raw)
         self.assertTrue(macro.steps[0].step_id.startswith("auto_step_"))
 
+    def test_compile_step_id_is_deterministic_and_content_addressed(self) -> None:
+        """The synthesized step_id must be the same across calls and processes.
+
+        Python's built-in ``hash()`` is salted per-process which made the
+        previous ``hash(str(step)) % 1000`` recipe non-deterministic. The
+        compiler now uses a SHA-256 content hash, so identical step JSON
+        always produces the same id and replays/diffs stay stable.
+        """
+        step = {"tool_name": "read_local_file", "arguments": {"file_path": "/tmp/a.txt"}}
+        first = MacroCompiler.compile({"steps": [dict(step)]}).steps[0].step_id
+        second = MacroCompiler.compile({"steps": [dict(step)]}).steps[0].step_id
+        self.assertEqual(first, second)
+        self.assertTrue(first.startswith("auto_step_"))
+        # Suffix is the truncated hex digest — must be stable hex chars.
+        suffix = first.split("auto_step_", 1)[1]
+        self.assertEqual(len(suffix), 12)
+        self.assertTrue(all(c in "0123456789abcdef" for c in suffix), suffix)
+
+    def test_compile_step_id_changes_when_step_content_changes(self) -> None:
+        a = {"tool_name": "read_local_file", "arguments": {"file_path": "/tmp/a.txt"}}
+        b = {"tool_name": "read_local_file", "arguments": {"file_path": "/tmp/b.txt"}}
+        id_a = MacroCompiler.compile({"steps": [a]}).steps[0].step_id
+        id_b = MacroCompiler.compile({"steps": [b]}).steps[0].step_id
+        self.assertNotEqual(id_a, id_b)
+
     def test_workflow_graph_compiler_validates_payload(self) -> None:
         with self.assertRaises(ValueError):
             WorkflowGraphCompiler.compile_graph({"workflow_id": "wf_x", "nodes": [], "edges": []})

--- a/tests/unit/test_runtime_service_bearer_token_resolution.py
+++ b/tests/unit/test_runtime_service_bearer_token_resolution.py
@@ -1,0 +1,112 @@
+"""Tests for the bearer-token resolution helper in eap_runtime_service.py.
+
+Phase-14 R10: bearer tokens passed via ``--bearer-token`` are visible in
+``ps``/``/proc/<pid>/cmdline``. The runtime service now also accepts the
+token via the ``EAP_RUNTIME_BEARER_TOKEN`` environment variable or via
+``--bearer-token-file`` (a path mounted from a Docker / Kubernetes secret).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _load_runtime_service_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "eap_runtime_service_module_for_test",
+        repo_root / "scripts" / "eap_runtime_service.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+runtime_service = _load_runtime_service_module()
+
+
+def _make_args(**kwargs) -> argparse.Namespace:
+    defaults = {"bearer_token": "", "bearer_token_file": ""}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class ResolveBearerTokenTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Ensure environment is clean for each test.
+        self._previous_env = os.environ.pop(runtime_service.BEARER_TOKEN_ENV_VAR, None)
+
+    def tearDown(self) -> None:
+        os.environ.pop(runtime_service.BEARER_TOKEN_ENV_VAR, None)
+        if self._previous_env is not None:
+            os.environ[runtime_service.BEARER_TOKEN_ENV_VAR] = self._previous_env
+
+    def test_resolve_returns_empty_when_nothing_provided(self) -> None:
+        token = runtime_service._resolve_bearer_token(_make_args())
+        self.assertEqual(token, "")
+
+    def test_resolve_uses_env_var_when_no_flag(self) -> None:
+        os.environ[runtime_service.BEARER_TOKEN_ENV_VAR] = "env-token-value"
+        token = runtime_service._resolve_bearer_token(_make_args())
+        self.assertEqual(token, "env-token-value")
+
+    def test_resolve_prefers_flag_over_env_var(self) -> None:
+        os.environ[runtime_service.BEARER_TOKEN_ENV_VAR] = "env-token-value"
+        token = runtime_service._resolve_bearer_token(_make_args(bearer_token="flag-token"))
+        self.assertEqual(token, "flag-token")
+
+    def test_resolve_reads_from_file(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".token", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write("file-token-value\n")
+            file_path = fh.name
+        try:
+            token = runtime_service._resolve_bearer_token(
+                _make_args(bearer_token_file=file_path)
+            )
+            self.assertEqual(token, "file-token-value")
+        finally:
+            os.remove(file_path)
+
+    def test_resolve_rejects_both_flag_and_file(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".token", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write("file-token-value\n")
+            file_path = fh.name
+        try:
+            with self.assertRaises(ValueError):
+                runtime_service._resolve_bearer_token(
+                    _make_args(bearer_token="flag-token", bearer_token_file=file_path)
+                )
+        finally:
+            os.remove(file_path)
+
+    def test_resolve_rejects_empty_file(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".token", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write("")
+            file_path = fh.name
+        try:
+            with self.assertRaises(ValueError):
+                runtime_service._resolve_bearer_token(_make_args(bearer_token_file=file_path))
+        finally:
+            os.remove(file_path)
+
+    def test_resolve_rejects_missing_file(self) -> None:
+        with self.assertRaises(ValueError):
+            runtime_service._resolve_bearer_token(
+                _make_args(bearer_token_file="/nonexistent/path/token.txt")
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_self_hosted_compose_hardening.py
+++ b/tests/unit/test_self_hosted_compose_hardening.py
@@ -1,0 +1,54 @@
+"""Regression tests for the self-hosted docker-compose hardening (Phase-14
+R10/R11).
+
+* The bearer token must not appear on the runtime command line (R10).
+* The operator-ui volume mount must be ``:ro`` so the SQLite file is only
+  written by a single container (R11).
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+COMPOSE_PATH = Path(__file__).resolve().parents[2] / "deploy" / "self_hosted" / "docker-compose.yml"
+
+
+class ComposeHardeningTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.compose_text = COMPOSE_PATH.read_text(encoding="utf-8")
+
+    def test_runtime_command_does_not_pass_bearer_token_on_cli(self) -> None:
+        """``--bearer-token`` must not appear in the runtime command list.
+
+        We scan only command list items (lines starting with ``      - ``)
+        to ignore comments / environment values that legitimately mention
+        the flag in prose.
+        """
+        cli_lines = [
+            line.strip()
+            for line in self.compose_text.splitlines()
+            if line.lstrip().startswith("- ")
+        ]
+        for line in cli_lines:
+            self.assertFalse(
+                line.strip("- ").strip().startswith("--bearer-token"),
+                f"bearer-token flag leaked into CLI: {line}",
+            )
+
+    def test_runtime_environment_carries_bearer_token(self) -> None:
+        """The runtime container reads the token from EAP_RUNTIME_BEARER_TOKEN."""
+        self.assertIn("EAP_RUNTIME_BEARER_TOKEN", self.compose_text)
+
+    def test_operator_ui_volume_is_read_only(self) -> None:
+        """``operator-ui`` must mount the shared SQLite volume as ``:ro``."""
+        # Cheap but explicit check: the ":ro" flag must appear next to the
+        # operator-ui mount of eap_state. The runtime service still mounts
+        # rw, so both forms are present in the file — the operator-ui block
+        # must include the read-only one.
+        self.assertIn("eap_state:/var/lib/eap:ro", self.compose_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_state_manager_connection_lifecycle.py
+++ b/tests/unit/test_state_manager_connection_lifecycle.py
@@ -1,0 +1,130 @@
+"""Regression tests for the StateManager / SQLitePointerStore connection
+lifecycle (Phase-14 R7).
+
+The previous implementation called ``sqlite3.connect(db_path)`` per method,
+which produced wasted IO under low concurrency and ``database is locked``
+failures under the new ASGI runtime. These tests exercise the new behaviour:
+
+* a single shared SQLite connection per StateManager / SQLitePointerStore;
+* explicit ``close()`` lifecycle that the runtime can call on shutdown;
+* concurrent ``store_and_point`` calls do not raise ``database is locked``.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+import unittest
+
+from eap.protocol import StateManager
+from eap.protocol.storage.sqlite_store import SQLitePointerStore
+
+
+class StateManagerConnectionLifecycleTest(unittest.TestCase):
+    def setUp(self) -> None:
+        fd, self.db_path = tempfile.mkstemp(prefix="eap-conn-", suffix=".db")
+        os.close(fd)
+        self.manager = StateManager(db_path=self.db_path)
+
+    def tearDown(self) -> None:
+        try:
+            self.manager.close()
+        except Exception:
+            pass
+        for suffix in ("", "-wal", "-shm"):
+            path = self.db_path + suffix
+            if os.path.exists(path):
+                os.remove(path)
+
+    def test_state_manager_reuses_a_single_connection(self) -> None:
+        """The shared connection must be the same object across calls."""
+        first = self.manager._connection_obj
+        self.manager.store_and_point(raw_data="x", summary="x")
+        self.manager.store_and_point(raw_data="y", summary="y")
+        self.assertIs(self.manager._connection_obj, first)
+
+    def test_close_is_idempotent_and_blocks_further_use(self) -> None:
+        self.manager.close()
+        # Calling close() a second time must not raise.
+        self.manager.close()
+        with self.assertRaises(RuntimeError):
+            self.manager.store_and_point(raw_data="x", summary="x")
+
+    def test_state_manager_supports_context_manager(self) -> None:
+        path = self.db_path + ".ctx"
+        try:
+            with StateManager(db_path=path) as sm:
+                sm.store_and_point(raw_data="ctx", summary="ctx")
+            # After exiting the context manager the connection must be closed.
+            self.assertTrue(sm._closed)
+        finally:
+            for suffix in ("", "-wal", "-shm"):
+                p = path + suffix
+                if os.path.exists(p):
+                    os.remove(p)
+
+    def test_concurrent_store_and_point_does_not_lock(self) -> None:
+        """100 concurrent store_and_point calls complete without errors."""
+        errors: list[BaseException] = []
+
+        def worker(idx: int) -> None:
+            try:
+                self.manager.store_and_point(
+                    raw_data=f"payload-{idx}",
+                    summary=f"summary-{idx}",
+                )
+            except BaseException as exc:  # noqa: BLE001 - we surface anything
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(100)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [])
+        # All 100 pointers must have been persisted.
+        pointers = self.manager.list_pointers(include_expired=True)
+        self.assertGreaterEqual(len(pointers), 100)
+
+
+class SQLitePointerStoreConnectionLifecycleTest(unittest.TestCase):
+    def setUp(self) -> None:
+        fd, self.db_path = tempfile.mkstemp(prefix="eap-ptr-", suffix=".db")
+        os.close(fd)
+        self.store = SQLitePointerStore(db_path=self.db_path)
+        self.store.initialize()
+
+    def tearDown(self) -> None:
+        try:
+            self.store.close()
+        except Exception:
+            pass
+        for suffix in ("", "-wal", "-shm"):
+            path = self.db_path + suffix
+            if os.path.exists(path):
+                os.remove(path)
+
+    def test_pointer_store_reuses_connection(self) -> None:
+        first = self.store._conn
+        self.store.store_pointer(
+            pointer_id="ptr_a",
+            raw_data="a",
+            summary="a",
+            metadata={},
+            created_at_utc="2026-01-01T00:00:00+00:00",
+            ttl_seconds=None,
+            expires_at_utc=None,
+        )
+        self.assertIs(self.store._conn, first)
+
+    def test_pointer_store_close_blocks_further_use(self) -> None:
+        self.store.close()
+        self.store.close()  # idempotent
+        with self.assertRaises(RuntimeError):
+            self.store.retrieve_pointer("ptr_missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -80,6 +80,202 @@ class ToolRegistryTest(unittest.TestCase):
         with self.assertRaises(PluginManifestError):
             self.registry.register_plugin_manifest({"plugin_name": "", "tools": []}, source="unit-test")
 
+    # ------------------------------------------------------------------
+    # R14: full JSON Schema validation when jsonschema is available.
+    # The hand-rolled validator silently accepted ``pattern`` mismatches and
+    # nested objects; the new path delegates to Draft 2020-12.
+    # ------------------------------------------------------------------
+    def test_validation_enforces_string_pattern(self) -> None:
+        registry = ToolRegistry()
+        registry.register(
+            "patterned_tool",
+            dummy_tool,
+            {
+                "name": "patterned_tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "code": {"type": "string", "pattern": r"^[A-Z]{3}-\d+$"},
+                    },
+                    "required": ["code"],
+                },
+            },
+        )
+        # Valid pattern passes.
+        registry.validate_arguments("patterned_tool", {"code": "ABC-123"})
+        # Invalid pattern is rejected.
+        with self.assertRaises(InputValidationError) as cm:
+            registry.validate_arguments("patterned_tool", {"code": "abc-123"})
+        self.assertIn("patterned_tool", str(cm.exception))
+
+    def test_validation_enforces_nested_properties(self) -> None:
+        registry = ToolRegistry()
+        registry.register(
+            "nested_tool",
+            dummy_tool,
+            {
+                "name": "nested_tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "object",
+                            "properties": {
+                                "age": {"type": "integer", "minimum": 0},
+                            },
+                            "required": ["age"],
+                        },
+                    },
+                    "required": ["user"],
+                },
+            },
+        )
+        registry.validate_arguments("nested_tool", {"user": {"age": 30}})
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("nested_tool", {"user": {"age": "not-a-number"}})
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("nested_tool", {"user": {}})
+
+    def test_validation_supports_oneof(self) -> None:
+        registry = ToolRegistry()
+        registry.register(
+            "oneof_tool",
+            dummy_tool,
+            {
+                "name": "oneof_tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "ident": {
+                            "oneOf": [
+                                {"type": "string", "minLength": 1},
+                                {"type": "integer"},
+                            ],
+                        },
+                    },
+                    "required": ["ident"],
+                },
+            },
+        )
+        registry.validate_arguments("oneof_tool", {"ident": "abc"})
+        registry.validate_arguments("oneof_tool", {"ident": 42})
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("oneof_tool", {"ident": [1, 2, 3]})
+
+    # ------------------------------------------------------------------
+    # R14 fallback path (no jsonschema): mirror the legacy hand-rolled
+    # validator so coverage remains complete and so that ``ToolRegistry``
+    # still works in stripped-down deployments without the optional
+    # ``jsonschema`` dependency.
+    # ------------------------------------------------------------------
+    def _registry_without_jsonschema(self, schema, name="legacy_tool"):
+        registry = ToolRegistry()
+        registry.register(name, dummy_tool, schema)
+        # Force the fallback path by clearing the cached compiled validator.
+        registry._validators.pop(name, None)
+        return registry
+
+    def test_legacy_validator_enforces_required_fields(self) -> None:
+        schema = dict(SCHEMA)
+        schema["name"] = "legacy_tool"
+        registry = self._registry_without_jsonschema(schema)
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("legacy_tool", {})
+
+    def test_legacy_validator_enforces_type_check(self) -> None:
+        schema = dict(SCHEMA)
+        schema["name"] = "legacy_tool"
+        registry = self._registry_without_jsonschema(schema)
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("legacy_tool", {"value": 123})
+
+    def test_legacy_validator_enforces_string_length_bounds(self) -> None:
+        schema = {
+            "name": "len_tool",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "value": {"type": "string", "minLength": 2, "maxLength": 4},
+                },
+                "required": ["value"],
+            },
+        }
+        registry = self._registry_without_jsonschema(schema, name="len_tool")
+        registry.validate_arguments("len_tool", {"value": "abc"})
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("len_tool", {"value": "a"})
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("len_tool", {"value": "abcde"})
+
+    def test_legacy_validator_enforces_numeric_bounds_and_arrays(self) -> None:
+        schema = {
+            "name": "n_tool",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "n": {"type": "integer", "minimum": 0, "maximum": 5},
+                    "tags": {"type": "array", "minItems": 1, "maxItems": 3},
+                },
+                "required": ["n", "tags"],
+            },
+        }
+        registry = self._registry_without_jsonschema(schema, name="n_tool")
+        registry.validate_arguments("n_tool", {"n": 3, "tags": ["a"]})
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("n_tool", {"n": -1, "tags": ["a"]})
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("n_tool", {"n": 9, "tags": ["a"]})
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("n_tool", {"n": 1, "tags": []})
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments(
+                "n_tool", {"n": 1, "tags": ["a", "b", "c", "d"]}
+            )
+
+    def test_legacy_validator_enforces_enum_and_additional_properties(self) -> None:
+        schema = {
+            "name": "e_tool",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "color": {"type": "string", "enum": ["red", "blue"]},
+                },
+                "required": ["color"],
+                "additionalProperties": False,
+            },
+        }
+        registry = self._registry_without_jsonschema(schema, name="e_tool")
+        registry.validate_arguments("e_tool", {"color": "red"})
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("e_tool", {"color": "purple"})
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("e_tool", {"color": "red", "extra": 1})
+
+    def test_legacy_validator_rejects_non_object_arguments(self) -> None:
+        schema = dict(SCHEMA)
+        schema["name"] = "legacy_tool"
+        registry = self._registry_without_jsonschema(schema)
+        with self.assertRaises(InputValidationError):
+            registry.validate_arguments("legacy_tool", "not-a-dict")
+
+    # ------------------------------------------------------------------
+    # R17: tool name hash is sha256-derived (no md5 anywhere).
+    # ------------------------------------------------------------------
+    def test_tool_name_hash_uses_sha256_not_md5(self) -> None:
+        import hashlib
+        import json as _json
+
+        schema_str = _json.dumps(SCHEMA, sort_keys=True)
+        expected_sha = hashlib.sha256(schema_str.encode()).hexdigest()[:8]
+        forbidden_md5 = hashlib.md5(schema_str.encode()).hexdigest()[:8]
+
+        hashed = self.registry.get_hashed_manifest()["dummy_tool"]
+        suffix = hashed.split("dummy_tool_", 1)[1]
+        self.assertEqual(suffix, expected_sha)
+        # The previous md5-derived hash must not be produced.
+        if expected_sha != forbidden_md5:
+            self.assertNotEqual(suffix, forbidden_md5)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Address the remaining non-P0 hardening items from the EAP production hardening brief that the post-Phase-13 verification report flagged as still open. None of these block downstream Cue-Auto integration on their own, but together they close the credible-production-use tier.

| ID  | Brief topic                                                | Status |
|-----|------------------------------------------------------------|--------|
| R7  | DB connection lifecycle (SQLite + Postgres)                | Fixed  |
| R8  | `app.py` auditor substring-match approval                  | Fixed  |
| R9  | Deterministic compiler `step_id` synthesis                 | Fixed  |
| R10 | Bearer token via docker-compose CLI arg                    | Fixed  |
| R11 | Two containers RW-mounting the same SQLite volume          | Fixed  |
| R12 | CI ruff / mypy / bandit gates                              | Tightened (incrementally) |
| R14 | `validate_arguments` vs `jsonschema`                       | Fixed  |
| R17 | `md5` → `sha256` for tool-name hashing                     | Fixed  |

### What changed

- **R7 — connection lifecycle.** `StateManager` and `SQLitePointerStore` now hold a single `sqlite3.Connection` for their lifetime, guarded by a `threading.Lock`. Both gain an idempotent `close()`, a context-manager protocol, and a `__del__` safety net. `PsycopgPointerClient` lazily creates a `psycopg_pool.ConnectionPool` when the optional dep is available; falls back to per-call connect when it isn't. The runtime service now calls `state_manager.close()` on shutdown.
- **R8 — structured auditor decision.** `app.py` introduces `parse_auditor_decision(raw)` which requires `{"decision": "approve" | "reject", "reason": "..."}`. Anything that doesn't parse — including the literal word `APPROVED` floating in prose — defaults to reject. The auditor system prompt is updated to demand JSON.
- **R9 — deterministic step-id.** `MacroCompiler` switches from `hash(str(step)) % 1000` (process-salted, 1000-entry collision space) to `sha256(json.dumps(step, sort_keys=True))[:12]`. Same step JSON now produces the same id across processes.
- **R10 — bearer token resolution.** `scripts/eap_runtime_service.py` resolves the bearer token from (1) `--bearer-token` CLI flag, (2) `--bearer-token-file <path>` (k8s/Docker secret mount; first line is read), (3) `EAP_RUNTIME_BEARER_TOKEN` env var. The bundled compose stack now passes the token via `environment:`, not the CLI.
- **R11 — operator-ui RO mount.** `deploy/self_hosted/docker-compose.yml` mounts the shared `eap_state` volume with `:ro` on the `operator-ui` container, and `scripts/eap_operator_ui.py` opens SQLite via URI mode (`mode=ro`) so it works on the read-only mount. Doc updated to recommend Postgres for any multi-process deploy.
- **R12 — CI gates.** Adds a HIGH-severity bandit step (currently passing — 0 high findings) plus an advisory `ruff E,F,W,B,UP,SIM,RUF` lane that is non-blocking so the broader rule set is reported in CI without requiring an immediate codebase-wide rewrite. Tightening to a blocking gate is the next phase.
- **R14 — jsonschema validation.** `ToolRegistry.validate_arguments` now delegates to `jsonschema.Draft202012Validator`. Compiled validators are cached per tool. Falls back to the legacy hand-rolled checks if the dep is missing. New tests cover `pattern`, nested object validation, and `oneOf`. `jsonschema>=4.0` added to runtime deps.
- **R17 — sha256 tool-name hash.** `eap/environment/tool_registry.py` swaps `hashlib.md5(...)[:8]` for `hashlib.sha256(...)[:8]`.

### Files changed (highlights)

- `eap/protocol/state_manager.py` — shared connection lifecycle (+ `clear_all` reopen path)
- `eap/protocol/storage/sqlite_store.py` — shared connection lifecycle
- `eap/protocol/storage/postgres_store.py` — `psycopg_pool.ConnectionPool` lazy pool + `close()`
- `eap/agent/compiler.py` — sha256 step-id
- `eap/environment/tool_registry.py` — jsonschema validator + sha256 hash
- `app.py` — `parse_auditor_decision` + structured auditor prompt
- `deploy/self_hosted/docker-compose.yml` — `:ro` mount, env-based bearer token
- `scripts/eap_runtime_service.py` — `_resolve_bearer_token()` from flag/file/env, calls `state_manager.close()`
- `scripts/eap_operator_ui.py` — read-only SQLite URI
- `.github/workflows/ci.yml` — bandit gate + advisory ruff lane
- `pyproject.toml`, `requirements.txt` — `jsonschema>=4.0` runtime dep, `bandit` dev dep
- `docs/self_hosted_control_plane.md` — secret-mount pattern + production deployment note

### Tests

29 new assertions across 4 new files plus extensions to existing `test_compiler.py` and `test_tool_registry.py`:

- `tests/unit/test_state_manager_connection_lifecycle.py` — single shared connection, idempotent `close()`, context-manager lifecycle, **100-thread concurrent `store_and_point` stress test** (the original brief's R7 acceptance criterion).
- `tests/unit/test_app_auditor_decision.py` — substring "APPROVED" no longer approves; JSON in prose is extracted; unknown decisions reject.
- `tests/unit/test_runtime_service_bearer_token_resolution.py` — env / flag / file precedence and mutual-exclusion errors.
- `tests/unit/test_self_hosted_compose_hardening.py` — bearer flag never on CLI; operator-ui mount is `:ro`.
- `test_compiler.py` — same input → same id; different input → different id.
- `test_tool_registry.py` — `pattern`, nested `properties`, `oneOf` enforcement; sha256 hash assertion; full coverage of the legacy fallback path.

## Test plan

- [x] `python -m pytest` → **431 passed, 1 skipped, 4 subtests passed**
- [x] `python scripts/production_hardening_gatepack.py` → **6/6 PASS**
- [x] `python scripts/v1_readiness_gatepack.py` → **10/10 PASS** (line cov 80.3%, branch 69.9%)
- [x] `ruff check . --select E9,F63,F7,F82` → All checks passed
- [x] `mypy --follow-imports=skip eap/environment/safe_eval.py eap/environment/executor.py eap/runtime/auth_scopes.py eap/runtime/guardrails.py eap/runtime/http_api.py` → no issues
- [x] `bandit -r eap/ --severity-level high` → No issues identified
- [ ] Self-hosted compose smoke (CI lane)

## Risks / follow-ups

- The advisory ruff lane reports ~2.4k findings across the codebase. Promoting it to a blocking gate is intentionally deferred — staging by rule family is the brief's recommendation.
- `R13` (StateManager god-class decomposition), `R15` (async provider clients), `R19` (fuzz tests), and `R20` (transactional migrations) are still unaddressed and tracked for a future phase.

---
🤖 *Generated by Computer*